### PR TITLE
fix connection listener use-after-free during ICE restart

### DIFF
--- a/src/source/Ice/ConnectionListener.c
+++ b/src/source/Ice/ConnectionListener.c
@@ -390,12 +390,19 @@ PVOID connectionListenerReceiveDataRoutine(PVOID arg)
                         }
                     }
                 }
+
+                // Release this socket immediately so freeSocketConnection can
+                // proceed as soon as this socket's processing is done, rather
+                // than waiting for all sockets in this iteration to finish.
+                ATOMIC_STORE_BOOL(&pSocketConnection->inUse, FALSE);
             }
         }
 
-        // Mark as unused
-        for (i = 0; i < socketCount; i++) {
-            ATOMIC_STORE_BOOL(&sockets[i]->inUse, FALSE);
+        // Release sockets that were not processed (poll timeout or error)
+        if (retval <= 0) {
+            for (i = 0; i < socketCount; i++) {
+                ATOMIC_STORE_BOOL(&sockets[i]->inUse, FALSE);
+            }
         }
     }
 


### PR DESCRIPTION
*What was changed?*

Fixed a use-after-free in connectionListenerReceiveDataRoutine by releasing each socket's inUse flag immediately after processing instead of in a batch loop at the end.

*Why was it changed?*

The previous batch-release pattern kept all sockets marked as inUse until every socket in the iteration was processed. This allowed freeSocketConnection to race with the listener, causing a use-after-free during ICE restart.

*How was it changed?*

Moved the ATOMIC_STORE_BOOL(&pSocketConnection->inUse, FALSE) call inside the per-socket processing block so each socket is released as soon as its data is handled. The batch release loop is now only used as a fallback when poll returns timeout or error (retval <= 0).

*What testing was done for the changes?*

Ran WebRTC ICE restart scenarios under AddressSanitizer on Android arm64 to confirm the use-after-free no longer occurs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.