### PR TITLE
CONVERT_TIMESTAMP_TO_RTP_PRECISE

### DIFF
--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -90,7 +90,13 @@ STATUS freeKvsRtpTransceiver(PKvsRtpTransceiver*);
 
 STATUS kvsRtpTransceiverSetJitterBuffer(PKvsRtpTransceiver, PJitterBuffer);
 
-#define CONVERT_TIMESTAMP_TO_RTP(clockRate, pts) ((UINT64) ((DOUBLE) (pts) * ((DOUBLE) (clockRate) / HUNDREDS_OF_NANOS_IN_A_SECOND)))
+// handles very large timestamp values, old style
+#define CONVERT_TIMESTAMP_TO_RTP_LARGE(clockRate, pts) ((UINT64) ((DOUBLE) (pts) * ((DOUBLE) (clockRate) / HUNDREDS_OF_NANOS_IN_A_SECOND)))
+
+// for timestamps that do not overflow UINT64 (pts * clockRate) this function converts to kinesis timescale accurately
+#define CONVERT_TIMESTAMP_TO_RTP_PRECISE(clockRate, pts) ((UINT64) ((UINT64) (pts) * (UINT64) (clockRate) / HUNDREDS_OF_NANOS_IN_A_SECOND))
+
+#define CONVERT_TIMESTAMP_TO_RTP CONVERT_TIMESTAMP_TO_RTP_PRECISE
 
 STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket);
 

--- a/tst/PeerConnectionApiTest.cpp
+++ b/tst/PeerConnectionApiTest.cpp
@@ -155,7 +155,7 @@ a=fmtp:97 profile-level-id=42e01f;level-asymmetry-allowed=1
 TEST_F(PeerConnectionApiTest, CONVERT_TIMESTAMP_TO_RTP_BigTimestamp)
 {
     UINT64 timestamp = 16034753564030000;
-    UINT64 rtpTimestamp = CONVERT_TIMESTAMP_TO_RTP(VIDEO_CLOCKRATE, timestamp);
+    UINT64 rtpTimestamp = CONVERT_TIMESTAMP_TO_RTP_LARGE(VIDEO_CLOCKRATE, timestamp);
     EXPECT_EQ(144312782076270, rtpTimestamp);
 }
 

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -800,11 +800,13 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
         THREAD_SLEEP(40 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
 
+    DLOGI("framesSent");
     // Wait for receiver to see at least 1 frame
     // exact number of frames depends on timing
     for (auto i = 0; i <= 1000 && ATOMIC_LOAD(&seenVideo) < 2; i++) {
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
+    DLOGI("framesReceived %zu", ATOMIC_LOAD(&seenVideo));
 
     MEMFREE(videoFrame.frameData);
     RtcOutboundRtpStreamStats stats{};


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Replaced the `CONVERT_TIMESTAMP_TO_RTP` macro with two variants: `CONVERT_TIMESTAMP_TO_RTP_LARGE` (floating-point, handles very large timestamps) and `CONVERT_TIMESTAMP_TO_RTP_PRECISE` (integer arithmetic, more accurate for normal timestamp ranges)
- Default `CONVERT_TIMESTAMP_TO_RTP` now aliases to `CONVERT_TIMESTAMP_TO_RTP_PRECISE`

*Why was it changed?*
- The original floating-point based conversion loses precision due to double rounding for timestamps that fit within UINT64 integer arithmetic. An integer-based conversion gives exact results for the common case.

*How was it changed?*
- Split the existing `CONVERT_TIMESTAMP_TO_RTP` macro in Rtp.h into `CONVERT_TIMESTAMP_TO_RTP_LARGE` (original float-based) and `CONVERT_TIMESTAMP_TO_RTP_PRECISE` (new integer-based)
- Aliased `CONVERT_TIMESTAMP_TO_RTP` to the precise variant
- Updated the existing big-timestamp test to use `CONVERT_TIMESTAMP_TO_RTP_LARGE` explicitly since that test exercises the float path

*What testing was done for the changes?*
- Updated PeerConnectionApiTest `CONVERT_TIMESTAMP_TO_RTP_BigTimestamp` to use the `CONVERT_TIMESTAMP_TO_RTP_LARGE` macro for the large-value test case

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.