### PR TITLE
correct frame timestamps

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -414,7 +414,7 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
     CHK(frameSize == filledSize, STATUS_INVALID_ARG_LEN);
 
     frame.version = FRAME_CURRENT_VERSION;
-    frame.decodingTs = pPacket->header.timestamp * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    frame.decodingTs = KVS_CONVERT_TIMESCALE(pPacket->header.timestamp, pTransceiver->pJitterBuffer->clockRate, HUNDREDS_OF_NANOS_IN_A_SECOND);
     frame.presentationTs = frame.decodingTs;
     frame.frameData = pTransceiver->peerFrameBuffer;
     frame.size = frameSize;

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -842,6 +842,8 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
 
     RtcInboundRtpStreamStats answerStats{};
     EXPECT_EQ(STATUS_SUCCESS, getRtpInboundStats(answerPc, answerVideoTransceiver, &answerStats));
+
+    EXPECT_LE(1, ATOMIC_LOAD(&seenVideo));
     EXPECT_LE(1, answerStats.framesReceived);
     EXPECT_LT(103, answerStats.received.packetsReceived);
     EXPECT_LT(120000, answerStats.bytesReceived);
@@ -853,8 +855,6 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
-
-    EXPECT_EQ(ATOMIC_LOAD(&frameCtx.seenVideo), 1);
 
     // Verify timestamp conversion: received timestamps should be in the correct range
     // Sent timestamps start at HUNDREDS_OF_NANOS_IN_A_SECOND (1s) with 25fps increments

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -825,7 +825,7 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     for (auto i = 0; i <= 1000 && ATOMIC_LOAD(&frameCtx.seenVideo) < 2; i++) {
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
-    DLOGI("framesReceived %zu", ATOMIC_LOAD(&seenVideo));
+    DLOGI("framesReceived %zu", ATOMIC_LOAD(&frameCtx.seenVideo));
 
     MEMFREE(videoFrame.frameData);
     RtcOutboundRtpStreamStats stats{};
@@ -843,7 +843,7 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     RtcInboundRtpStreamStats answerStats{};
     EXPECT_EQ(STATUS_SUCCESS, getRtpInboundStats(answerPc, answerVideoTransceiver, &answerStats));
 
-    EXPECT_LE(1, ATOMIC_LOAD(&seenVideo));
+    EXPECT_LE(1, ATOMIC_LOAD(&frameCtx.seenVideo));
     EXPECT_LE(1, answerStats.framesReceived);
     EXPECT_LT(103, answerStats.received.packetsReceived);
     EXPECT_LT(120000, answerStats.bytesReceived);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -635,7 +635,13 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
     PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
     RtcSessionDescriptionInit sdp;
-    ATOMIC_BOOL seenFirstFrame = FALSE;
+    struct NoLostFramesContext {
+        ATOMIC_BOOL seenFirstFrame;
+        UINT64 receivedDecodingTs;
+    };
+    NoLostFramesContext frameCtx;
+    ATOMIC_STORE_BOOL(&frameCtx.seenFirstFrame, FALSE);
+    frameCtx.receivedDecodingTs = 0;
     Frame videoFrame;
 
     PeerContainer offer;
@@ -646,7 +652,7 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
 
     videoFrame.frameData = (PBYTE) MEMALLOC(1);
     videoFrame.size = 1;
-    videoFrame.presentationTs = 0;
+    videoFrame.presentationTs = HUNDREDS_OF_NANOS_IN_A_SECOND;
 
     context.mutex = MUTEX_CREATE(FALSE);
     ASSERT_NE(context.mutex, INVALID_MUTEX_VALUE);
@@ -688,12 +694,13 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     };
 
     auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
-        UNUSED_PARAM(pFrame);
+        NoLostFramesContext* ctx = (NoLostFramesContext*) customData;
         if (pFrame->frameData[0] == 1) {
-            ATOMIC_STORE_BOOL((PSIZE_T) customData, 1);
+            ctx->receivedDecodingTs = pFrame->decodingTs;
+            ATOMIC_STORE_BOOL(&ctx->seenFirstFrame, 1);
         }
     };
-    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &seenFirstFrame, onFrameHandler), STATUS_SUCCESS);
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &frameCtx, onFrameHandler), STATUS_SUCCESS);
 
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &offer, onICECandidateHdlr));
@@ -730,7 +737,7 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND / 25);
     }
 
-    for (auto i = 0; i <= 1000 && !ATOMIC_LOAD_BOOL(&seenFirstFrame); i++) {
+    for (auto i = 0; i <= 1000 && !ATOMIC_LOAD_BOOL(&frameCtx.seenFirstFrame); i++) {
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
 
@@ -754,7 +761,11 @@ TEST_F(PeerConnectionFunctionalityTest, noLostFramesAfterConnected)
     CVAR_FREE(context.cvar);
     MUTEX_FREE(context.mutex);
 
-    EXPECT_EQ(ATOMIC_LOAD_BOOL(&seenFirstFrame), TRUE);
+    EXPECT_EQ(ATOMIC_LOAD_BOOL(&frameCtx.seenFirstFrame), TRUE);
+
+    // Verify timestamp conversion: first frame was sent with presentationTs = HUNDREDS_OF_NANOS_IN_A_SECOND
+    // With correct conversion, received decodingTs should match (not be ~90x too large)
+    EXPECT_EQ(frameCtx.receivedDecodingTs, HUNDREDS_OF_NANOS_IN_A_SECOND);
 }
 
 // Assert that two PeerConnections can connect and then send media until the receiver gets both audio/video
@@ -766,7 +777,13 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     PRtcPeerConnection offerPc = NULL, answerPc = NULL;
     RtcMediaStreamTrack offerVideoTrack, answerVideoTrack, offerAudioTrack, answerAudioTrack;
     PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
-    SIZE_T seenVideo = 0;
+    struct ExchangeMediaFrameContext {
+        SIZE_T seenVideo;
+        UINT64 receivedDecodingTs;
+        UINT64 receivedPresentationTs;
+    };
+    ExchangeMediaFrameContext frameCtx;
+    MEMSET(&frameCtx, 0, SIZEOF(frameCtx));
     Frame videoFrame;
 
     initRtcConfiguration(&configuration);
@@ -786,10 +803,12 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     addTrackToPeerConnection(answerPc, &answerAudioTrack, &answerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
 
     auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
-        UNUSED_PARAM(pFrame);
-        ATOMIC_INCREMENT((PSIZE_T) customData);
+        ExchangeMediaFrameContext* ctx = (ExchangeMediaFrameContext*) customData;
+        ctx->receivedDecodingTs = pFrame->decodingTs;
+        ctx->receivedPresentationTs = pFrame->presentationTs;
+        ATOMIC_INCREMENT((PSIZE_T) &ctx->seenVideo);
     };
-    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &seenVideo, onFrameHandler), STATUS_SUCCESS);
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &frameCtx, onFrameHandler), STATUS_SUCCESS);
 
     EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
 
@@ -803,7 +822,7 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     DLOGI("framesSent");
     // Wait for receiver to see at least 1 frame
     // exact number of frames depends on timing
-    for (auto i = 0; i <= 1000 && ATOMIC_LOAD(&seenVideo) < 2; i++) {
+    for (auto i = 0; i <= 1000 && ATOMIC_LOAD(&frameCtx.seenVideo) < 2; i++) {
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }
     DLOGI("framesReceived %zu", ATOMIC_LOAD(&seenVideo));
@@ -823,8 +842,6 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
 
     RtcInboundRtpStreamStats answerStats{};
     EXPECT_EQ(STATUS_SUCCESS, getRtpInboundStats(answerPc, answerVideoTransceiver, &answerStats));
-
-    EXPECT_LE(1, ATOMIC_LOAD(&seenVideo));
     EXPECT_LE(1, answerStats.framesReceived);
     EXPECT_LT(103, answerStats.received.packetsReceived);
     EXPECT_LT(120000, answerStats.bytesReceived);
@@ -837,6 +854,14 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
 
+    EXPECT_EQ(ATOMIC_LOAD(&frameCtx.seenVideo), 1);
+
+    // Verify timestamp conversion: received timestamps should be in the correct range
+    // Sent timestamps start at HUNDREDS_OF_NANOS_IN_A_SECOND (1s) with 25fps increments
+    // With the old bug (treating RTP clock rate units as ms), they'd be ~90x too large
+    EXPECT_GE(frameCtx.receivedDecodingTs, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_LE(frameCtx.receivedDecodingTs, (UINT64) 50 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(frameCtx.receivedDecodingTs, frameCtx.receivedPresentationTs);
 }
 
 // Same test as exchangeMedia, but assert that if one side is RSA DTLS and Key Extraction works


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed RTP-to-KVS timestamp conversion in `onFrameReadyFunc` to use `KVS_CONVERT_TIMESCALE` with the actual jitter buffer clock rate instead of treating RTP timestamps as milliseconds

*Why was it changed?*
- The previous conversion (`timestamp * HUNDREDS_OF_NANOS_IN_A_MILLISECOND`) assumed RTP timestamps were in milliseconds, but they are in clock rate units (e.g. 90kHz for video). This produced decoded frame timestamps ~90x too large for video streams.

*How was it changed?*
- In PeerConnection.c `onFrameReadyFunc`, replaced the millisecond-based multiplication with `KVS_CONVERT_TIMESCALE(timestamp, clockRate, HUNDREDS_OF_NANOS_IN_A_SECOND)` to correctly convert from the transceiver's jitter buffer clock rate to hundreds-of-nanoseconds
- Updated `noLostFramesAfterConnected` and `exchangeMedia` tests to capture and verify the received `decodingTs`/`presentationTs`, asserting they match the sent timestamps rather than being inflated

*What testing was done for the changes?*
- Updated `noLostFramesAfterConnected` test to send a frame at `presentationTs = 1s` and assert the received `decodingTs` equals `HUNDREDS_OF_NANOS_IN_A_SECOND`
- Updated `exchangeMedia` test to verify received timestamps are in the expected range (1s–50s) and that `decodingTs == presentationTs`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.