### PR TITLE
set socket SO_RCVBUF to handle packet bursts for UDP sockets

### DIFF
--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -192,6 +192,15 @@ STATUS createSocket(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL protocol,
         CHK(FALSE, STATUS_SOCKET_SET_SEND_BUFFER_SIZE_FAILED);
     }
 
+    // Increase UDP receive buffer to handle burst traffic (e.g. a full video
+    // frame worth of RTP packets arriving before the reader thread drains them).
+    if (protocol == KVS_SOCKET_PROTOCOL_UDP) {
+        INT32 rcvBufSize = 512 * 1024;
+        if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &rcvBufSize, SIZEOF(rcvBufSize)) < 0) {
+            DLOGD("setsockopt() SO_RCVBUF failed with errno %s", getErrorString(getErrorCode()));
+        }
+    }
+
     *pOutSockFd = (INT32) sockfd;
 
 #ifdef _WIN32


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Set `SO_RCVBUF` to 512 KB on UDP sockets created in `createSocket` to increase the kernel receive buffer size

*Why was it changed?*
- Video frames can arrive as bursts of many RTP packets. With the default OS receive buffer, packets can be dropped before the reader thread drains them, causing frame loss and corruption.

*How was it changed?*
- In `Network.c` `createSocket`, added a `setsockopt(SO_RCVBUF)` call for UDP sockets after the existing send buffer configuration
- Failure to set the buffer is logged as a debug message but does not fail socket creation

*What testing was done for the changes?*
- Existing network and ICE tests continue to pass. The change is a best-effort socket option that gracefully degrades if the OS rejects the requested buffer size.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.