### PR TITLE
correct port reporting

### DIFF
--- a/src/source/Ice/IceUtils.c
+++ b/src/source/Ice/IceUtils.c
@@ -178,19 +178,19 @@ STATUS iceUtilsSendStunPacket(PStunPacket pStunPacket, PBYTE password, UINT32 pa
         case STUN_PACKET_TYPE_BINDING_REQUEST:
             if (pDest->family == KVS_IP_FAMILY_TYPE_IPV4) {
                 DLOGD("Sending BINDING_REQUEST on socket id: %d, to ip:%s, port:%u", pSocketConnection->localSocket, ipAddrStr,
-                      getInt16(pDest->port));
+                      (UINT16) getInt16(pDest->port));
             } else {
                 DLOGD("Sending BINDING_REQUEST on socket id: %d, to ip:%s, port:%u", pSocketConnection->localSocket, ipAddrStr,
-                      getInt16(pDest->port));
+                      (UINT16) getInt16(pDest->port));
             }
             break;
         case STUN_PACKET_TYPE_BINDING_RESPONSE_SUCCESS:
             if (pDest->family == KVS_IP_FAMILY_TYPE_IPV4) {
                 DLOGD("Sending BINDING_RESPONSE_SUCCESS on socket id: %d to ip:%s, port:%u", pSocketConnection->localSocket, ipAddrStr,
-                      getInt16(pDest->port));
+                      (UINT16) getInt16(pDest->port));
             } else {
                 DLOGD("Sending BINDING_RESPONSE_SUCCESS on socket id: %d to ip:%s, port:%u", pSocketConnection->localSocket, ipAddrStr,
-                      getInt16(pDest->port));
+                      (UINT16) getInt16(pDest->port));
             }
             break;
         default:


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Cast `getInt16(pDest->port)` to `UINT16` in STUN packet debug log messages in `iceUtilsSendStunPacket`

*Why was it changed?*
- `getInt16` returns a signed value, but the `%u` format specifier expects an unsigned value. Without the cast, ports with the high bit set (>32767) would be printed as large negative or garbage values in debug logs.

*How was it changed?*
- Added `(UINT16)` casts to the four `getInt16(pDest->port)` calls in the BINDING_REQUEST and BINDING_RESPONSE_SUCCESS log statements in IceUtils.c

*What testing was done for the changes?*
- Existing ICE tests continue to pass. Verified that port values now display correctly in debug log output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.