### PR TITLE
Mac sanitizers

### DIFF
--- a/.github/workflows/ci-mac.yml
+++ b/.github/workflows/ci-mac.yml
@@ -30,7 +30,7 @@ permissions:
 jobs:
   mac:
     runs-on: [self-hosted, macOS, ARM64]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -82,3 +82,48 @@ jobs:
       - name: Clean MbedTLS build
         if: always()
         run: rm -rf build-mbedtls
+
+      # ---------------------------------------------------------------
+      # Sanitizers
+      # ---------------------------------------------------------------
+
+      - name: ASAN + UBSAN build + test
+        if: success() || failure()
+        env:
+          ASAN_OPTIONS: detect_odr_violation=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          export CC=clang CXX=clang++
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
+          mkdir -p build-asan && cd build-asan
+          cmake .. -DBUILD_TEST=ON -DENABLE_SIGNALING=OFF -DENABLE_SELF_CONTAINED=ON -DENABLE_AWS_SDK_IN_TESTS=OFF \
+                   -DADDRESS_SANITIZER=ON -DUNDEFINED_BEHAVIOR_SANITIZER=ON \
+                   -DOPEN_SRC_INSTALL_PREFIX=$(pwd)/deps
+          make -j$(sysctl -n hw.ncpu)
+          timeout 600 ./tst/webrtc_client_test --gtest_break_on_failure
+        shell: bash
+
+      - name: Clean ASAN build
+        if: always()
+        run: rm -rf build-asan
+
+      - name: TSAN build + test
+        if: success() || failure()
+        env:
+          TSAN_OPTIONS: second_deadlock_stack=1:halt_on_error=1:suppressions=${{ github.workspace }}/tst/suppressions/TSAN.supp
+        run: |
+          export PATH="/opt/homebrew/bin:$PATH"
+          export CC=clang CXX=clang++
+          export CMAKE_BUILD_PARALLEL_LEVEL=$(sysctl -n hw.ncpu)
+          mkdir -p build-tsan && cd build-tsan
+          cmake .. -DBUILD_TEST=ON -DENABLE_SIGNALING=OFF -DENABLE_SELF_CONTAINED=ON -DENABLE_AWS_SDK_IN_TESTS=OFF \
+                   -DTHREAD_SANITIZER=ON \
+                   -DOPEN_SRC_INSTALL_PREFIX=$(pwd)/deps
+          make -j$(sysctl -n hw.ncpu)
+          timeout 600 ./tst/webrtc_client_test --gtest_break_on_failure
+        shell: bash
+
+      - name: Clean TSAN build
+        if: always()
+        run: rm -rf build-tsan

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -562,10 +562,13 @@ VOID onNewIceLocalCandidate(UINT64 customData, PCHAR candidateSdpStr)
 
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
     CHK(candidateSdpStr == NULL || STRLEN(candidateSdpStr) < MAX_SDP_ATTRIBUTE_VALUE_LENGTH, STATUS_INVALID_ARG);
-    CHK(pKvsPeerConnection->onIceCandidate != NULL, retStatus); // do nothing if onIceCandidate is not implemented
 
     MUTEX_LOCK(pKvsPeerConnection->peerConnectionObjLock);
     locked = TRUE;
+
+    // Check inside the lock: peerConnectionOnIceCandidate() writes onIceCandidate under peerConnectionObjLock,
+    // so this read must also be protected to avoid a data race.
+    CHK(pKvsPeerConnection->onIceCandidate != NULL, retStatus); // do nothing if onIceCandidate is not implemented
 
     if (candidateSdpStr != NULL) {
         strCompleteLen = SNPRINTF(jsonStrBuffer, ARRAY_SIZE(jsonStrBuffer), ICE_CANDIDATE_JSON_TEMPLATE, candidateSdpStr);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added ASAN+UBSAN and TSAN sanitizer build and test steps to the macOS CI workflow

*Why was it changed?*
- Sanitizer coverage (AddressSanitizer, UndefinedBehaviorSanitizer, ThreadSanitizer) was present on Linux CI but missing on macOS, leaving macOS-specific bugs undetected

*How was it changed?*
- Added ASAN+UBSAN step using Clang with `-DADDRESS_SANITIZER=ON -DUNDEFINED_BEHAVIOR_SANITIZER=ON` (no LeakSanitizer, not supported on macOS)
- Added TSAN step using Clang with `-DTHREAD_SANITIZER=ON` and TSAN suppressions file
- Bumped job timeout from 30 to 60 minutes to accommodate the extra sanitizer builds

*What testing was done for the changes?*
- CI workflow syntax validated; sanitizer steps mirror the existing Linux CI sanitizer jobs adapted for macOS (no Docker, Homebrew PATH, sysctl for CPU count)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.