### PR TITLE
TWCC sending

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -245,8 +245,45 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
     CHK(pKvsPeerConnection != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen >= MIN_HEADER_LENGTH, STATUS_INVALID_ARG);
 
-    ssrc = getInt32(*(PUINT32) (pBuffer + SSRC_OFFSET));
+    now = GETTIME();
 
+    // IMPORTANT: Track TWCC BEFORE decryption!
+    // RTP header and extensions are NOT encrypted by SRTP (only payload is)
+    // This ensures we track TWCC even for packets that fail SRTP replay check
+    if (pKvsPeerConnection->twccExtId != 0) {
+        // Parse RTP header from raw (still encrypted) packet to get TWCC extension
+        PRtpPacket pTwccPacket = NULL;
+        PBYTE pTwccBuffer = (PBYTE) MEMALLOC(bufferLen);
+        if (pTwccBuffer != NULL) {
+            MEMCPY(pTwccBuffer, pBuffer, bufferLen);
+            if (STATUS_SUCCEEDED(createRtpPacketFromBytes(pTwccBuffer, bufferLen, &pTwccPacket))) {
+                pTwccPacket->receivedTime = now;
+                if (pTwccPacket->header.extension && pTwccPacket->header.extensionProfile == TWCC_EXT_PROFILE) {
+                    twccReceiverOnPacketReceived(pKvsPeerConnection, pTwccPacket);
+                }
+                freeRtpPacket(&pTwccPacket);
+            } else {
+                MEMFREE(pTwccBuffer);
+            }
+        }
+    }
+
+    // Now decrypt
+    if (STATUS_FAILED(retStatus = decryptSrtpPacket(pKvsPeerConnection->pSrtpSession, pBuffer, (PINT32) &bufferLen))) {
+        DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
+        packetsFailedDecryption++;
+        CHK(FALSE, STATUS_SUCCESS);
+    }
+
+    CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
+    MEMCPY(pPayload, pBuffer, bufferLen);
+    CHK_STATUS(createRtpPacketFromBytes(pPayload, bufferLen, &pRtpPacket));
+    pPayload = NULL; // pRtpPacket now owns the buffer
+    pRtpPacket->receivedTime = now;
+
+    ssrc = pRtpPacket->header.ssrc;
+
+    // Find matching transceiver for this SSRC
     CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &item));
@@ -254,19 +291,6 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
 
         if (pTransceiver->jitterBufferSsrc == ssrc) {
             packetsReceived++;
-            if (STATUS_FAILED(retStatus = decryptSrtpPacket(pKvsPeerConnection->pSrtpSession, pBuffer, (PINT32) &bufferLen))) {
-                DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
-                packetsFailedDecryption++;
-                CHK(FALSE, STATUS_SUCCESS);
-            }
-            now = GETTIME();
-            CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
-            MEMCPY(pPayload, pBuffer, bufferLen);
-            CHK_STATUS(createRtpPacketFromBytes(pPayload, bufferLen, &pRtpPacket));
-            // pRtpPacket took ownership of pPayload. Set pPayload to NULL to
-            // avoid possible double-free.
-            pPayload = NULL;
-            pRtpPacket->receivedTime = now;
 
             // https://tools.ietf.org/html/rfc3550#section-6.4.1
             // https://tools.ietf.org/html/rfc3550#appendix-A.8
@@ -1057,6 +1081,11 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
                                              &pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable));
     }
 
+    // TWCC feedback generation (receiver side)
+    pKvsPeerConnection->twccReceiverLock = MUTEX_CREATE(TRUE);
+    CHK_STATUS(createTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
+    pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32; // Invalid timer ID
+
     *ppPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
 
 CleanUp:
@@ -1095,7 +1124,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     PDoubleListNode pCurNode = NULL;
     UINT64 item = 0;
     UINT64 startTime;
-    UINT32 twccHashTableCount = 0;
     BOOL twccLocked = FALSE;
 
     CHK(ppPeerConnection != NULL, STATUS_NULL_ARG);
@@ -1111,6 +1139,16 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
 
     // free timer queue first to remove liveness provided by timer
     if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
+        if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
+            UINT32 twccTimerId;
+            MUTEX_LOCK(pKvsPeerConnection->twccLock);
+            twccTimerId = pKvsPeerConnection->twccFeedbackTimerId;
+            pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32;
+            MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+            if (twccTimerId != MAX_UINT32) {
+                timerQueueCancelTimer(pKvsPeerConnection->timerQueueHandle, twccTimerId, (UINT64) pKvsPeerConnection);
+            }
+        }
         timerQueueShutdown(pKvsPeerConnection->timerQueueHandle);
     }
 
@@ -1142,7 +1180,11 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pDataChannels));
 
     // free rest of structs
-    CHK_LOG_ERR(freeSrtpSession(&pKvsPeerConnection->pSrtpSession));
+    if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->pSrtpSessionLock)) {
+        MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+        CHK_LOG_ERR(freeSrtpSession(&pKvsPeerConnection->pSrtpSession));
+        MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    }
     CHK_LOG_ERR(freeDtlsSession(&pKvsPeerConnection->pDtlsSession));
     // Since ICE agent has a callback invoked from DTLS during handshake,
     // it is safer to free the ICE agent after DTLS session
@@ -1168,10 +1210,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
         MUTEX_LOCK(pKvsPeerConnection->twccLock);
         twccLocked = TRUE;
 
-        if (STATUS_SUCCEEDED(hashTableGetCount(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, &twccHashTableCount))) {
-            DLOGI("Number of TWCC info packets in memory: %d", twccHashTableCount);
-        }
-
         CHK_LOG_ERR(hashTableIterateEntries(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, 0, freeHashEntry));
         CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable));
 
@@ -1188,6 +1226,16 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
         }
         MUTEX_FREE(pKvsPeerConnection->twccLock);
         pKvsPeerConnection->twccLock = INVALID_MUTEX_VALUE;
+    }
+
+    // Free TWCC receiver manager
+    if (pKvsPeerConnection->pTwccReceiverManager != NULL) {
+        CHK_LOG_ERR(freeTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccReceiverLock)) {
+        MUTEX_FREE(pKvsPeerConnection->twccReceiverLock);
+        pKvsPeerConnection->twccReceiverLock = INVALID_MUTEX_VALUE;
     }
 
     PROFILE_WITH_START_TIME_OBJ(startTime, pKvsPeerConnection->peerConnectionDiagnostics.freePeerConnectionTime, "Free peer connection");
@@ -1489,6 +1537,13 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         DLOGD("REMOTE_SDP:%s\n", pSessionDescriptionInit->sdp);
     }
 
+    // Start TWCC feedback timer when remote offers TWCC
+    if (pKvsPeerConnection->twccExtId != 0 && pKvsPeerConnection->twccFeedbackTimerId == MAX_UINT32) {
+        CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, TWCC_FEEDBACK_INITIAL_DELAY, TIMER_QUEUE_SINGLE_INVOCATION_PERIOD,
+                                      twccFeedbackCallback, (UINT64) pKvsPeerConnection, &pKvsPeerConnection->twccFeedbackTimerId));
+        DLOGI("Started TWCC feedback timer with extension ID %u", pKvsPeerConnection->twccExtId);
+    }
+
 CleanUp:
     if (pKvsPeerConnection != NULL && pKvsPeerConnection->isOffer) {
         SAFE_MEMFREE(pKvsPeerConnection->pRemoteSessionDescription);
@@ -1775,6 +1830,24 @@ STATUS closePeerConnection(PRtcPeerConnection pPeerConnection)
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
     CHK_LOG_ERR(dtlsSessionShutdown(pKvsPeerConnection->pDtlsSession));
     CHK_LOG_ERR(iceAgentShutdown(pKvsPeerConnection->pIceAgent));
+
+    // Cancel TWCC feedback timer so it stops re-scheduling itself.
+    // This is needed because on Android THREAD_CANCEL is a no-op, so
+    // timerQueueShutdown cannot forcefully stop the executor thread.
+    // Cancelling timers first lets the executor exit cleanly.
+    // Snapshot and reset twccFeedbackTimerId under twccLock to avoid
+    // racing with twccFeedbackCallback which writes it on the timer thread.
+    if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle) && IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
+        UINT32 twccTimerId;
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        twccTimerId = pKvsPeerConnection->twccFeedbackTimerId;
+        pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32;
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+        if (twccTimerId != MAX_UINT32) {
+            timerQueueCancelTimer(pKvsPeerConnection->timerQueueHandle, twccTimerId, (UINT64) pKvsPeerConnection);
+        }
+    }
+
     PROFILE_WITH_START_TIME_OBJ(startTime, pKvsPeerConnection->peerConnectionDiagnostics.closePeerConnectionTime, "Close peer connection");
 
 CleanUp:

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -61,6 +61,21 @@ typedef struct {
     UINT16 prevReportedBaseSeqNum;        // To monitor the base seqNum in the TWCC response
 } TwccManager, *PTwccManager;
 
+// Receiver-side TWCC tracking for feedback generation
+typedef struct {
+    UINT64 arrivalTimeKvs; // Local arrival time in 100ns units
+} TwccReceivedPacketInfo, *PTwccReceivedPacketInfo;
+
+typedef struct {
+    PHashTable pReceivedPktsHashTable; // Hash table of [seqNum -> PTwccReceivedPacketInfo]
+    UINT16 firstSeqNum;                // First seq in current feedback window
+    UINT16 lastSeqNum;                 // Last seq received
+    BOOL firstPacketReceived;          // Any packet received yet?
+    UINT8 feedbackPacketCount;         // Counter for fb pkt. count field
+    UINT32 mediaSourceSsrc;            // SSRC we're providing feedback for
+    UINT64 baseTimeKvs;                // Base time for relative arrival timestamps
+} TwccReceiverManager, *PTwccReceiverManager;
+
 typedef struct {
     UINT64 peerConnectionCreationTime;
     UINT64 dtlsSessionSetupTime;
@@ -138,13 +153,18 @@ typedef struct {
 
     NullableBool canTrickleIce;
 
-    // congestion control
+    // congestion control (sender side)
     // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
     UINT16 twccExtId;
     MUTEX twccLock;
     PTwccManager pTwccManager;
     RtcOnSenderBandwidthEstimation onSenderBandwidthEstimation;
     UINT64 onSenderBandwidthEstimationCustomData;
+
+    // TWCC feedback generation (receiver side)
+    MUTEX twccReceiverLock;
+    PTwccReceiverManager pTwccReceiverManager;
+    UINT32 twccFeedbackTimerId;
 
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -686,3 +686,531 @@ STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UIN
 CleanUp:
     return retStatus;
 }
+
+//
+// TWCC Feedback Generation (Receiver Side)
+//
+
+STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+
+    CHK(ppManager != NULL, STATUS_NULL_ARG);
+
+    pManager = (PTwccReceiverManager) MEMCALLOC(1, SIZEOF(TwccReceiverManager));
+    CHK(pManager != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    CHK_STATUS(hashTableCreateWithParams(TWCC_RECEIVER_HASH_BUCKET_COUNT, TWCC_RECEIVER_HASH_BUCKET_LENGTH, &pManager->pReceivedPktsHashTable));
+
+    pManager->firstPacketReceived = FALSE;
+    pManager->feedbackPacketCount = 0;
+    pManager->firstSeqNum = 0;
+    pManager->lastSeqNum = 0;
+    pManager->mediaSourceSsrc = 0;
+
+    *ppManager = pManager;
+    pManager = NULL;
+
+CleanUp:
+    if (pManager != NULL) {
+        freeTwccReceiverManager(&pManager);
+    }
+    return retStatus;
+}
+
+static STATUS twccReceiverFreeHashEntry(UINT64 customData, PHashEntry pHashEntry)
+{
+    UNUSED_PARAM(customData);
+    if (pHashEntry != NULL && pHashEntry->value != 0) {
+        MEMFREE((PVOID) pHashEntry->value);
+    }
+    return STATUS_SUCCESS;
+}
+
+STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+
+    CHK(ppManager != NULL, STATUS_NULL_ARG);
+    pManager = *ppManager;
+    CHK(pManager != NULL, retStatus);
+
+    if (pManager->pReceivedPktsHashTable != NULL) {
+        hashTableIterateEntries(pManager->pReceivedPktsHashTable, 0, twccReceiverFreeHashEntry);
+        hashTableFree(pManager->pReceivedPktsHashTable);
+    }
+
+    MEMFREE(pManager);
+    *ppManager = NULL;
+
+CleanUp:
+    return retStatus;
+}
+
+// Helper function to find a specific extension by ID in one-byte header extension payload (0xBEDE format)
+// Returns pointer to extension data (after ID|L byte) or NULL if not found
+static PBYTE findOneByteExtension(PBYTE pExtPayload, UINT32 extLength, UINT8 targetId, PUINT8 pDataLen)
+{
+    UINT32 offset = 0;
+    UINT8 id, len;
+
+    while (offset < extLength) {
+        UINT8 byte = pExtPayload[offset];
+
+        // Skip padding bytes (0x00)
+        if (byte == 0) {
+            offset++;
+            continue;
+        }
+
+        // Parse ID (4 bits) and L (4 bits)
+        id = (byte >> 4) & 0x0F;
+        len = (byte & 0x0F) + 1; // L=0 means 1 byte of data, L=1 means 2 bytes, etc.
+
+        // ID 15 is reserved for future two-byte header, skip rest
+        if (id == 15) {
+            break;
+        }
+
+        // Check if this is the extension we're looking for
+        if (id == targetId) {
+            if (pDataLen != NULL) {
+                *pDataLen = len;
+            }
+            return pExtPayload + offset + 1; // Return pointer to data after ID|L byte
+        }
+
+        // Move to next extension
+        offset += 1 + len;
+    }
+
+    return NULL;
+}
+
+STATUS twccReceiverOnPacketReceived(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+    PTwccReceivedPacketInfo pPacketInfo = NULL;
+    UINT16 twccSeqNum = 0;
+    UINT64 existingValue = 0;
+    PBYTE pTwccExtData = NULL;
+
+    CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pRtpPacket->header.extension && pRtpPacket->header.extensionProfile == TWCC_EXT_PROFILE, retStatus);
+    CHK(pRtpPacket->header.extensionPayload != NULL, retStatus);
+
+    pManager = pKvsPeerConnection->pTwccReceiverManager;
+    CHK(pManager != NULL, retStatus);
+
+    // Find TWCC extension by ID in the one-byte header extension payload
+    pTwccExtData =
+        findOneByteExtension(pRtpPacket->header.extensionPayload, pRtpPacket->header.extensionLength, (UINT8) pKvsPeerConnection->twccExtId, NULL);
+    if (pTwccExtData == NULL) {
+        DLOGW("TWCC extension ID %u not found in payload (extLen=%u)", pKvsPeerConnection->twccExtId, pRtpPacket->header.extensionLength);
+        CHK(FALSE, retStatus);
+    }
+
+    // Extract TWCC sequence number (16-bit big-endian)
+    twccSeqNum = (UINT16) getUnalignedInt16BigEndian(pTwccExtData);
+    DLOGD("TWCC packet received: seq=%u", twccSeqNum);
+
+    MUTEX_LOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Check if packet already exists (duplicate)
+    if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, twccSeqNum, &existingValue))) {
+        // Already tracked, skip
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    // Allocate packet info
+    pPacketInfo = (PTwccReceivedPacketInfo) MEMCALLOC(1, SIZEOF(TwccReceivedPacketInfo));
+    if (pPacketInfo == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Set base time once (on first ever packet), then store relative arrival time
+    if (pManager->baseTimeKvs == 0) {
+        pManager->baseTimeKvs = pRtpPacket->receivedTime;
+    }
+    pPacketInfo->arrivalTimeKvs = pRtpPacket->receivedTime - pManager->baseTimeKvs;
+
+    // Store in hash table
+    retStatus = hashTablePut(pManager->pReceivedPktsHashTable, twccSeqNum, (UINT64) pPacketInfo);
+    if (STATUS_FAILED(retStatus)) {
+        MEMFREE(pPacketInfo);
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    // Update sequence number tracking
+    if (!pManager->firstPacketReceived) {
+        pManager->firstSeqNum = twccSeqNum;
+        pManager->lastSeqNum = twccSeqNum;
+        pManager->firstPacketReceived = TRUE;
+    } else {
+        // Handle sequence number wraparound using signed comparison
+        INT16 diffFromFirst = (INT16) (twccSeqNum - pManager->firstSeqNum);
+        INT16 diffFromLast = (INT16) (twccSeqNum - pManager->lastSeqNum);
+
+        if (diffFromFirst < 0) {
+            // New packet is before current first (wraparound or out of order)
+            pManager->firstSeqNum = twccSeqNum;
+        }
+        if (diffFromLast > 0) {
+            // New packet is after current last
+            pManager->lastSeqNum = twccSeqNum;
+        }
+    }
+
+    // Store media SSRC for feedback
+    pManager->mediaSourceSsrc = pRtpPacket->header.ssrc;
+
+    MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+
+CleanUp:
+    return retStatus;
+}
+
+// Helper function to determine packet status and delta
+static TWCC_STATUS_SYMBOL getTwccPacketStatus(UINT64 arrivalTimeKvs, UINT64 referenceTimeKvs, PINT32 pDeltaTicks)
+{
+    INT64 deltaKvs;
+    INT64 deltaTicks;
+
+    // Calculate delta from reference time
+    deltaKvs = (INT64) arrivalTimeKvs - (INT64) referenceTimeKvs;
+
+    // Convert from 100ns to 250us ticks
+    // 100ns * (1us/10 * 100ns) * (1 tick / 250us) = 100ns / 2500
+    deltaTicks = deltaKvs / 2500;
+
+    *pDeltaTicks = (INT32) deltaTicks;
+
+    // Determine which delta encoding to use
+    if (deltaTicks >= 0 && deltaTicks <= 255) {
+        return TWCC_STATUS_SYMBOL_SMALLDELTA;
+    } else if (deltaTicks >= -32768 && deltaTicks <= 32767) {
+        return TWCC_STATUS_SYMBOL_LARGEDELTA;
+    } else {
+        // Delta too large - treat as not received
+        return TWCC_STATUS_SYMBOL_NOTRECEIVED;
+    }
+}
+
+STATUS sendRtcpTwccFeedback(PKvsPeerConnection pKvsPeerConnection)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL hasSrtpSession = FALSE;
+    PTwccReceiverManager pManager = NULL;
+    PBYTE pPacket = NULL;
+    UINT32 packetLen = 0;
+    UINT32 allocSize = 0;
+    UINT16 baseSeqNum = 0;
+    UINT16 packetStatusCount = 0;
+    UINT32 currentTime = 0;
+    UINT64 referenceTimeKvs = 0;
+    UINT32 referenceTime24 = 0;
+    UINT16 seqNum = 0;
+    UINT32 offset = 0;
+    UINT64 packetInfoValue = 0;
+    PTwccReceivedPacketInfo pPacketInfo = NULL;
+    INT32 deltaTicks = 0;
+    TWCC_STATUS_SYMBOL status = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+    UINT32 senderSsrc = 0;
+
+    // Arrays to store packet statuses and deltas
+    TWCC_STATUS_SYMBOL* pStatuses = NULL;
+    INT32* pDeltas = NULL;
+    UINT32 i = 0;
+    UINT32 chunkOffset = 0;
+    UINT32 deltaOffset = 0;
+    UINT16 runLength = 0;
+    TWCC_STATUS_SYMBOL runStatus = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    hasSrtpSession = pKvsPeerConnection->pSrtpSession != NULL;
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    CHK(hasSrtpSession, retStatus);
+
+    pManager = pKvsPeerConnection->pTwccReceiverManager;
+    CHK(pManager != NULL, retStatus);
+
+    MUTEX_LOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Check if we have packets to report
+    if (!pManager->firstPacketReceived) {
+        DLOGD("TWCC sendFeedback: no packets received yet");
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    baseSeqNum = pManager->firstSeqNum;
+    // Calculate packet status count (handles wraparound)
+    packetStatusCount = (UINT16) ((pManager->lastSeqNum - pManager->firstSeqNum) + 1);
+
+    // Limit packet status count to avoid huge packets
+    if (packetStatusCount > TWCC_MAX_PACKET_STATUS_COUNT) {
+        packetStatusCount = TWCC_MAX_PACKET_STATUS_COUNT;
+    }
+
+    // Allocate arrays for statuses and deltas
+    pStatuses = (TWCC_STATUS_SYMBOL*) MEMCALLOC(packetStatusCount, SIZEOF(TWCC_STATUS_SYMBOL));
+    pDeltas = (INT32*) MEMCALLOC(packetStatusCount, SIZEOF(INT32));
+    if (pStatuses == NULL || pDeltas == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Find first received packet to use as reference time base
+    // Per TWCC spec, reference time should be based on arrival time of first packet in report
+    seqNum = baseSeqNum;
+    referenceTimeKvs = 0;
+    BOOL foundPacket = FALSE;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            referenceTimeKvs = pPacketInfo->arrivalTimeKvs;
+            foundPacket = TRUE;
+            break;
+        }
+        seqNum++;
+    }
+
+    // If no packets found, bail out
+    if (!foundPacket) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, retStatus);
+    }
+
+    // Calculate reference time in 64ms units (24-bit field) for the packet
+    // Convert from 100ns to ms, then divide by 64
+    currentTime = (UINT32) (referenceTimeKvs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    referenceTime24 = (currentTime / TWCC_REFERENCE_TIME_DIVISOR) & 0xFFFFFF;
+
+    // Deltas are incremental: delta[i] = arrival[i] - arrival[i-1]
+    // First delta uses 64ms-aligned reference (Chrome reconstructs: referenceTime24 * 64ms + delta * 0.25ms)
+    // Arrival times are relative to stream start, so values are small and won't overflow
+    UINT64 lastArrivalTimeKvs =
+        (UINT64) (currentTime / TWCC_REFERENCE_TIME_DIVISOR) * TWCC_REFERENCE_TIME_DIVISOR * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    DLOGD("TWCC ref: refTimeKvs=%llu currentTime=%u refTime24=%u lastArrival=%llu", (unsigned long long) referenceTimeKvs, currentTime,
+          referenceTime24, (unsigned long long) lastArrivalTimeKvs);
+    INT32 minDelta = INT32_MAX, maxDelta = INT32_MIN;
+    UINT32 receivedCount = 0, lostCount = 0;
+    seqNum = baseSeqNum;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            status = getTwccPacketStatus(pPacketInfo->arrivalTimeKvs, lastArrivalTimeKvs, &deltaTicks);
+            pStatuses[i] = status;
+            pDeltas[i] = deltaTicks;
+            if (status == TWCC_STATUS_SYMBOL_NOTRECEIVED) {
+                DLOGD("TWCC delta overflow: seq=%u i=%u delta=%d arrival=%llu la    stArrival=%llu", seqNum, i, deltaTicks,
+                      (unsigned long long) pPacketInfo->arrivalTimeKvs, (unsigned long long) lastArrivalTimeKvs);
+                lostCount++;
+            } else {
+                receivedCount++;
+                if (deltaTicks < minDelta)
+                    minDelta = deltaTicks;
+                if (deltaTicks > maxDelta)
+                    maxDelta = deltaTicks;
+            }
+            lastArrivalTimeKvs = pPacketInfo->arrivalTimeKvs; // Update for next packet's delta
+        } else {
+            pStatuses[i] = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+            pDeltas[i] = 0;
+            lostCount++;
+        }
+        seqNum++;
+    }
+    DLOGD("TWCC feedback: base=%u count=%u received=%u lost=%u minDelta=%d maxDelta=%d", baseSeqNum, packetStatusCount, receivedCount, lostCount,
+          minDelta, maxDelta);
+
+    // Calculate packet size:
+    // Header: 20 bytes (4 RTCP header + 4 sender SSRC + 4 media SSRC + 4 base seq + 4 ref time)
+    // Chunks: variable (2 bytes each, worst case is status vector with 7 packets = packetStatusCount/7 chunks)
+    // Deltas: variable (1 byte for small, 2 bytes for large)
+    // Add SRTP overhead
+    allocSize = 20; // Fixed header size
+
+    // Estimate chunk size (worst case: all status vectors with 7 packets each)
+    allocSize += ((packetStatusCount + 6) / 7) * 2;
+
+    // Estimate delta size (worst case: all large deltas)
+    for (i = 0; i < packetStatusCount; i++) {
+        if (pStatuses[i] == TWCC_STATUS_SYMBOL_SMALLDELTA) {
+            allocSize += 1;
+        } else if (pStatuses[i] == TWCC_STATUS_SYMBOL_LARGEDELTA) {
+            allocSize += 2;
+        }
+    }
+
+    // Pad to 32-bit boundary + SRTP overhead
+    allocSize = (allocSize + 3) & ~3;
+    allocSize += SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
+
+    pPacket = (PBYTE) MEMCALLOC(1, allocSize);
+    if (pPacket == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Get sender SSRC (use first transceiver's receive SSRC or generate one)
+    // For simplicity, we'll use a fixed SSRC derived from the connection
+    senderSsrc = (UINT32) ((UINT64) pKvsPeerConnection & 0xFFFFFFFF);
+
+    // Build RTCP TWCC Feedback packet
+    // Byte 0: V=2, P=0, FMT=15
+    pPacket[0] = (RTCP_PACKET_VERSION_VAL << 6) | RTCP_FEEDBACK_MESSAGE_TYPE_TWCC;
+    // Byte 1: PT=205 (Generic RTP Feedback)
+    pPacket[1] = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    // Bytes 2-3: Length (fill in later)
+    offset = 4;
+
+    // Bytes 4-7: Sender SSRC
+    putUnalignedInt32BigEndian(pPacket + offset, senderSsrc);
+    offset += 4;
+
+    // Bytes 8-11: Media source SSRC
+    putUnalignedInt32BigEndian(pPacket + offset, pManager->mediaSourceSsrc);
+    offset += 4;
+
+    // Bytes 12-13: Base sequence number
+    putUnalignedInt16BigEndian(pPacket + offset, baseSeqNum);
+    offset += 2;
+
+    // Bytes 14-15: Packet status count
+    putUnalignedInt16BigEndian(pPacket + offset, packetStatusCount);
+    offset += 2;
+
+    // Bytes 16-18: Reference time (24-bit)
+    pPacket[offset++] = (referenceTime24 >> 16) & 0xFF;
+    pPacket[offset++] = (referenceTime24 >> 8) & 0xFF;
+    pPacket[offset++] = referenceTime24 & 0xFF;
+
+    // Byte 19: Feedback packet count
+    pPacket[offset++] = pManager->feedbackPacketCount++;
+
+    // Build packet chunks using run-length encoding
+    chunkOffset = offset;
+    i = 0;
+    while (i < packetStatusCount) {
+        // Count run of same status
+        runStatus = pStatuses[i];
+        runLength = 1;
+        while (i + runLength < packetStatusCount && pStatuses[i + runLength] == runStatus && runLength < TWCC_MAX_PACKET_STATUS_COUNT) {
+            runLength++;
+        }
+
+        // Write run-length chunk
+        putUnalignedInt16BigEndian(pPacket + chunkOffset, TWCC_MAKE_RUNLEN(runStatus, runLength));
+        chunkOffset += 2;
+        i += runLength;
+    }
+
+    // Build receive deltas
+    deltaOffset = chunkOffset;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (pStatuses[i] == TWCC_STATUS_SYMBOL_SMALLDELTA) {
+            pPacket[deltaOffset++] = (UINT8) pDeltas[i];
+        } else if (pStatuses[i] == TWCC_STATUS_SYMBOL_LARGEDELTA) {
+            putUnalignedInt16BigEndian(pPacket + deltaOffset, (INT16) pDeltas[i]);
+            deltaOffset += 2;
+        }
+    }
+
+    // Pad to 32-bit boundary
+    while ((deltaOffset % 4) != 0) {
+        pPacket[deltaOffset++] = 0;
+    }
+
+    packetLen = deltaOffset;
+
+    // Fill in length field (length in 32-bit words minus 1)
+    putUnalignedInt16BigEndian(pPacket + 2, (packetLen / 4) - 1);
+
+    // Clear processed packets from hash table
+    seqNum = baseSeqNum;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            hashTableRemove(pManager->pReceivedPktsHashTable, seqNum);
+            MEMFREE(pPacketInfo);
+        }
+        seqNum++;
+    }
+
+    // Reset tracking for next feedback
+    pManager->firstPacketReceived = FALSE;
+    pManager->firstSeqNum = 0;
+    pManager->lastSeqNum = 0;
+
+    MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Encrypt and send
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    retStatus = encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, pPacket, (PINT32) &packetLen);
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    CHK_STATUS(retStatus);
+
+    CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pPacket, packetLen));
+
+CleanUp:
+    SAFE_MEMFREE(pPacket);
+    SAFE_MEMFREE(pStatuses);
+    SAFE_MEMFREE(pDeltas);
+    return retStatus;
+}
+
+STATUS twccFeedbackCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData)
+{
+    UNUSED_PARAM(timerId);
+    UNUSED_PARAM(currentTime);
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
+    UINT64 delay = 0;
+    BOOL srtpReady = FALSE;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    // Skip if SRTP not ready yet - must lock to avoid race with allocateSrtp
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    srtpReady = pKvsPeerConnection->pSrtpSession != NULL;
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+
+    if (srtpReady) {
+        // Send TWCC feedback (ignore errors - will try again next interval)
+        sendRtcpTwccFeedback(pKvsPeerConnection);
+    } else {
+        DLOGD("TWCC callback: SRTP not ready yet");
+    }
+
+    // Reschedule timer with jitter (80-120ms).
+    // Write to a local first, then copy under twccLock to avoid racing
+    // with closePeerConnection which reads twccFeedbackTimerId.
+    {
+        UINT32 newTimerId = MAX_UINT32;
+        delay = 80 + (RAND() % 40);
+        CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, delay * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                                      TIMER_QUEUE_SINGLE_INVOCATION_PERIOD, twccFeedbackCallback, (UINT64) pKvsPeerConnection, &newTimerId));
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        pKvsPeerConnection->twccFeedbackTimerId = newTimerId;
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    return retStatus;
+}

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -16,6 +16,13 @@ STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUIN
 STATUS sendRtcpPLI(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc);
 STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc, UINT8* pSeqNum);
 
+// TWCC feedback generation (receiver side)
+STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager);
+STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager);
+STATUS twccReceiverOnPacketReceived(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket);
+STATUS sendRtcpTwccFeedback(PKvsPeerConnection pKvsPeerConnection);
+STATUS twccFeedbackCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData);
+
 // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 // Deltas are represented as multiples of 250us:
 #define TWCC_TICKS_PER_SECOND        (1000000LL / 250)
@@ -45,6 +52,26 @@ typedef enum {
     (((packetChunk) >> (14u - (i) * TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
 #define TWCC_STATUSVECTOR_COUNT(packetChunk) (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 7 : 14)
 #define TWCC_PACKET_STATUS_COUNT(payload)    (getUnalignedInt16BigEndian((payload) + 10))
+
+// TWCC feedback generation constants
+#define TWCC_FEEDBACK_INITIAL_DELAY      (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define TWCC_FEEDBACK_INTERVAL_MS        100
+#define TWCC_RECEIVER_HASH_BUCKET_COUNT  100
+#define TWCC_RECEIVER_HASH_BUCKET_LENGTH 2
+#define TWCC_REFERENCE_TIME_DIVISOR      64     // 64ms granularity for reference time
+#define TWCC_MAX_PACKET_STATUS_COUNT     0x1FFF // Max run-length count (13 bits)
+
+// TWCC chunk encoding macros for feedback generation
+// Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
+#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) &0x1FFF)))
+// Status vector chunk (2-bit): bit 15 = 1, bit 14 = 1, bits 13-0 = 7 status symbols (2 bits each)
+#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) &0x3FFF)))
+// Status vector chunk (1-bit): bit 15 = 1, bit 14 = 0, bits 13-0 = 14 status symbols (1 bit each)
+#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) &0x3FFF)))
+
+// TWCC feedback packet type
+#define RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK 205
+#define RTCP_FEEDBACK_MESSAGE_TYPE_TWCC       15
 
 #ifdef __cplusplus
 }

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -63,11 +63,11 @@ typedef enum {
 
 // TWCC chunk encoding macros for feedback generation
 // Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
-#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) &0x1FFF)))
+#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) & 0x1FFF)))
 // Status vector chunk (2-bit): bit 15 = 1, bit 14 = 1, bits 13-0 = 7 status symbols (2 bits each)
-#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) &0x3FFF)))
+#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) & 0x3FFF)))
 // Status vector chunk (1-bit): bit 15 = 1, bit 14 = 0, bits 13-0 = 14 status symbols (1 bit each)
-#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) &0x3FFF)))
+#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) & 0x3FFF)))
 
 // TWCC feedback packet type
 #define RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK 205

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -901,6 +901,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                      SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " " TWCC_SDP_ATTR, payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb twcc could not be written");
         attributeCount++;
+
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
+        amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                                 SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
+                                 TWCC_EXT_URL);
+        CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
+        attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -1605,6 +1605,292 @@ TEST_F(PeerConnectionFunctionalityTest, firRequestTriggersKeyFrame)
     EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.firResponseFrameReceived)) << "Receiver should have received the I-frame sent in response to FIR";
 }
 
+// Test TWCC (Transport-Wide Congestion Control) feedback functionality
+// Sender sends video frames to receiver
+// Receiver generates TWCC feedback for incoming RTP packets
+// When sender receives TWCC feedback, RtcOnSenderBandwidthEstimation callback is fired
+TEST_F(PeerConnectionFunctionalityTest, twccFeedbackTriggersBandwidthEstimation)
+{
+    // Frame size for test frames
+    auto const frameBufferSize = 1200;
+
+    // Context structure for sharing state between callbacks
+    struct TwccTestContext {
+        ATOMIC_BOOL bandwidthEstimationReceived;
+        ATOMIC_BOOL frameReceived;
+        ATOMIC_BOOL testComplete;
+        SIZE_T callbackCount;
+        UINT32 totalTxBytes;
+        UINT32 totalRxBytes;
+        UINT32 totalTxPackets;
+        UINT32 totalRxPackets;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    TwccTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(TwccTestContext));
+
+    // Allocate frame buffer
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+    MEMSET(videoFrame.frameData, 0xAB, videoFrame.size);
+
+    // Initialize atomic flags
+    ATOMIC_STORE_BOOL(&context.bandwidthEstimationReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.frameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+    context.callbackCount = 0;
+
+    // Create peer connections
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Manually enable TWCC extension on both peers
+    // In real scenarios, this is negotiated via SDP when connecting to browsers
+    // For peer-to-peer testing between SDK instances, we need to set it manually
+    PKvsPeerConnection pOfferKvs = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pAnswerKvs = (PKvsPeerConnection) answerPc;
+    pOfferKvs->twccExtId = 1;  // Standard TWCC extension ID
+    pAnswerKvs->twccExtId = 1;
+
+    // Add video tracks to both peers (VP8 codec supports TWCC)
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    // Callback for when sender receives TWCC feedback and computes bandwidth estimation
+    auto onBandwidthEstimationHandler = [](UINT64 customData, UINT32 txBytes, UINT32 rxBytes,
+                                           UINT32 txPackets, UINT32 rxPackets, UINT64 duration) -> void {
+        UNUSED_PARAM(duration);
+        TwccTestContext* pContext = (TwccTestContext*) customData;
+
+        pContext->callbackCount++;
+        pContext->totalTxBytes += txBytes;
+        pContext->totalRxBytes += rxBytes;
+        pContext->totalTxPackets += txPackets;
+        pContext->totalRxPackets += rxPackets;
+
+        ATOMIC_STORE_BOOL(&pContext->bandwidthEstimationReceived, TRUE);
+        DLOGD("Bandwidth estimation callback: txBytes=%u rxBytes=%u txPackets=%u rxPackets=%u",
+              txBytes, rxBytes, txPackets, rxPackets);
+
+        // Mark test complete if we've received enough callbacks
+        if (pContext->callbackCount >= 2) {
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+        }
+    };
+
+    // Register bandwidth estimation callback on sender (offer peer)
+    EXPECT_EQ(peerConnectionOnSenderBandwidthEstimation(offerPc, (UINT64) &context, onBandwidthEstimationHandler), STATUS_SUCCESS);
+
+    // Callback for when receiver gets a frame
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        UNUSED_PARAM(pFrame);
+        TwccTestContext* pContext = (TwccTestContext*) customData;
+        ATOMIC_STORE_BOOL(&pContext->frameReceived, TRUE);
+    };
+
+    // Register frame callback on receiver's transceiver
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &context, onFrameHandler), STATUS_SUCCESS);
+
+    // Connect the two peers
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Verify TWCC extension ID is set
+    DLOGD("Offer TWCC ext ID: %u, Answer TWCC ext ID: %u", pOfferKvs->twccExtId, pAnswerKvs->twccExtId);
+
+    // Send video frames from offer to answer
+    // TWCC feedback is generated every ~100ms, so we need to send for a while
+    for (auto i = 0; i < 300 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        // Send video frame
+        videoFrame.flags = (i % 30 == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 30);  // 30 fps
+
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 33);  // ~30fps timing
+    }
+
+    // Cleanup
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify test succeeded
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.frameReceived)) << "Receiver should have received video frames";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.bandwidthEstimationReceived))
+        << "Sender should have received TWCC feedback and bandwidth estimation callback should have been fired";
+    EXPECT_GT(context.callbackCount, 0) << "Bandwidth estimation callback should have been called at least once";
+    EXPECT_GT(context.totalTxPackets, 0) << "Should have reported transmitted packets";
+    EXPECT_GT(context.totalRxPackets, 0) << "Should have reported received packets";
+
+    DLOGD("TWCC test completed: %zu callbacks, txPackets=%u rxPackets=%u",
+          context.callbackCount, context.totalTxPackets, context.totalRxPackets);
+}
+
+// Test TWCC feedback generation on the receiver side
+// This verifies the receiver correctly generates TWCC feedback packets
+// with proper incremental deltas (not absolute timestamps)
+// Bug history: Chrome reported 300kbps stable bitrate because:
+// 1. Delta calculation was absolute instead of incremental
+// 2. 24-bit reference time wraparound caused delta overflow
+// 3. First packet with relative time=0 was treated as "no packet found"
+TEST_F(PeerConnectionFunctionalityTest, twccReceiverGeneratesFeedback)
+{
+    auto const frameBufferSize = 1200;
+
+    struct TwccReceiverTestContext {
+        ATOMIC_BOOL feedbackSent;
+        SIZE_T feedbackCount;
+        ATOMIC_BOOL testComplete;
+        UINT32 totalTxPackets;
+        UINT32 totalRxPackets;
+        SIZE_T validDurationCount;
+        SIZE_T invalidDurationCount;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    TwccReceiverTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(TwccReceiverTestContext));
+
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+    MEMSET(videoFrame.frameData, 0xAB, videoFrame.size);
+
+    ATOMIC_STORE_BOOL(&context.feedbackSent, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+    context.feedbackCount = 0;
+    context.totalTxPackets = 0;
+    context.totalRxPackets = 0;
+    context.validDurationCount = 0;
+    context.invalidDurationCount = 0;
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Enable TWCC on both peers
+    PKvsPeerConnection pOfferKvs = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pAnswerKvs = (PKvsPeerConnection) answerPc;
+    pOfferKvs->twccExtId = 1;
+    pAnswerKvs->twccExtId = 1;
+
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    // Bandwidth estimation callback on SENDER (offer) proves receiver sent feedback
+    auto onBandwidthEstimationHandler = [](UINT64 customData, UINT32 txBytes, UINT32 rxBytes,
+                                           UINT32 txPackets, UINT32 rxPackets, UINT64 duration) -> void {
+        UNUSED_PARAM(txBytes);
+        UNUSED_PARAM(rxBytes);
+        TwccReceiverTestContext* pContext = (TwccReceiverTestContext*) customData;
+
+        pContext->feedbackCount++;
+        pContext->totalTxPackets += txPackets;
+        pContext->totalRxPackets += rxPackets;
+        ATOMIC_STORE_BOOL(&pContext->feedbackSent, TRUE);
+
+        // Verify we're getting reasonable packet counts (not zero due to delta overflow)
+        // This would fail with the old bugs where packets were marked as "lost"
+        EXPECT_GT(rxPackets, 0) << "rxPackets should be > 0 (not marked as lost due to delta overflow)";
+
+        // Verify duration is reasonable (not negative or huge due to delta overflow)
+        // Duration is in 100ns units, should be positive and less than 10 seconds for each feedback
+        INT64 signedDuration = (INT64) duration;
+        if (signedDuration >= 0 && signedDuration <= 10 * HUNDREDS_OF_NANOS_IN_A_SECOND) {
+            pContext->validDurationCount++;
+        } else {
+            pContext->invalidDurationCount++;
+            DLOGW("Invalid TWCC duration: %lld (possible delta overflow)", (long long) signedDuration);
+        }
+
+        // Verify receive ratio is reasonable (> 50% of packets should be marked received)
+        // With delta overflow bugs, most packets would be marked as "lost"
+        if (txPackets > 0) {
+            UINT32 receivePercent = (rxPackets * 100) / txPackets;
+            EXPECT_GE(receivePercent, 50) << "Receive ratio should be >= 50% (was " << receivePercent
+                                          << "%), low ratio indicates delta calculation bugs";
+        }
+
+        // After several feedbacks, mark complete
+        if (pContext->feedbackCount >= 3) {
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+        }
+    };
+
+    EXPECT_EQ(peerConnectionOnSenderBandwidthEstimation(offerPc, (UINT64) &context, onBandwidthEstimationHandler), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Verify TWCC receiver manager is initialized on answer peer
+    EXPECT_NE(pAnswerKvs->pTwccReceiverManager, nullptr) << "TWCC receiver manager should be initialized";
+
+    // Send frames - receiver (answer) should generate TWCC feedback
+    for (auto i = 0; i < 300 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        videoFrame.flags = (i % 30 == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 30);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 33);
+    }
+
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify receiver generated feedback
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.feedbackSent))
+        << "Receiver should have sent TWCC feedback";
+    EXPECT_GE(context.feedbackCount, 3)
+        << "Should have received multiple TWCC feedbacks";
+    EXPECT_GT(context.totalRxPackets, 0)
+        << "Should have reported received packets (not all marked lost due to delta bugs)";
+
+    // Verify duration checks actually ran and ALL passed
+    // Using total ensures we don't pass by doing nothing (0 == 0 would be meaningless)
+    SIZE_T totalDurationChecks = context.validDurationCount + context.invalidDurationCount;
+    EXPECT_GT(totalDurationChecks, 0)
+        << "Should have performed duration checks (test did nothing if 0)";
+    EXPECT_EQ(context.validDurationCount, totalDurationChecks)
+        << "All duration checks should pass (had " << context.invalidDurationCount
+        << " invalid out of " << totalDurationChecks << ", indicates delta overflow bugs)";
+
+    // Final receive ratio check - should be high if deltas are correct
+    EXPECT_GT(context.totalTxPackets, 0)
+        << "Should have transmitted packets";
+    if (context.totalTxPackets > 0) {
+        UINT32 overallReceivePercent = (context.totalRxPackets * 100) / context.totalTxPackets;
+        EXPECT_GE(overallReceivePercent, 80)
+            << "Overall receive ratio should be >= 80% (was " << overallReceivePercent
+            << "%), low ratio indicates TWCC delta calculation bugs";
+    }
+
+    DLOGD("TWCC receiver test completed: %zu feedbacks, txPackets=%u rxPackets=%u ratio=%u%% validDurations=%zu invalidDurations=%zu",
+          context.feedbackCount, context.totalTxPackets, context.totalRxPackets,
+          context.totalTxPackets > 0 ? (context.totalRxPackets * 100) / context.totalTxPackets : 0,
+          context.validDurationCount, context.invalidDurationCount);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -512,6 +512,251 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+//
+// TWCC Feedback Generation (Receiver Side) Tests
+//
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedBasic)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+    UINT64 packetInfoValue = 0;
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Verify receiver manager was created
+    EXPECT_NE(nullptr, pKvsPeerConnection->pTwccReceiverManager);
+
+    // Set up TWCC extension ID (simulating SDP negotiation)
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Create a mock RTP packet with TWCC extension
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.receivedTime = GETTIME();
+
+    // Create TWCC extension payload for sequence number 100
+    // Format: ID (4 bits) | Length-1 (4 bits) | SeqNum (16 bits) | Padding
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    // Track the packet
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Verify packet was tracked
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+    EXPECT_EQ(TRUE, pManager->firstPacketReceived);
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(100, pManager->lastSeqNum);
+    EXPECT_EQ(0x12345678, pManager->mediaSourceSsrc);
+
+    // Verify packet is in hash table
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGet(pManager->pReceivedPktsHashTable, 100, &packetInfoValue));
+    EXPECT_NE(0, packetInfoValue);
+
+    // Add another packet with sequence number 101
+    twccPayload = htonl((1 << 28) | (1 << 24) | (101 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Verify sequence tracking updated
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(101, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedOutOfOrder)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet 100 first
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(100, pManager->lastSeqNum);
+
+    // Add packet 102 (skip 101)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (102 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(102, pManager->lastSeqNum);
+
+    // Add packet 99 (out of order, before first)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (99 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(99, pManager->firstSeqNum);  // Updated to earlier packet
+    EXPECT_EQ(102, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedSeqNumWraparound)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet at UINT16_MAX - 1
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | ((UINT16_MAX - 1) << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(UINT16_MAX - 1, pManager->lastSeqNum);
+
+    // Add packet at UINT16_MAX
+    twccPayload = htonl((1 << 28) | (1 << 24) | (UINT16_MAX << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(UINT16_MAX, pManager->lastSeqNum);
+
+    // Add packet at 0 (wrapped around)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (0 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(0, pManager->lastSeqNum);  // Wrapped to 0
+
+    // Add packet at 1
+    twccPayload = htonl((1 << 28) | (1 << 24) | (1 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(1, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverDuplicatePacketHandling)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+    UINT32 itemCount = 0;
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet 100
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Get initial count
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGetCount(pManager->pReceivedPktsHashTable, &itemCount));
+    EXPECT_EQ(1, itemCount);
+
+    // Try to add duplicate packet 100 - should be silently ignored
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Count should still be 1
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGetCount(pManager->pReceivedPktsHashTable, &itemCount));
+    EXPECT_EQ(1, itemCount);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccMakeRunlenMacro)
+{
+    // Test run-length chunk creation macro
+    // Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
+
+    // Test with NOT_RECEIVED status (00), run length 10
+    UINT16 chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_NOTRECEIVED, 10);
+    EXPECT_EQ(0, (chunk >> 15) & 1);  // Bit 15 should be 0 for run-length
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_NOTRECEIVED, (chunk >> 13) & 3);
+    EXPECT_EQ(10, chunk & 0x1FFF);
+
+    // Test with SMALL_DELTA status (01), run length 100
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_SMALLDELTA, 100);
+    EXPECT_EQ(0, (chunk >> 15) & 1);
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_SMALLDELTA, (chunk >> 13) & 3);
+    EXPECT_EQ(100, chunk & 0x1FFF);
+
+    // Test with LARGE_DELTA status (10), run length 1000
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_LARGEDELTA, 1000);
+    EXPECT_EQ(0, (chunk >> 15) & 1);
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_LARGEDELTA, (chunk >> 13) & 3);
+    EXPECT_EQ(1000, chunk & 0x1FFF);
+
+    // Test max run length (0x1FFF = 8191)
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_SMALLDELTA, 0x1FFF);
+    EXPECT_EQ(0x1FFF, chunk & 0x1FFF);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Implemented receiver-side TWCC (Transport-Wide Congestion Control) feedback generation, allowing the receiving peer to send RTCP TWCC feedback packets back to the sender

*Why was it changed?*
- The SDK only had sender-side TWCC processing (parsing incoming feedback). Without receiver-side feedback generation, the remote sender could not perform bandwidth estimation when our peer is the receiver.

*How was it changed?*
- Added `TwccReceiverManager` struct and lifecycle (`createTwccReceiverManager`/`freeTwccReceiverManager`) for tracking received packets by TWCC sequence number
- Moved TWCC tracking before SRTP decryption in `sendPacketToRtpReceiver` so packets that fail replay checks are still counted
- Added `twccReceiverOnPacketReceived` to parse the TWCC extension from RTP headers and record arrival times
- Implemented `sendRtcpTwccFeedback` to build and send RFC 8888 TWCC feedback packets with run-length encoded status chunks and small/large deltas
- Added `twccFeedbackCallback` timer (started when remote SDP offers TWCC) that periodically generates and sends feedback
- Added `pSrtpSessionLock` mutex to protect SRTP session access during feedback sending
- Cancel TWCC feedback timer in `closePeerConnection` and `freePeerConnection` for clean shutdown (especially on Android where `THREAD_CANCEL` is a no-op)
- Added `TWCC_MAKE_RUNLEN` macro for constructing run-length status chunks

*What testing was done for the changes?*
- Added unit tests in `RtcpFunctionalityTest`: basic packet tracking, out-of-order reception, sequence number wraparound, duplicate handling, and `TWCC_MAKE_RUNLEN` macro verification
- Added end-to-end `twccReceiverFeedbackGeneration` test in `PeerConnectionFunctionalityTest` that sends 300 frames between peers and verifies the sender receives TWCC feedback with correct packet counts, receive ratios (>80%), and valid durations

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.