### PR TITLE
implemented PLI/FIR sending/receiving

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -2263,6 +2263,37 @@ PUBLIC_API STATUS createRtcCertificate(PRtcCertificate*);
  */
 PUBLIC_API STATUS freeRtcCertificate(PRtcCertificate);
 
+/**
+ * @brief Requests a key frame from the remote peer.
+ *
+ * This function sends a Picture Loss Indication (PLI) packet to the remote peer,
+ * requesting a key frame. This is useful when the decoder detects packet loss
+ * or corruption and needs a fresh key frame to recover.
+ *
+ * @param[in] PRtcRtpTransceiver The transceiver associated with the media stream.
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success.
+ */
+PUBLIC_API STATUS requestKeyFrame(PRtcRtpTransceiver);
+
+/**
+ * @brief Sends a Picture Loss Indication (PLI) packet to the remote peer.
+ *
+ * @param[in] PRtcRtpTransceiver The transceiver associated with the media stream.
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success.
+ */
+PUBLIC_API STATUS transceiverSendPli(PRtcRtpTransceiver);
+
+/**
+ * @brief Sends a Full Intra Request (FIR) packet to the remote peer.
+ *
+ * @param[in] PRtcRtpTransceiver The transceiver associated with the media stream.
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success.
+ */
+PUBLIC_API STATUS transceiverSendFir(PRtcRtpTransceiver);
+
 /*!@} */
 #ifdef __cplusplus
 }

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -431,6 +431,57 @@ CleanUp:
     return retStatus;
 }
 
+/*
+* 0                   1                   2                   3
+0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|V=2|P|   FMT=4 |   PT=206      |          Length = 4           |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                  SSRC of Packet Sender                        |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|        SSRC of Media Source (UNUSED - MUST BE 0)              |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                              SSRC     (useful)                |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Seq Nr      |    Reserved (Must be all 0)                   |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+...
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|    SSRC2     (technically possible to have multiple ssrcs)    |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|   Seq Nr      |    Reserved (Must be all 0)                   |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+
+*/
+#define PSFB_FIR_MIN_SIZE        16
+#define PSFB_FIR_FCI_SSRC_OFFSET 8
+STATUS onRtcpPSFBFIRPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 ssrc, offset;
+    PKvsRtpTransceiver pTransceiver = NULL;
+
+    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
+    if (pRtcpPacket->payloadLength >= PSFB_FIR_MIN_SIZE) {
+        offset = PSFB_FIR_FCI_SSRC_OFFSET;
+        for (; (offset + 4) < pRtcpPacket->payloadLength; offset += PSFB_FIR_FCI_SSRC_OFFSET) {
+            ssrc = getUnalignedInt32BigEndian(pRtcpPacket->payload + offset);
+            CHK_STATUS_ERR(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, ssrc), STATUS_RTCP_INPUT_SSRC_INVALID,
+                           "Received FIR for non existing ssrc: %u", ssrc);
+            MUTEX_LOCK(pTransceiver->statsLock);
+            pTransceiver->outboundStats.firCount++;
+            MUTEX_UNLOCK(pTransceiver->statsLock);
+
+            if (pTransceiver->onPictureLoss != NULL) {
+                pTransceiver->onPictureLoss(pTransceiver->onPictureLossCustomData);
+            }
+        }
+    }
+
+CleanUp:
+    return retStatus;
+}
+
 STATUS onRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuff, UINT32 buffLen)
 {
     STATUS retStatus = STATUS_SUCCESS;
@@ -443,6 +494,13 @@ STATUS onRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuff, UINT32 b
 
         switch (rtcpPacket.header.packetType) {
             case RTCP_PACKET_TYPE_FIR:
+                //  0                   1                   2                   3
+                //  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                // |V=2|P|   MBZ   |  PT=RTCP_FIR  |           length              |
+                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+                // |                              SSRC                             |
+                // +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
                 CHK_STATUS(onRtcpFIRPacket(&rtcpPacket, pKvsPeerConnection));
                 break;
             case RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK:
@@ -460,6 +518,8 @@ STATUS onRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuff, UINT32 b
                     CHK_STATUS(onRtcpRembPacket(&rtcpPacket, pKvsPeerConnection));
                 } else if (rtcpPacket.header.receptionReportCount == RTCP_PSFB_PLI) {
                     CHK_STATUS(onRtcpPLIPacket(&rtcpPacket, pKvsPeerConnection));
+                } else if (rtcpPacket.header.receptionReportCount == RTCP_PSFB_FIR) {
+                    CHK_STATUS(onRtcpPSFBFIRPacket(&rtcpPacket, pKvsPeerConnection));
                 } else if (rtcpPacket.header.receptionReportCount == RTCP_PSFB_SLI) {
                     CHK_STATUS(onRtcpSLIPacket(&rtcpPacket, pKvsPeerConnection));
                 } else {
@@ -539,5 +599,90 @@ STATUS onRtcpPLIPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConne
 
 CleanUp:
 
+    return retStatus;
+}
+
+static STATUS writeRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pPacket, UINT32 packetLen)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PBYTE pRawPacket = NULL;
+    UINT32 allocSize;
+
+    CHK(pKvsPeerConnection != NULL && pPacket != NULL, STATUS_NULL_ARG);
+
+    // srtp_protect_rtcp() in encryptRtcpPacket() assumes memory availability to write 10 bytes of authentication tag and
+    // SRTP_MAX_TRAILER_LEN + 4 following the actual rtcp Packet payload
+    allocSize = packetLen + SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
+    CHK(NULL != (pRawPacket = (PBYTE) MEMALLOC(allocSize)), STATUS_NOT_ENOUGH_MEMORY);
+
+    MEMCPY(pRawPacket, pPacket, packetLen);
+
+    CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, pRawPacket, (PINT32) &packetLen));
+    CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pRawPacket, packetLen));
+
+CleanUp:
+    SAFE_MEMFREE(pRawPacket);
+    return retStatus;
+}
+
+STATUS sendRtcpPLI(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BYTE packet[12];
+    UINT32 packetLen = sizeof(packet);
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    // RTCP Header
+    packet[0] = (RTCP_PACKET_VERSION_VAL << 6) | RTCP_PSFB_PLI; // V=2, P=0, FMT=1 (PLI)
+    packet[1] = RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK;     // PT=206
+    putUnalignedInt16BigEndian(packet + 2, (packetLen / 4) - 1);
+
+    // SSRC of packet sender
+    putUnalignedInt32BigEndian(packet + 4, senderSsrc);
+
+    // SSRC of media source
+    putUnalignedInt32BigEndian(packet + 8, mediaSsrc);
+
+    CHK_STATUS(writeRtcpPacket(pKvsPeerConnection, packet, packetLen));
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc, UINT8* pSeqNum)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BYTE packet[20];
+    UINT32 packetLen = sizeof(packet);
+
+    CHK(pKvsPeerConnection != NULL && pSeqNum != NULL, STATUS_NULL_ARG);
+
+    // RTCP Header
+    packet[0] = (RTCP_PACKET_VERSION_VAL << 6) | RTCP_PSFB_FIR; // V=2, P=0, FMT=4 (FIR)
+    packet[1] = RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK;     // PT=206
+    putUnalignedInt16BigEndian(packet + 2, (packetLen / 4) - 1);
+
+    // SSRC of packet sender
+    putUnalignedInt32BigEndian(packet + 4, senderSsrc);
+
+    // SSRC of media source (unused, set to 0)
+    putUnalignedInt32BigEndian(packet + 8, 0);
+
+    // FCI: SSRC
+    putUnalignedInt32BigEndian(packet + 12, mediaSsrc);
+
+    // FCI: Sequence number
+    (*pSeqNum)++;
+    packet[16] = *pSeqNum;
+
+    // FCI: Reserved (set to 0)
+    packet[17] = 0;
+    packet[18] = 0;
+    packet[19] = 0;
+
+    CHK_STATUS(writeRtcpPacket(pKvsPeerConnection, packet, packetLen));
+
+CleanUp:
     return retStatus;
 }

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -34,7 +34,7 @@ typedef enum {
 #define TWCC_FB_PACKETCHUNK_SIZE               2
 #define IS_TWCC_RUNLEN(packetChunk)            ((((packetChunk) >> 15u) & 1u) == 0)
 #define TWCC_RUNLEN_STATUS_SYMBOL(packetChunk) (((packetChunk) >> 13u) & 3u)
-#define TWCC_RUNLEN_GET(packetChunk)           ((packetChunk) &0x1fffu)
+#define TWCC_RUNLEN_GET(packetChunk)           ((packetChunk) & 0x1fffu)
 #define TWCC_IS_NOTRECEIVED(statusSymbol)      ((statusSymbol) == TWCC_STATUS_SYMBOL_NOTRECEIVED)
 #define TWCC_ISRECEIVED(statusSymbol)          ((statusSymbol) == TWCC_STATUS_SYMBOL_SMALLDELTA || (statusSymbol) == TWCC_STATUS_SYMBOL_LARGEDELTA)
 #define TWCC_RUNLEN_ISRECEIVED(packetChunk)    TWCC_ISRECEIVED(TWCC_RUNLEN_STATUS_SYMBOL(packetChunk))
@@ -42,7 +42,7 @@ typedef enum {
 #define TWCC_STATUSVECTOR_SSIZE(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
 #define TWCC_STATUSVECTOR_SMASK(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
 #define TWCC_STATUSVECTOR_STATUS(packetChunk, i)                                                                                                     \
-    (((packetChunk) >> (14u - (i) *TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
+    (((packetChunk) >> (14u - (i) * TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
 #define TWCC_STATUSVECTOR_COUNT(packetChunk) (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 7 : 14)
 #define TWCC_PACKET_STATUS_COUNT(payload)    (getUnalignedInt16BigEndian((payload) + 10))
 

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -13,6 +13,8 @@ STATUS onRtcpPLIPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS parseRtcpTwccPacket(PRtcpPacket, PTwccManager);
 STATUS onRtcpTwccPacket(PRtcpPacket, PKvsPeerConnection);
 STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUINT64);
+STATUS sendRtcpPLI(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc);
+STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc, UINT8* pSeqNum);
 
 // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 // Deltas are represented as multiples of 250us:
@@ -32,7 +34,7 @@ typedef enum {
 #define TWCC_FB_PACKETCHUNK_SIZE               2
 #define IS_TWCC_RUNLEN(packetChunk)            ((((packetChunk) >> 15u) & 1u) == 0)
 #define TWCC_RUNLEN_STATUS_SYMBOL(packetChunk) (((packetChunk) >> 13u) & 3u)
-#define TWCC_RUNLEN_GET(packetChunk)           ((packetChunk) & 0x1fffu)
+#define TWCC_RUNLEN_GET(packetChunk)           ((packetChunk) &0x1fffu)
 #define TWCC_IS_NOTRECEIVED(statusSymbol)      ((statusSymbol) == TWCC_STATUS_SYMBOL_NOTRECEIVED)
 #define TWCC_ISRECEIVED(statusSymbol)          ((statusSymbol) == TWCC_STATUS_SYMBOL_SMALLDELTA || (statusSymbol) == TWCC_STATUS_SYMBOL_LARGEDELTA)
 #define TWCC_RUNLEN_ISRECEIVED(packetChunk)    TWCC_ISRECEIVED(TWCC_RUNLEN_STATUS_SYMBOL(packetChunk))
@@ -40,7 +42,7 @@ typedef enum {
 #define TWCC_STATUSVECTOR_SSIZE(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
 #define TWCC_STATUSVECTOR_SMASK(packetChunk)   (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 2u : 1u)
 #define TWCC_STATUSVECTOR_STATUS(packetChunk, i)                                                                                                     \
-    (((packetChunk) >> (14u - (i) * TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
+    (((packetChunk) >> (14u - (i) *TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
 #define TWCC_STATUSVECTOR_COUNT(packetChunk) (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 7 : 14)
 #define TWCC_PACKET_STATUS_COUNT(payload)    (getUnalignedInt16BigEndian((payload) + 10))
 

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -526,3 +526,35 @@ CleanUp:
     CHK_LOG_ERR(retStatus);
     return retStatus;
 }
+
+STATUS transceiverSendPli(PRtcRtpTransceiver pRtcRtpTransceiver)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
+
+    CHK(pKvsRtpTransceiver != NULL && pKvsRtpTransceiver->pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(sendRtcpPLI(pKvsRtpTransceiver->pKvsPeerConnection, pKvsRtpTransceiver->sender.ssrc, pKvsRtpTransceiver->jitterBufferSsrc));
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS transceiverSendFir(PRtcRtpTransceiver pRtcRtpTransceiver)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
+
+    CHK(pKvsRtpTransceiver != NULL && pKvsRtpTransceiver->pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    CHK_STATUS(sendRtcpFIR(pKvsRtpTransceiver->pKvsPeerConnection, pKvsRtpTransceiver->sender.ssrc, pKvsRtpTransceiver->jitterBufferSsrc,
+                           &pKvsRtpTransceiver->firSequenceNumber));
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS requestKeyFrame(PRtcRtpTransceiver pRtcRtpTransceiver)
+{
+    return transceiverSendPli(pRtcRtpTransceiver);
+}

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -82,6 +82,8 @@ typedef struct {
     RtcOutboundRtpStreamStats outboundStats;
     RtcRemoteInboundRtpStreamStats remoteInboundStats;
     RtcInboundRtpStreamStats inboundStats;
+
+    UINT8 firSequenceNumber;
 } KvsRtpTransceiver, *PKvsRtpTransceiver;
 
 STATUS createKvsRtpTransceiver(RTC_RTP_TRANSCEIVER_DIRECTION, PKvsPeerConnection, UINT32, UINT32, PRtcMediaStreamTrack, PJitterBuffer, RTC_CODEC,

--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -49,6 +49,7 @@ typedef enum {
     RTCP_FEEDBACK_MESSAGE_TYPE_NACK = 1,
     RTCP_PSFB_PLI = 1, // https://tools.ietf.org/html/rfc4585#section-6.3
     RTCP_PSFB_SLI = 2, // https://tools.ietf.org/html/rfc4585#section-6.3.2
+    RTCP_PSFB_FIR = 4, // https://tools.ietf.org/html/rfc5104#section-4.3.1
     RTCP_FEEDBACK_MESSAGE_TYPE_APPLICATION_LAYER_FEEDBACK = 15,
 } RTCP_FEEDBACK_MESSAGE_TYPE;
 

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -1288,6 +1288,298 @@ TEST_F(PeerConnectionFunctionalityTest, aggressiveNominationDTLSRaceConditionChe
     }
 }
 
+// Test PLI (Picture Loss Indication) functionality
+// Sender sends I-frames (filled with 'I') and P-frames (filled with 'P')
+// When receiver gets a P-frame, it sends a PLI request
+// Sender responds to PLI by sending a special i-frame (filled with lowercase 'i')
+// Test passes when receiver gets the lowercase 'i' frame
+TEST_F(PeerConnectionFunctionalityTest, pliRequestTriggersKeyFrame)
+{
+    // Frame size for test frames
+    auto const frameBufferSize = 42;
+
+    // Frame type markers
+    const BYTE IFRAME_MARKER = 'I';     // Regular I-frame
+    const BYTE PFRAME_MARKER = 'P';     // P-frame
+    const BYTE PLI_IFRAME_MARKER = 'i'; // I-frame sent in response to PLI
+
+    // Context structure for sharing state between callbacks
+    struct PliTestContext {
+        PRtcRtpTransceiver pSenderTransceiver;
+        ATOMIC_BOOL pliReceived;
+        ATOMIC_BOOL pliResponseFrameReceived;
+        ATOMIC_BOOL pFrameReceived;
+        ATOMIC_BOOL testComplete;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    PliTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(PliTestContext));
+
+    // Allocate frame buffer
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+
+    // Initialize atomic flags
+    ATOMIC_STORE_BOOL(&context.pliReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.pliResponseFrameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.pFrameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+
+    // Create peer connections
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Add video tracks to both peers
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    context.pSenderTransceiver = offerVideoTransceiver;
+
+    // Callback for when sender (offer) receives PLI from receiver
+    auto onPictureLossHandler = [](UINT64 customData) -> void {
+        PliTestContext* pContext = (PliTestContext*) customData;
+        ATOMIC_STORE_BOOL(&pContext->pliReceived, TRUE);
+        DLOGD("PLI received by sender");
+    };
+
+    // Register PLI callback on sender's transceiver
+    EXPECT_EQ(transceiverOnPictureLoss(offerVideoTransceiver, (UINT64) &context, onPictureLossHandler), STATUS_SUCCESS);
+
+    // Callback for when receiver (answer) gets a frame
+    // If it's a P-frame, send PLI; if it's lowercase 'i', the test passes
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        PliTestContext* pContext = (PliTestContext*) customData;
+
+        if (pFrame == NULL || pFrame->frameData == NULL || pFrame->size == 0) {
+            return;
+        }
+
+        BYTE frameMarker = pFrame->frameData[0];
+
+        if (frameMarker == 'P' && !ATOMIC_LOAD_BOOL(&pContext->pFrameReceived)) {
+            // First P-frame received, send PLI
+            ATOMIC_STORE_BOOL(&pContext->pFrameReceived, TRUE);
+            DLOGD("P-frame received, sending PLI");
+            // Note: We'll send PLI from the main test loop after detecting pFrameReceived
+        } else if (frameMarker == 'i') {
+            // Received the I-frame sent in response to PLI
+            ATOMIC_STORE_BOOL(&pContext->pliResponseFrameReceived, TRUE);
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+            DLOGD("PLI response I-frame received (lowercase 'i')");
+        }
+    };
+
+    // Register frame callback on receiver's transceiver
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &context, onFrameHandler), STATUS_SUCCESS);
+
+    // Connect the two peers
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Send frames: I, P, P... until we get PLI response
+    BOOL sentPliResponseFrame = FALSE;
+    BOOL pliSent = FALSE;
+
+    for (auto i = 0; i < 200 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        // Check if we received PLI and need to send response I-frame
+        if (ATOMIC_LOAD_BOOL(&context.pliReceived) && !sentPliResponseFrame) {
+            // Send I-frame in response to PLI (lowercase 'i')
+            MEMSET(videoFrame.frameData, PLI_IFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_KEY_FRAME;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+            sentPliResponseFrame = TRUE;
+            DLOGD("Sent PLI response I-frame (lowercase 'i')");
+        } else if (ATOMIC_LOAD_BOOL(&context.pFrameReceived) && !pliSent) {
+            // Receiver got P-frame, now send PLI from receiver
+            EXPECT_EQ(transceiverSendPli(answerVideoTransceiver), STATUS_SUCCESS);
+            pliSent = TRUE;
+            DLOGD("PLI sent from receiver");
+        } else if (i == 0) {
+            // First frame: send I-frame
+            MEMSET(videoFrame.frameData, IFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_KEY_FRAME;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+            DLOGD("Sent I-frame");
+        } else if (!ATOMIC_LOAD_BOOL(&context.pFrameReceived)) {
+            // Send P-frames until receiver gets one
+            MEMSET(videoFrame.frameData, PFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_NONE;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        }
+
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 10);
+    }
+
+    // Cleanup
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify test succeeded
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.pFrameReceived)) << "Receiver should have received a P-frame";
+    EXPECT_TRUE(pliSent) << "PLI should have been sent";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.pliReceived)) << "Sender should have received PLI";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.pliResponseFrameReceived)) << "Receiver should have received the I-frame sent in response to PLI";
+}
+
+// Test FIR (Full Intra Request) functionality - similar to PLI test
+// Sender sends I-frames (filled with 'I') and P-frames (filled with 'P')
+// When receiver gets a P-frame, it sends a FIR request
+// Sender responds to FIR by sending a special i-frame (filled with lowercase 'i')
+// Test passes when receiver gets the lowercase 'i' frame
+TEST_F(PeerConnectionFunctionalityTest, firRequestTriggersKeyFrame)
+{
+    // Frame size for test frames
+    auto const frameBufferSize = 42;
+
+    // Frame type markers
+    const BYTE IFRAME_MARKER = 'I';     // Regular I-frame
+    const BYTE PFRAME_MARKER = 'P';     // P-frame
+    const BYTE FIR_IFRAME_MARKER = 'i'; // I-frame sent in response to FIR
+
+    // Context structure for sharing state between callbacks
+    struct FirTestContext {
+        PRtcRtpTransceiver pSenderTransceiver;
+        ATOMIC_BOOL firReceived;
+        ATOMIC_BOOL firResponseFrameReceived;
+        ATOMIC_BOOL pFrameReceived;
+        ATOMIC_BOOL testComplete;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    FirTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(FirTestContext));
+
+    // Allocate frame buffer
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+
+    // Initialize atomic flags
+    ATOMIC_STORE_BOOL(&context.firReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.firResponseFrameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.pFrameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+
+    // Create peer connections
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Add video tracks to both peers
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    context.pSenderTransceiver = offerVideoTransceiver;
+
+    // Callback for when sender (offer) receives FIR from receiver (uses same onPictureLoss callback)
+    auto onPictureLossHandler = [](UINT64 customData) -> void {
+        FirTestContext* pContext = (FirTestContext*) customData;
+        ATOMIC_STORE_BOOL(&pContext->firReceived, TRUE);
+        DLOGD("FIR received by sender (via onPictureLoss callback)");
+    };
+
+    // Register PLI/FIR callback on sender's transceiver
+    EXPECT_EQ(transceiverOnPictureLoss(offerVideoTransceiver, (UINT64) &context, onPictureLossHandler), STATUS_SUCCESS);
+
+    // Callback for when receiver (answer) gets a frame
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        FirTestContext* pContext = (FirTestContext*) customData;
+
+        if (pFrame == NULL || pFrame->frameData == NULL || pFrame->size == 0) {
+            return;
+        }
+
+        BYTE frameMarker = pFrame->frameData[0];
+
+        if (frameMarker == 'P' && !ATOMIC_LOAD_BOOL(&pContext->pFrameReceived)) {
+            // First P-frame received, will trigger FIR from main loop
+            ATOMIC_STORE_BOOL(&pContext->pFrameReceived, TRUE);
+            DLOGD("P-frame received, will send FIR");
+        } else if (frameMarker == 'i') {
+            // Received the I-frame sent in response to FIR
+            ATOMIC_STORE_BOOL(&pContext->firResponseFrameReceived, TRUE);
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+            DLOGD("FIR response I-frame received (lowercase 'i')");
+        }
+    };
+
+    // Register frame callback on receiver's transceiver
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &context, onFrameHandler), STATUS_SUCCESS);
+
+    // Connect the two peers
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Send frames: I, P, P... until we get FIR response
+    BOOL sentFirResponseFrame = FALSE;
+    BOOL firSent = FALSE;
+
+    for (auto i = 0; i < 200 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        // Check if we received FIR and need to send response I-frame
+        if (ATOMIC_LOAD_BOOL(&context.firReceived) && !sentFirResponseFrame) {
+            // Send I-frame in response to FIR (lowercase 'i')
+            MEMSET(videoFrame.frameData, FIR_IFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_KEY_FRAME;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+            sentFirResponseFrame = TRUE;
+            DLOGD("Sent FIR response I-frame (lowercase 'i')");
+        } else if (ATOMIC_LOAD_BOOL(&context.pFrameReceived) && !firSent) {
+            // Receiver got P-frame, now send FIR from receiver
+            EXPECT_EQ(transceiverSendFir(answerVideoTransceiver), STATUS_SUCCESS);
+            firSent = TRUE;
+            DLOGD("FIR sent from receiver");
+        } else if (i == 0) {
+            // First frame: send I-frame
+            MEMSET(videoFrame.frameData, IFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_KEY_FRAME;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+            DLOGD("Sent I-frame");
+        } else if (!ATOMIC_LOAD_BOOL(&context.pFrameReceived)) {
+            // Send P-frames until receiver gets one
+            MEMSET(videoFrame.frameData, PFRAME_MARKER, videoFrame.size);
+            videoFrame.flags = FRAME_FLAG_NONE;
+            EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        }
+
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 10);
+    }
+
+    // Cleanup
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify test succeeded
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.pFrameReceived)) << "Receiver should have received a P-frame";
+    EXPECT_TRUE(firSent) << "FIR should have been sent";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.firReceived)) << "Sender should have received FIR";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.firResponseFrameReceived)) << "Receiver should have received the I-frame sent in response to FIR";
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Added public APIs for sending PLI (Picture Loss Indication) and FIR (Full Intra Request) RTCP packets: `requestKeyFrame()`, `transceiverSendPli()`, and `transceiverSendFir()`
- Added handling for incoming PSFB FIR packets (FMT=4 in PT=206)

*Why was it changed?*
- The SDK lacked the ability to programmatically request key frames from remote peers, which is needed for decoder recovery after packet loss or corruption

*How was it changed?*
- Added `requestKeyFrame`, `transceiverSendPli`, and `transceiverSendFir` to the public API in Include.h
- Implemented `sendRtcpPLI` and `sendRtcpFIR` in Rtcp.c with proper RTCP packet construction and SRTP encryption
- Added `onRtcpPSFBFIRPacket` handler and wired it into the RTCP packet dispatch for PSFB FIR (FMT=4)
- Added `firSequenceNumber` field to `KvsRtpTransceiver` for FIR sequence tracking

*What testing was done for the changes?*
- Updated PeerConnectionFunctionalityTest with tests covering PLI and FIR sending/receiving

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.