### PR TITLE
fix KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE

### DIFF
--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1646,10 +1646,13 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
         }
 
         // If the candidate has moved to valid state, then we can report it and start creating pairs with
-        // srflx candidates.
+        // srflx candidates. Only report up to KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE candidates
+        // per timer callback - remaining candidates will be reported in subsequent callbacks.
         else if (pIceCandidate->state == ICE_CANDIDATE_STATE_VALID && !pIceCandidate->reported) {
-            newLocalCandidates[newLocalCandidateCount++] = *pIceCandidate;
-            pIceCandidate->reported = TRUE;
+            if (newLocalCandidateCount < KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE) {
+                newLocalCandidates[newLocalCandidateCount++] = *pIceCandidate;
+                pIceCandidate->reported = TRUE;
+            }
 
             if (pIceCandidate->iceCandidateType == ICE_CANDIDATE_TYPE_SERVER_REFLEXIVE) {
                 CHK_STATUS(createIceCandidatePairs(pIceAgent, pIceCandidate, FALSE));


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Fixed a buffer overflow in `iceAgentGatherCandidateTimerCallback` where new local candidates could exceed the `KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE` array bound

*Why was it changed?*
- The `newLocalCandidates` array is sized to `KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE`, but the loop did not check the count before writing into it. If more candidates became valid in a single timer callback than the array size, it would write out of bounds.

*How was it changed?*
- Added a bounds check (`newLocalCandidateCount < KVS_ICE_MAX_NEW_LOCAL_CANDIDATES_TO_REPORT_AT_ONCE`) before copying a candidate into the array and marking it as reported
- Candidates that exceed the limit are left unreported and will be picked up in subsequent timer callbacks

*What testing was done for the changes?*
- Existing ICE agent tests continue to pass. The fix is a defensive bounds check that prevents out-of-bounds writes under high candidate volume.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.