### PR TITLE
Add GCC (Google Congestion Control) with TWCC-based bandwidth estimation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -444,6 +444,7 @@ file(
   "src/source/PeerConnection/PeerConnection.c"
   "src/source/PeerConnection/Retransmitter.c"
   "src/source/PeerConnection/Rtcp.c"
+  "src/source/PeerConnection/Gcc.c"
   "src/source/PeerConnection/Rtp.c"
   "src/source/PeerConnection/SessionDescription.c"
   "src/source/Rtcp/*.c"
@@ -515,6 +516,10 @@ target_link_libraries(
           ${GPERFTOOLS_MALLOC_LIBRARIES}
           ${GPERFTOOLS_PROFILER_LIBRARIES}
           ${EXTRA_DEPS})
+
+if(NOT WIN32)
+  target_link_libraries(kvsWebrtcClient PRIVATE m)
+endif()
 
 if(ENABLE_SIGNALING)
 add_library(kvsWebrtcSignalingClient ${LINKAGE} ${WEBRTC_SIGNALING_CLIENT_SOURCE_FILES})

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Gcc.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Gcc.h
@@ -1,0 +1,94 @@
+/*
+ * GCC (Google Congestion Control) public include file
+ */
+#ifndef __KINESIS_VIDEO_WEBRTCCLIENT_GCC_INCLUDE__
+#define __KINESIS_VIDEO_WEBRTCCLIENT_GCC_INCLUDE__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief GCC Rate Controller States
+ */
+typedef enum {
+    GCC_STATE_HOLD,     //!< Wait for queues to stabilize
+    GCC_STATE_INCREASE, //!< Increase rate (no congestion detected)
+    GCC_STATE_DECREASE  //!< Decrease rate (congestion detected)
+} GccState;
+
+/**
+ * @brief Forward declaration - opaque pointer for external use
+ */
+typedef struct __GccController GccController;
+typedef GccController* PGccController;
+
+/**
+ * @brief GCC Configuration structure
+ */
+typedef struct {
+    UINT64 minBitrateBps;     //!< Minimum bitrate (default: 100 kbps)
+    UINT64 maxBitrateBps;     //!< Maximum bitrate (default: 2.5 Mbps)
+    UINT64 initialBitrateBps; //!< Initial bitrate (default: 300 kbps)
+} GccConfig, *PGccConfig;
+
+/**
+ * @brief Create a new GCC controller
+ *
+ * @param[out] ppController Pointer to receive the new controller
+ * @param[in] pConfig Optional configuration (NULL for defaults)
+ * @return STATUS code
+ */
+PUBLIC_API STATUS createGccController(PGccController* ppController, PGccConfig pConfig);
+
+/**
+ * @brief Free a GCC controller
+ *
+ * @param[in,out] ppController Pointer to controller to free
+ * @return STATUS code
+ */
+PUBLIC_API STATUS freeGccController(PGccController* ppController);
+
+/**
+ * @brief Process TWCC packet reports from the callback
+ *
+ * This is the main entry point - call this from your RtcOnTwccPacketReport callback
+ *
+ * @param[in] pController GCC controller
+ * @param[in] pReports Array of packet reports
+ * @param[in] reportCount Number of reports
+ * @param[in] rttEstimateKvs RTT estimate (0 if unknown)
+ * @return STATUS code
+ */
+PUBLIC_API STATUS gccOnTwccPacketReports(PGccController pController, PTwccPacketReport pReports, UINT32 reportCount, UINT64 rttEstimateKvs);
+
+/**
+ * @brief Get the current target bitrate
+ *
+ * @param[in] pController GCC controller
+ * @return Target bitrate in bits per second
+ */
+PUBLIC_API UINT64 gccGetTargetBitrate(PGccController pController);
+
+/**
+ * @brief Get the current GCC state for debugging
+ *
+ * @param[in] pController GCC controller
+ * @return Current state (GCC_STATE_HOLD, GCC_STATE_INCREASE, or GCC_STATE_DECREASE)
+ */
+PUBLIC_API GccState gccGetState(PGccController pController);
+
+/**
+ * @brief Get the current loss ratio
+ *
+ * @param[in] pController GCC controller
+ * @return Loss ratio (0.0 - 1.0)
+ */
+PUBLIC_API DOUBLE gccGetLossRatio(PGccController pController);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_WEBRTCCLIENT_GCC_INCLUDE__ */

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1046,6 +1046,35 @@ typedef VOID (*RtcOnBandwidthEstimation)(UINT64, DOUBLE);
 typedef VOID (*RtcOnSenderBandwidthEstimation)(UINT64, UINT32, UINT32, UINT32, UINT32, UINT64);
 
 /**
+ * @brief Per-packet report from TWCC feedback for congestion control algorithms.
+ *
+ * This structure provides detailed information about individual packets from
+ * TWCC (Transport-Wide Congestion Control) feedback. Applications can use this
+ * to implement congestion control algorithms like GCC (Google Congestion Control).
+ */
+typedef struct {
+    UINT16 seqNum;         //!< Transport-wide sequence number
+    UINT64 sendTimeKvs;    //!< Time packet was sent (100ns units from GETTIME())
+    UINT64 arrivalTimeKvs; //!< Time remote peer received packet (0 = lost/not received)
+    UINT32 packetSize;     //!< Packet size in bytes
+    BOOL received;         //!< TRUE if packet was received, FALSE if lost
+} TwccPacketReport, *PTwccPacketReport;
+
+/**
+ * @brief RtcOnTwccPacketReport is fired when TWCC feedback is received, providing
+ * per-packet arrival time and loss information for congestion control.
+ *
+ * Applications can implement GCC or other congestion control algorithms using
+ * this callback. The SDK also provides GccController as a reference implementation.
+ *
+ * @param[in] UINT64 User customData passed during registration
+ * @param[in] PTwccPacketReport Array of TwccPacketReport structures
+ * @param[in] UINT32 Number of reports in the array
+ * @param[in] UINT64 Estimated round-trip time in 100ns units (0 if unknown)
+ */
+typedef VOID (*RtcOnTwccPacketReport)(UINT64, PTwccPacketReport, UINT32, UINT64);
+
+/**
  * @brief RtcOnPictureLoss is fired everytime a Picture Loss Indication (PLI)
  * feedback message is received. Receiving such message normally indicates that
  * you sent a video frame which receiver could not decode.
@@ -1706,6 +1735,24 @@ PUBLIC_API STATUS peerConnectionOnIceCandidate(PRtcPeerConnection, UINT64, RtcOn
  * @return STATUS code of the execution. STATUS_SUCCESS on success
  */
 PUBLIC_API STATUS peerConnectionOnSenderBandwidthEstimation(PRtcPeerConnection, UINT64, RtcOnSenderBandwidthEstimation);
+
+/**
+ * @brief Set a callback for per-packet TWCC feedback data.
+ *
+ * This callback provides detailed per-packet arrival time and loss information
+ * from TWCC feedback. Applications can use this to implement congestion control
+ * algorithms like GCC (Google Congestion Control), SCReAM, or custom algorithms.
+ *
+ * The SDK provides GccController as a reference implementation that can be
+ * hooked to this callback.
+ *
+ * @param[in] PRtcPeerConnection Initialized RtcPeerConnection
+ * @param[in] UINT64 User customData that will be passed to the callback
+ * @param[in] RtcOnTwccPacketReport User callback for TWCC packet reports
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS peerConnectionOnTwccPacketReport(PRtcPeerConnection, UINT64, RtcOnTwccPacketReport);
 
 /**
  * Set a callback for data channel

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -177,7 +177,6 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "PeerConnection/Rtp.h"
 #include "PeerConnection/Rtcp.h"
 #include "PeerConnection/Gcc_i.h"
-#include "PeerConnection/Pacer.h"
 #include "PeerConnection/DataChannel.h"
 #include "Rtp/Codecs/RtpVP8Payloader.h"
 #include "Rtp/Codecs/RtpH264Payloader.h"

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -176,6 +176,8 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "PeerConnection/SessionDescription.h"
 #include "PeerConnection/Rtp.h"
 #include "PeerConnection/Rtcp.h"
+#include "PeerConnection/Gcc_i.h"
+#include "PeerConnection/Pacer.h"
 #include "PeerConnection/DataChannel.h"
 #include "Rtp/Codecs/RtpVP8Payloader.h"
 #include "Rtp/Codecs/RtpH264Payloader.h"

--- a/src/source/PeerConnection/Gcc.c
+++ b/src/source/PeerConnection/Gcc.c
@@ -1,0 +1,606 @@
+/*******************************************
+GCC (Google Congestion Control) Implementation
+Based on draft-ietf-rmcat-gcc-02
+*******************************************/
+
+#define LOG_CLASS "Gcc"
+#include "../Include_i.h"
+
+//
+// Kalman Filter Implementation (RFC Section 5.3)
+//
+
+STATUS gccKalmanInit(PGccKalmanState pKalman)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pKalman != NULL, STATUS_NULL_ARG);
+
+    pKalman->m_hat = 0.0;
+    pKalman->e = GCC_INITIAL_ERROR_COV;
+    pKalman->var_v_hat = 1.0; // Initial variance estimate
+    pKalman->q = GCC_STATE_NOISE_COV;
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS gccKalmanUpdate(PGccKalmanState pKalman, DOUBLE d_i)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    DOUBLE z, z_clamped, threshold, k, alpha;
+
+    CHK(pKalman != NULL, STATUS_NULL_ARG);
+
+    // Innovation: z(i) = d(i) - m_hat(i-1)
+    z = d_i - pKalman->m_hat;
+
+    // Outlier filtering for variance estimate
+    // If z(i) > 3*sqrt(var_v_hat), clamp it
+    threshold = 3.0 * sqrt(pKalman->var_v_hat);
+    z_clamped = z;
+    if (fabs(z) > threshold) {
+        z_clamped = (z > 0) ? threshold : -threshold;
+    }
+
+    // Update variance estimate using exponential moving average
+    // alpha = (1 - chi)^(30 / (1000 * f_max))
+    // For typical 30fps video, alpha ≈ 0.9999
+    alpha = GCC_ALPHA_EMA;
+    pKalman->var_v_hat = MAX(alpha * pKalman->var_v_hat + (1.0 - alpha) * z_clamped * z_clamped, 1.0);
+
+    // Kalman gain: k(i) = (e(i-1) + q) / (var_v_hat + e(i-1) + q)
+    k = (pKalman->e + pKalman->q) / (pKalman->var_v_hat + pKalman->e + pKalman->q);
+
+    // State update: m_hat(i) = m_hat(i-1) + z(i) * k(i)
+    pKalman->m_hat = pKalman->m_hat + z * k;
+
+    // Error covariance update: e(i) = (1 - k(i)) * (e(i-1) + q)
+    pKalman->e = (1.0 - k) * (pKalman->e + pKalman->q);
+
+CleanUp:
+    return retStatus;
+}
+
+//
+// Over-use Detector Implementation (RFC Section 5.4)
+//
+
+STATUS gccOveruseDetectorInit(PGccOveruseDetector pOveruse)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pOveruse != NULL, STATUS_NULL_ARG);
+
+    pOveruse->del_var_th = GCC_INITIAL_THRESHOLD_MS;
+    pOveruse->overuseStartTimeKvs = 0;
+    pOveruse->prevM_hat = 0.0;
+
+CleanUp:
+    return retStatus;
+}
+
+GccSignal gccDetectOveruse(PGccOveruseDetector pOveruse, DOUBLE m_hat, UINT64 dtKvs)
+{
+    GccSignal signal = GCC_SIGNAL_NORMAL;
+    DOUBLE dt, K, absDiff;
+
+    if (pOveruse == NULL) {
+        return GCC_SIGNAL_NORMAL;
+    }
+
+    // Convert time delta to seconds
+    dt = (DOUBLE) dtKvs / HUNDREDS_OF_NANOS_IN_A_SECOND;
+
+    // Update adaptive threshold (RFC Section 5.4)
+    // del_var_th(i) = del_var_th(i-1) + dt * K * (|m(i)| - del_var_th(i-1))
+    K = (fabs(m_hat) < pOveruse->del_var_th) ? GCC_K_D : GCC_K_U;
+
+    // Don't update if too far from threshold
+    absDiff = fabs(m_hat) - pOveruse->del_var_th;
+    if (absDiff <= GCC_THRESHOLD_UPDATE_LIMIT) {
+        pOveruse->del_var_th = pOveruse->del_var_th + dt * K * (fabs(m_hat) - pOveruse->del_var_th);
+        // Clamp threshold to valid range
+        pOveruse->del_var_th = MAX(pOveruse->del_var_th, GCC_THRESHOLD_MIN_MS);
+        pOveruse->del_var_th = MIN(pOveruse->del_var_th, GCC_THRESHOLD_MAX_MS);
+    }
+
+    // Detect over-use: m_hat > del_var_th for overuse_time_th
+    if (m_hat > pOveruse->del_var_th) {
+        if (pOveruse->overuseStartTimeKvs == 0) {
+            pOveruse->overuseStartTimeKvs = GETTIME();
+        } else {
+            // Check if overuse has persisted for overuse_time_th
+            UINT64 now = GETTIME();
+            if ((now - pOveruse->overuseStartTimeKvs) >= GCC_MS_TO_KVS(GCC_OVERUSE_TIME_TH_MS)) {
+                // But not if trend is decreasing (RFC: "if m(i) < m(i-1), over-use will not be signaled")
+                if (m_hat >= pOveruse->prevM_hat) {
+                    signal = GCC_SIGNAL_OVERUSE;
+                }
+            }
+        }
+    } else {
+        pOveruse->overuseStartTimeKvs = 0;
+    }
+
+    // Detect under-use: m_hat < -del_var_th
+    if (m_hat < -pOveruse->del_var_th) {
+        signal = GCC_SIGNAL_UNDERUSE;
+    }
+
+    pOveruse->prevM_hat = m_hat;
+    return signal;
+}
+
+//
+// Rate Controller Implementation (RFC Section 5.5 and 6)
+//
+
+STATUS gccRateControllerInit(PGccRateController pRateCtrl, UINT64 initialBitrate)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pRateCtrl != NULL, STATUS_NULL_ARG);
+
+    pRateCtrl->state = GCC_STATE_INCREASE;
+    pRateCtrl->A_hat = initialBitrate;
+    pRateCtrl->As_hat = initialBitrate;
+    pRateCtrl->targetBitrate = initialBitrate;
+    pRateCtrl->lastUpdateTimeKvs = GETTIME();
+    pRateCtrl->avgMaxBitrate = 0.0;
+    pRateCtrl->varMaxBitrate = 0.0;
+    pRateCtrl->nearConvergence = FALSE;
+    pRateCtrl->rttEstimateKvs = GCC_MS_TO_KVS(100); // Default 100ms RTT
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS gccUpdateDelayController(PGccRateController pRateCtrl, GccSignal signal, UINT64 dtKvs, UINT64 incomingBitrate, UINT64 minBitrate,
+                                UINT64 maxBitrate)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    DOUBLE timeSinceLastUpdateSec, eta, responseTimeMs, alpha;
+    UINT64 rttMs, bitsPerFrame, packetsPerFrame, avgPacketSizeBits;
+
+    CHK(pRateCtrl != NULL, STATUS_NULL_ARG);
+
+    timeSinceLastUpdateSec = (DOUBLE) dtKvs / HUNDREDS_OF_NANOS_IN_A_SECOND;
+
+    // State transitions (RFC Section 5.5 table)
+    switch (pRateCtrl->state) {
+        case GCC_STATE_HOLD:
+            if (signal == GCC_SIGNAL_OVERUSE) {
+                pRateCtrl->state = GCC_STATE_DECREASE;
+            } else if (signal == GCC_SIGNAL_NORMAL) {
+                pRateCtrl->state = GCC_STATE_INCREASE;
+            }
+            break;
+        case GCC_STATE_INCREASE:
+            if (signal == GCC_SIGNAL_OVERUSE) {
+                pRateCtrl->state = GCC_STATE_DECREASE;
+            } else if (signal == GCC_SIGNAL_UNDERUSE) {
+                pRateCtrl->state = GCC_STATE_HOLD;
+            }
+            break;
+        case GCC_STATE_DECREASE:
+            if (signal == GCC_SIGNAL_NORMAL) {
+                pRateCtrl->state = GCC_STATE_HOLD;
+            } else if (signal == GCC_SIGNAL_UNDERUSE) {
+                pRateCtrl->state = GCC_STATE_HOLD;
+            }
+            break;
+    }
+
+    // Rate adjustment based on state
+    switch (pRateCtrl->state) {
+        case GCC_STATE_INCREASE:
+            // Check if we're near convergence
+            if (pRateCtrl->avgMaxBitrate > 0.0) {
+                // Within 3 standard deviations of avg max bitrate
+                DOUBLE stdDev = sqrt(pRateCtrl->varMaxBitrate);
+                if (incomingBitrate > pRateCtrl->avgMaxBitrate + 3.0 * stdDev) {
+                    // Congestion level changed, reset
+                    pRateCtrl->avgMaxBitrate = 0.0;
+                    pRateCtrl->varMaxBitrate = 0.0;
+                    pRateCtrl->nearConvergence = FALSE;
+                } else if (fabs((DOUBLE) incomingBitrate - pRateCtrl->avgMaxBitrate) < 3.0 * stdDev) {
+                    pRateCtrl->nearConvergence = TRUE;
+                }
+            }
+
+            if (pRateCtrl->nearConvergence) {
+                // Additive increase: half a packet per response_time interval
+                // response_time_ms = 100 + rtt_ms
+                rttMs = pRateCtrl->rttEstimateKvs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+                responseTimeMs = 100.0 + (DOUBLE) rttMs;
+                alpha = 0.5 * MIN(timeSinceLastUpdateSec * 1000.0 / responseTimeMs, 1.0);
+
+                // expected_packet_size_bits calculation (assuming 30fps)
+                bitsPerFrame = pRateCtrl->A_hat / 30;
+                packetsPerFrame = (bitsPerFrame / (1200 * 8)) + 1;
+                avgPacketSizeBits = bitsPerFrame / packetsPerFrame;
+
+                pRateCtrl->A_hat += (UINT64) MAX(1000, alpha * avgPacketSizeBits);
+            } else {
+                // Multiplicative increase: at most 8% per second
+                eta = pow(GCC_ETA_MULTIPLICATIVE, MIN(timeSinceLastUpdateSec, 1.0));
+                pRateCtrl->A_hat = (UINT64) (eta * pRateCtrl->A_hat);
+            }
+
+            // Don't let estimate diverge too far from actual sending rate
+            // A_hat(i) < 1.5 * R_hat(i)
+            if (incomingBitrate > 0 && pRateCtrl->A_hat > (UINT64) (1.5 * incomingBitrate)) {
+                pRateCtrl->A_hat = (UINT64) (1.5 * incomingBitrate);
+            }
+            break;
+
+        case GCC_STATE_DECREASE:
+            // Decrease to beta times the incoming rate
+            if (incomingBitrate > 0) {
+                pRateCtrl->A_hat = (UINT64) (GCC_BETA * incomingBitrate);
+            } else {
+                pRateCtrl->A_hat = (UINT64) (GCC_BETA * pRateCtrl->A_hat);
+            }
+
+            // Update convergence tracking
+            if (pRateCtrl->avgMaxBitrate == 0.0) {
+                pRateCtrl->avgMaxBitrate = (DOUBLE) pRateCtrl->A_hat;
+                pRateCtrl->varMaxBitrate = 0.0;
+            } else {
+                // EMA update
+                DOUBLE diff = (DOUBLE) pRateCtrl->A_hat - pRateCtrl->avgMaxBitrate;
+                pRateCtrl->avgMaxBitrate =
+                    GCC_CONVERGENCE_SMOOTHING * pRateCtrl->avgMaxBitrate + (1.0 - GCC_CONVERGENCE_SMOOTHING) * pRateCtrl->A_hat;
+                pRateCtrl->varMaxBitrate = GCC_CONVERGENCE_SMOOTHING * pRateCtrl->varMaxBitrate + (1.0 - GCC_CONVERGENCE_SMOOTHING) * diff * diff;
+            }
+            break;
+
+        case GCC_STATE_HOLD:
+            // Keep rate steady
+            break;
+    }
+
+    // Clamp to bounds
+    pRateCtrl->A_hat = MAX(pRateCtrl->A_hat, minBitrate);
+    pRateCtrl->A_hat = MIN(pRateCtrl->A_hat, maxBitrate);
+
+    // Update target bitrate (minimum of delay-based and loss-based)
+    pRateCtrl->targetBitrate = MIN(pRateCtrl->A_hat, pRateCtrl->As_hat);
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS gccUpdateLossController(PGccRateController pRateCtrl, DOUBLE lossRatio, UINT64 minBitrate, UINT64 maxBitrate)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+
+    CHK(pRateCtrl != NULL, STATUS_NULL_ARG);
+
+    // RFC Section 6: Loss-based control
+    if (lossRatio > GCC_LOSS_THRESHOLD_HIGH) {
+        // More than 10% loss: reduce by half the loss ratio
+        pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * (1.0 - 0.5 * lossRatio));
+    } else if (lossRatio > GCC_LOSS_THRESHOLD_LOW) {
+        // 2-10% loss: hold steady
+        // As_hat unchanged
+    } else {
+        // Less than 2% loss: increase by 5%
+        pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * 1.05);
+    }
+
+    // Clamp to bounds
+    pRateCtrl->As_hat = MAX(pRateCtrl->As_hat, minBitrate);
+    pRateCtrl->As_hat = MIN(pRateCtrl->As_hat, maxBitrate);
+
+    // Update target bitrate
+    pRateCtrl->targetBitrate = MIN(pRateCtrl->A_hat, pRateCtrl->As_hat);
+
+CleanUp:
+    return retStatus;
+}
+
+//
+// Packet Grouping / Pre-filtering (RFC Section 5.2)
+//
+
+STATUS gccProcessPacket(PGccController pController, UINT64 sendTimeKvs, UINT64 arrivalTimeKvs, UINT32 packetSize, UINT16 seqNum)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 interArrivalKvs;
+
+    CHK(pController != NULL, STATUS_NULL_ARG);
+    CHK(arrivalTimeKvs != 0 && arrivalTimeKvs != TWCC_PACKET_LOST_TIME, STATUS_SUCCESS); // Skip lost packets
+
+    if (pController->currentGroup.packetCount == 0) {
+        // First packet in group
+        pController->currentGroup.departureTimeKvs = sendTimeKvs;
+        pController->currentGroup.arrivalTimeKvs = arrivalTimeKvs;
+        pController->currentGroup.totalBytes = packetSize;
+        pController->currentGroup.firstSeqNum = seqNum;
+        pController->currentGroup.packetCount = 1;
+    } else {
+        // Check if this packet belongs to the current group
+        // Condition 1: packets sent within burst_time interval
+        // Condition 2: inter-arrival time < burst_time AND d(i) < 0
+        BOOL sameGroup = FALSE;
+
+        if (sendTimeKvs <= pController->currentGroup.departureTimeKvs + GCC_MS_TO_KVS(GCC_BURST_TIME_MS)) {
+            // Sent within burst_time of the group
+            sameGroup = TRUE;
+        } else {
+            // Check if inter-arrival time < burst_time and d(i) < 0
+            interArrivalKvs = arrivalTimeKvs - pController->currentGroup.arrivalTimeKvs;
+            if (interArrivalKvs < GCC_MS_TO_KVS(GCC_BURST_TIME_MS)) {
+                // Calculate instantaneous delay variation
+                INT64 interDepartureKvs = (INT64) sendTimeKvs - (INT64) pController->currentGroup.departureTimeKvs;
+                INT64 d_instant = (INT64) interArrivalKvs - interDepartureKvs;
+                if (d_instant < 0) {
+                    sameGroup = TRUE;
+                }
+            }
+        }
+
+        if (sameGroup) {
+            // Add to current group
+            pController->currentGroup.departureTimeKvs = sendTimeKvs;
+            pController->currentGroup.arrivalTimeKvs = arrivalTimeKvs;
+            pController->currentGroup.totalBytes += packetSize;
+            pController->currentGroup.packetCount++;
+        } else {
+            // Finalize current group and start a new one
+            pController->prevGroup = pController->currentGroup;
+            pController->hasPrevGroup = TRUE;
+
+            pController->currentGroup.departureTimeKvs = sendTimeKvs;
+            pController->currentGroup.arrivalTimeKvs = arrivalTimeKvs;
+            pController->currentGroup.totalBytes = packetSize;
+            pController->currentGroup.firstSeqNum = seqNum;
+            pController->currentGroup.packetCount = 1;
+        }
+    }
+
+CleanUp:
+    return retStatus;
+}
+
+BOOL gccFinalizeGroup(PGccController pController, DOUBLE* pD_i)
+{
+    INT64 interArrivalKvs, interDepartureKvs;
+
+    if (pController == NULL || pD_i == NULL) {
+        return FALSE;
+    }
+
+    if (!pController->hasPrevGroup || pController->currentGroup.packetCount == 0) {
+        return FALSE;
+    }
+
+    // Calculate inter-group delay variation (RFC Section 5.1)
+    // d(i) = t(i) - t(i-1) - (T(i) - T(i-1))
+    interArrivalKvs = (INT64) pController->currentGroup.arrivalTimeKvs - (INT64) pController->prevGroup.arrivalTimeKvs;
+    interDepartureKvs = (INT64) pController->currentGroup.departureTimeKvs - (INT64) pController->prevGroup.departureTimeKvs;
+
+    // Convert to milliseconds
+    *pD_i = GCC_KVS_TO_MS(interArrivalKvs - interDepartureKvs);
+
+    // Prepare for next group
+    pController->prevGroup = pController->currentGroup;
+    MEMSET(&pController->currentGroup, 0, SIZEOF(GccPacketGroup));
+
+    return TRUE;
+}
+
+//
+// Public API Implementation
+//
+
+STATUS createGccController(PGccController* ppController, PGccConfig pConfig)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PGccController pController = NULL;
+
+    CHK(ppController != NULL, STATUS_NULL_ARG);
+
+    pController = (PGccController) MEMCALLOC(1, SIZEOF(GccController));
+    CHK(pController != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pController->lock = MUTEX_CREATE(FALSE);
+    CHK(IS_VALID_MUTEX_VALUE(pController->lock), STATUS_INVALID_OPERATION);
+
+    // Set configuration
+    if (pConfig != NULL) {
+        pController->minBitrate = pConfig->minBitrateBps > 0 ? pConfig->minBitrateBps : GCC_DEFAULT_MIN_BITRATE;
+        pController->maxBitrate = pConfig->maxBitrateBps > 0 ? pConfig->maxBitrateBps : GCC_DEFAULT_MAX_BITRATE;
+        pController->initialBitrate = pConfig->initialBitrateBps > 0 ? pConfig->initialBitrateBps : GCC_DEFAULT_INITIAL_BITRATE;
+    } else {
+        pController->minBitrate = GCC_DEFAULT_MIN_BITRATE;
+        pController->maxBitrate = GCC_DEFAULT_MAX_BITRATE;
+        pController->initialBitrate = GCC_DEFAULT_INITIAL_BITRATE;
+    }
+
+    // Initialize sub-components
+    CHK_STATUS(gccKalmanInit(&pController->kalman));
+    CHK_STATUS(gccOveruseDetectorInit(&pController->overuse));
+    CHK_STATUS(gccRateControllerInit(&pController->rateCtrl, pController->initialBitrate));
+
+    // Initialize packet group tracking
+    MEMSET(&pController->currentGroup, 0, SIZEOF(GccPacketGroup));
+    MEMSET(&pController->prevGroup, 0, SIZEOF(GccPacketGroup));
+    pController->hasPrevGroup = FALSE;
+
+    *ppController = pController;
+    pController = NULL;
+
+CleanUp:
+    if (pController != NULL) {
+        freeGccController(&pController);
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+STATUS freeGccController(PGccController* ppController)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PGccController pController = NULL;
+
+    CHK(ppController != NULL, STATUS_NULL_ARG);
+    pController = *ppController;
+    CHK(pController != NULL, retStatus);
+
+    if (IS_VALID_MUTEX_VALUE(pController->lock)) {
+        MUTEX_FREE(pController->lock);
+    }
+
+    SAFE_MEMFREE(pController);
+    *ppController = NULL;
+
+CleanUp:
+    LEAVES();
+    return retStatus;
+}
+
+STATUS gccOnTwccPacketReports(PGccController pController, PTwccPacketReport pReports, UINT32 reportCount, UINT64 rttEstimateKvs)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL locked = FALSE;
+    UINT32 i;
+    UINT64 receivedCount = 0, lostCount = 0;
+    UINT64 totalBytes = 0, receivedBytes = 0;
+    DOUBLE d_i = 0.0;
+    GccSignal signal;
+    UINT64 now, dtKvs;
+    UINT64 incomingBitrate = 0;
+    UINT64 duration = 0;
+
+    CHK(pController != NULL && pReports != NULL && reportCount > 0, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pController->lock);
+    locked = TRUE;
+
+    now = GETTIME();
+    dtKvs = now - pController->rateCtrl.lastUpdateTimeKvs;
+    pController->rateCtrl.lastUpdateTimeKvs = now;
+
+    // Update RTT estimate if provided
+    if (rttEstimateKvs > 0) {
+        pController->rateCtrl.rttEstimateKvs = rttEstimateKvs;
+        pController->lastRttKvs = rttEstimateKvs;
+    }
+
+    // Process all packets through the pre-filter/grouping
+    for (i = 0; i < reportCount; i++) {
+        totalBytes += pReports[i].packetSize;
+        pController->totalPacketsSent++;
+
+        if (pReports[i].received) {
+            receivedCount++;
+            receivedBytes += pReports[i].packetSize;
+
+            // Process packet for grouping
+            gccProcessPacket(pController, pReports[i].sendTimeKvs, pReports[i].arrivalTimeKvs, pReports[i].packetSize, pReports[i].seqNum);
+        } else {
+            lostCount++;
+            pController->totalPacketsLost++;
+        }
+    }
+
+    // Update loss ratio
+    if (receivedCount + lostCount > 0) {
+        pController->currentLossRatio = (DOUBLE) lostCount / (DOUBLE) (receivedCount + lostCount);
+    }
+
+    // Calculate incoming bitrate from received packets
+    // Find duration from first to last received packet
+    UINT64 firstSendTime = 0, lastSendTime = 0;
+    for (i = 0; i < reportCount; i++) {
+        if (pReports[i].received) {
+            if (firstSendTime == 0 || pReports[i].sendTimeKvs < firstSendTime) {
+                firstSendTime = pReports[i].sendTimeKvs;
+            }
+            if (pReports[i].sendTimeKvs > lastSendTime) {
+                lastSendTime = pReports[i].sendTimeKvs;
+            }
+        }
+    }
+    if (lastSendTime > firstSendTime) {
+        duration = lastSendTime - firstSendTime;
+        // Convert to bps: bytes * 8 / seconds
+        incomingBitrate = (UINT64) ((DOUBLE) receivedBytes * 8.0 * HUNDREDS_OF_NANOS_IN_A_SECOND / (DOUBLE) duration);
+    }
+
+    // Finalize current group and get inter-group delay variation
+    while (gccFinalizeGroup(pController, &d_i)) {
+        // Update Kalman filter with the inter-group delay variation
+        CHK_STATUS(gccKalmanUpdate(&pController->kalman, d_i));
+
+        // Run over-use detector
+        signal = gccDetectOveruse(&pController->overuse, pController->kalman.m_hat, dtKvs);
+
+        // Update delay-based controller
+        CHK_STATUS(
+            gccUpdateDelayController(&pController->rateCtrl, signal, dtKvs, incomingBitrate, pController->minBitrate, pController->maxBitrate));
+    }
+
+    // Update loss-based controller
+    CHK_STATUS(gccUpdateLossController(&pController->rateCtrl, pController->currentLossRatio, pController->minBitrate, pController->maxBitrate));
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pController->lock);
+    }
+
+    LEAVES();
+    return retStatus;
+}
+
+UINT64 gccGetTargetBitrate(PGccController pController)
+{
+    UINT64 targetBitrate = 0;
+
+    if (pController == NULL) {
+        return 0;
+    }
+
+    MUTEX_LOCK(pController->lock);
+    targetBitrate = pController->rateCtrl.targetBitrate;
+    MUTEX_UNLOCK(pController->lock);
+
+    return targetBitrate;
+}
+
+GccState gccGetState(PGccController pController)
+{
+    GccState state = GCC_STATE_HOLD;
+
+    if (pController == NULL) {
+        return GCC_STATE_HOLD;
+    }
+
+    MUTEX_LOCK(pController->lock);
+    state = pController->rateCtrl.state;
+    MUTEX_UNLOCK(pController->lock);
+
+    return state;
+}
+
+DOUBLE gccGetLossRatio(PGccController pController)
+{
+    DOUBLE lossRatio = 0.0;
+
+    if (pController == NULL) {
+        return 0.0;
+    }
+
+    MUTEX_LOCK(pController->lock);
+    lossRatio = pController->currentLossRatio;
+    MUTEX_UNLOCK(pController->lock);
+
+    return lossRatio;
+}

--- a/src/source/PeerConnection/Gcc_i.h
+++ b/src/source/PeerConnection/Gcc_i.h
@@ -39,7 +39,7 @@ extern "C" {
 #define GCC_DEFAULT_INITIAL_BITRATE 300000  // 300 kbps
 
 // Convert ms to 100ns units (KVS time format)
-#define GCC_MS_TO_KVS(ms)  ((UINT64) (ms) *HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define GCC_MS_TO_KVS(ms)  ((UINT64) (ms) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 #define GCC_KVS_TO_MS(kvs) ((DOUBLE) (kvs) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
 
 /**

--- a/src/source/PeerConnection/Gcc_i.h
+++ b/src/source/PeerConnection/Gcc_i.h
@@ -1,0 +1,220 @@
+/*******************************************
+GCC (Google Congestion Control) Internal Implementation
+Based on draft-ietf-rmcat-gcc-02
+*******************************************/
+#ifndef __KINESIS_VIDEO_WEBRTC_CLIENT_PEERCONNECTION_GCC_I__
+#define __KINESIS_VIDEO_WEBRTC_CLIENT_PEERCONNECTION_GCC_I__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Public API types (GccState, GccConfig, GccController typedef)
+// GCC is experimental and not included in Include.h by default
+#include <com/amazonaws/kinesis/video/webrtcclient/Gcc.h>
+
+// GCC Parameters from RFC (Section 5.6)
+#define GCC_BURST_TIME_MS          5       // Time limit for packet grouping (ms)
+#define GCC_STATE_NOISE_COV        0.001   // q - State noise covariance
+#define GCC_INITIAL_ERROR_COV      0.1     // e(0) - Initial system error covariance
+#define GCC_INITIAL_THRESHOLD_MS   12.5    // del_var_th(0) - Initial adaptive threshold (ms)
+#define GCC_OVERUSE_TIME_TH_MS     10      // Time to trigger over-use signal (ms)
+#define GCC_K_U                    0.01    // Threshold increase coefficient
+#define GCC_K_D                    0.00018 // Threshold decrease coefficient
+#define GCC_BETA                   0.85    // Decrease rate factor
+#define GCC_ALPHA_EMA              0.9999  // Exponential moving average coefficient for variance
+#define GCC_THRESHOLD_MIN_MS       6.0     // Minimum threshold value (ms)
+#define GCC_THRESHOLD_MAX_MS       600.0   // Maximum threshold value (ms)
+#define GCC_THRESHOLD_UPDATE_LIMIT 15.0    // Don't update threshold if too far (ms)
+#define GCC_ETA_MULTIPLICATIVE     1.08    // Multiplicative increase per second (8%)
+#define GCC_CONVERGENCE_SMOOTHING  0.95    // Smoothing factor for convergence tracking
+#define GCC_LOSS_THRESHOLD_LOW     0.02    // 2% loss threshold
+#define GCC_LOSS_THRESHOLD_HIGH    0.10    // 10% loss threshold
+
+// Default bitrate bounds
+#define GCC_DEFAULT_MIN_BITRATE     100000  // 100 kbps
+#define GCC_DEFAULT_MAX_BITRATE     2500000 // 2.5 Mbps
+#define GCC_DEFAULT_INITIAL_BITRATE 300000  // 300 kbps
+
+// Convert ms to 100ns units (KVS time format)
+#define GCC_MS_TO_KVS(ms)  ((UINT64) (ms) *HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define GCC_KVS_TO_MS(kvs) ((DOUBLE) (kvs) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+
+/**
+ * GCC Over-use Signal (internal)
+ */
+typedef enum {
+    GCC_SIGNAL_NORMAL,  //!< No congestion detected
+    GCC_SIGNAL_OVERUSE, //!< Congestion detected (queue building)
+    GCC_SIGNAL_UNDERUSE //!< Under-use detected (queue draining)
+} GccSignal;
+
+/**
+ * Packet group for pre-filtering (RFC Section 5.2)
+ * Packets within GCC_BURST_TIME_MS are grouped together
+ */
+typedef struct {
+    UINT64 departureTimeKvs; //!< Send time of last packet in group
+    UINT64 arrivalTimeKvs;   //!< Arrival time of last packet in group
+    UINT32 totalBytes;       //!< Total bytes in group
+    UINT16 firstSeqNum;      //!< First sequence number in group
+    UINT16 packetCount;      //!< Number of packets in group
+} GccPacketGroup, *PGccPacketGroup;
+
+/**
+ * Kalman filter state for delay estimation (RFC Section 5.3)
+ */
+typedef struct {
+    DOUBLE m_hat;     //!< Estimated queuing delay trend (ms)
+    DOUBLE e;         //!< System error covariance
+    DOUBLE var_v_hat; //!< Estimated measurement noise variance
+    DOUBLE q;         //!< State noise covariance (constant: GCC_STATE_NOISE_COV)
+} GccKalmanState, *PGccKalmanState;
+
+/**
+ * Over-use detector state (RFC Section 5.4)
+ */
+typedef struct {
+    DOUBLE del_var_th;          //!< Adaptive threshold (ms)
+    UINT64 overuseStartTimeKvs; //!< Time when overuse condition started
+    DOUBLE prevM_hat;           //!< Previous m_hat value (for trend detection)
+} GccOveruseDetector, *PGccOveruseDetector;
+
+/**
+ * Rate controller state (RFC Section 5.5)
+ */
+typedef struct {
+    GccState state;           //!< Current state: HOLD/INCREASE/DECREASE
+    UINT64 A_hat;             //!< Delay-based available bandwidth estimate (bps)
+    UINT64 As_hat;            //!< Loss-based available bandwidth estimate (bps)
+    UINT64 targetBitrate;     //!< Final target bitrate (min of A_hat, As_hat)
+    UINT64 lastUpdateTimeKvs; //!< Time of last rate update
+    DOUBLE avgMaxBitrate;     //!< EMA of max bitrate for convergence detection
+    DOUBLE varMaxBitrate;     //!< Variance of max bitrate for convergence detection
+    BOOL nearConvergence;     //!< TRUE if we're near max capacity
+    UINT64 rttEstimateKvs;    //!< Estimated RTT in 100ns units
+} GccRateController, *PGccRateController;
+
+/**
+ * Main GCC Controller structure (full definition for internal use)
+ * The typedef GccController and PGccController are in the public header.
+ */
+struct __GccController {
+    MUTEX lock; //!< Thread safety
+
+    // Sub-components
+    GccKalmanState kalman;      //!< Kalman filter state
+    GccOveruseDetector overuse; //!< Over-use detector state
+    GccRateController rateCtrl; //!< Rate controller state
+
+    // Packet group tracking
+    GccPacketGroup currentGroup; //!< Current packet group being built
+    GccPacketGroup prevGroup;    //!< Previous completed group
+    BOOL hasPrevGroup;           //!< TRUE if prevGroup is valid
+
+    // Configuration
+    UINT64 minBitrate;     //!< Minimum allowed bitrate (bps)
+    UINT64 maxBitrate;     //!< Maximum allowed bitrate (bps)
+    UINT64 initialBitrate; //!< Starting bitrate (bps)
+
+    // Statistics
+    UINT64 totalPacketsSent; //!< Total packets processed
+    UINT64 totalPacketsLost; //!< Total packets marked as lost
+    DOUBLE currentLossRatio; //!< Current loss ratio (0.0 - 1.0)
+    UINT64 lastRttKvs;       //!< Last RTT observation
+};
+
+// NOTE: GccConfig is defined in the public header <com/amazonaws/kinesis/video/webrtcclient/Gcc.h>
+// NOTE: Public API functions (createGccController, freeGccController, gccOnTwccPacketReports,
+//       gccGetTargetBitrate, gccGetState, gccGetLossRatio) are declared in the public header
+
+//
+// Internal functions (exposed for unit testing)
+//
+
+/**
+ * Initialize Kalman filter state
+ */
+STATUS gccKalmanInit(PGccKalmanState pKalman);
+
+/**
+ * Update Kalman filter with new inter-group delay variation
+ *
+ * @param[in,out] pKalman Kalman filter state
+ * @param[in] d_i Inter-group delay variation (ms)
+ * @return STATUS code
+ */
+STATUS gccKalmanUpdate(PGccKalmanState pKalman, DOUBLE d_i);
+
+/**
+ * Initialize over-use detector state
+ */
+STATUS gccOveruseDetectorInit(PGccOveruseDetector pOveruse);
+
+/**
+ * Detect over-use condition and update adaptive threshold
+ *
+ * @param[in,out] pOveruse Over-use detector state
+ * @param[in] m_hat Current queuing delay estimate (ms)
+ * @param[in] dtKvs Time since last update (100ns units)
+ * @return GCC signal (NORMAL, OVERUSE, or UNDERUSE)
+ */
+GccSignal gccDetectOveruse(PGccOveruseDetector pOveruse, DOUBLE m_hat, UINT64 dtKvs);
+
+/**
+ * Initialize rate controller state
+ */
+STATUS gccRateControllerInit(PGccRateController pRateCtrl, UINT64 initialBitrate);
+
+/**
+ * Update delay-based rate controller
+ *
+ * @param[in,out] pRateCtrl Rate controller state
+ * @param[in] signal Over-use signal
+ * @param[in] dtKvs Time since last update (100ns units)
+ * @param[in] incomingBitrate Current measured incoming bitrate
+ * @param[in] minBitrate Minimum allowed bitrate
+ * @param[in] maxBitrate Maximum allowed bitrate
+ * @return STATUS code
+ */
+STATUS gccUpdateDelayController(PGccRateController pRateCtrl, GccSignal signal, UINT64 dtKvs, UINT64 incomingBitrate, UINT64 minBitrate,
+                                UINT64 maxBitrate);
+
+/**
+ * Update loss-based rate controller
+ *
+ * @param[in,out] pRateCtrl Rate controller state
+ * @param[in] lossRatio Current loss ratio (0.0 - 1.0)
+ * @param[in] minBitrate Minimum allowed bitrate
+ * @param[in] maxBitrate Maximum allowed bitrate
+ * @return STATUS code
+ */
+STATUS gccUpdateLossController(PGccRateController pRateCtrl, DOUBLE lossRatio, UINT64 minBitrate, UINT64 maxBitrate);
+
+/**
+ * Process a single packet and add to current group if appropriate
+ *
+ * @param[in,out] pController GCC controller
+ * @param[in] sendTimeKvs Packet send time
+ * @param[in] arrivalTimeKvs Packet arrival time
+ * @param[in] packetSize Packet size in bytes
+ * @param[in] seqNum Sequence number
+ * @return STATUS code
+ */
+STATUS gccProcessPacket(PGccController pController, UINT64 sendTimeKvs, UINT64 arrivalTimeKvs, UINT32 packetSize, UINT16 seqNum);
+
+/**
+ * Finalize current packet group and compute inter-group delay variation
+ *
+ * @param[in,out] pController GCC controller
+ * @param[out] pD_i Inter-group delay variation in ms (only valid if return is TRUE)
+ * @return TRUE if a new d(i) value was computed
+ */
+BOOL gccFinalizeGroup(PGccController pController, DOUBLE* pD_i);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_WEBRTC_CLIENT_PEERCONNECTION_GCC_I__ */

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1349,6 +1349,31 @@ CleanUp:
     return retStatus;
 }
 
+STATUS peerConnectionOnTwccPacketReport(PRtcPeerConnection pRtcPeerConnection, UINT64 customData, RtcOnTwccPacketReport rtcOnTwccPacketReport)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pRtcPeerConnection;
+    BOOL locked = FALSE;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pKvsPeerConnection->peerConnectionObjLock);
+    locked = TRUE;
+
+    pKvsPeerConnection->onTwccPacketReport = rtcOnTwccPacketReport;
+    pKvsPeerConnection->onTwccPacketReportCustomData = customData;
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pKvsPeerConnection->peerConnectionObjLock);
+    }
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS peerConnectionGetLocalDescription(PRtcPeerConnection pRtcPeerConnection, PRtcSessionDescriptionInit pRtcSessionDescriptionInit)
 {
     ENTERS();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -245,8 +245,45 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
     CHK(pKvsPeerConnection != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen >= MIN_HEADER_LENGTH, STATUS_INVALID_ARG);
 
-    ssrc = getInt32(*(PUINT32) (pBuffer + SSRC_OFFSET));
+    now = GETTIME();
 
+    // IMPORTANT: Track TWCC BEFORE decryption!
+    // RTP header and extensions are NOT encrypted by SRTP (only payload is)
+    // This ensures we track TWCC even for packets that fail SRTP replay check
+    if (pKvsPeerConnection->twccExtId != 0) {
+        // Parse RTP header from raw (still encrypted) packet to get TWCC extension
+        PRtpPacket pTwccPacket = NULL;
+        PBYTE pTwccBuffer = (PBYTE) MEMALLOC(bufferLen);
+        if (pTwccBuffer != NULL) {
+            MEMCPY(pTwccBuffer, pBuffer, bufferLen);
+            if (STATUS_SUCCEEDED(createRtpPacketFromBytes(pTwccBuffer, bufferLen, &pTwccPacket))) {
+                pTwccPacket->receivedTime = now;
+                if (pTwccPacket->header.extension && pTwccPacket->header.extensionProfile == TWCC_EXT_PROFILE) {
+                    twccReceiverOnPacketReceived(pKvsPeerConnection, pTwccPacket);
+                }
+                freeRtpPacket(&pTwccPacket);
+            } else {
+                MEMFREE(pTwccBuffer);
+            }
+        }
+    }
+
+    // Now decrypt
+    if (STATUS_FAILED(retStatus = decryptSrtpPacket(pKvsPeerConnection->pSrtpSession, pBuffer, (PINT32) &bufferLen))) {
+        DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
+        packetsFailedDecryption++;
+        CHK(FALSE, STATUS_SUCCESS);
+    }
+
+    CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
+    MEMCPY(pPayload, pBuffer, bufferLen);
+    CHK_STATUS(createRtpPacketFromBytes(pPayload, bufferLen, &pRtpPacket));
+    pPayload = NULL; // pRtpPacket now owns the buffer
+    pRtpPacket->receivedTime = now;
+
+    ssrc = pRtpPacket->header.ssrc;
+
+    // Find matching transceiver for this SSRC
     CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
     while (pCurNode != NULL) {
         CHK_STATUS(doubleListGetNodeData(pCurNode, &item));
@@ -254,19 +291,6 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
 
         if (pTransceiver->jitterBufferSsrc == ssrc) {
             packetsReceived++;
-            if (STATUS_FAILED(retStatus = decryptSrtpPacket(pKvsPeerConnection->pSrtpSession, pBuffer, (PINT32) &bufferLen))) {
-                DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
-                packetsFailedDecryption++;
-                CHK(FALSE, STATUS_SUCCESS);
-            }
-            now = GETTIME();
-            CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
-            MEMCPY(pPayload, pBuffer, bufferLen);
-            CHK_STATUS(createRtpPacketFromBytes(pPayload, bufferLen, &pRtpPacket));
-            // pRtpPacket took ownership of pPayload. Set pPayload to NULL to
-            // avoid possible double-free.
-            pPayload = NULL;
-            pRtpPacket->receivedTime = now;
 
             // https://tools.ietf.org/html/rfc3550#section-6.4.1
             // https://tools.ietf.org/html/rfc3550#appendix-A.8
@@ -1057,6 +1081,11 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
                                              &pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable));
     }
 
+    // TWCC feedback generation (receiver side)
+    pKvsPeerConnection->twccReceiverLock = MUTEX_CREATE(TRUE);
+    CHK_STATUS(createTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
+    pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32; // Invalid timer ID
+
     *ppPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
 
 CleanUp:
@@ -1095,7 +1124,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     PDoubleListNode pCurNode = NULL;
     UINT64 item = 0;
     UINT64 startTime;
-    UINT32 twccHashTableCount = 0;
     BOOL twccLocked = FALSE;
 
     CHK(ppPeerConnection != NULL, STATUS_NULL_ARG);
@@ -1111,6 +1139,16 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
 
     // free timer queue first to remove liveness provided by timer
     if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle)) {
+        if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
+            UINT32 twccTimerId;
+            MUTEX_LOCK(pKvsPeerConnection->twccLock);
+            twccTimerId = pKvsPeerConnection->twccFeedbackTimerId;
+            pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32;
+            MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+            if (twccTimerId != MAX_UINT32) {
+                timerQueueCancelTimer(pKvsPeerConnection->timerQueueHandle, twccTimerId, (UINT64) pKvsPeerConnection);
+            }
+        }
         timerQueueShutdown(pKvsPeerConnection->timerQueueHandle);
     }
 
@@ -1142,7 +1180,11 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pDataChannels));
 
     // free rest of structs
-    CHK_LOG_ERR(freeSrtpSession(&pKvsPeerConnection->pSrtpSession));
+    if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->pSrtpSessionLock)) {
+        MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+        CHK_LOG_ERR(freeSrtpSession(&pKvsPeerConnection->pSrtpSession));
+        MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    }
     CHK_LOG_ERR(freeDtlsSession(&pKvsPeerConnection->pDtlsSession));
     // Since ICE agent has a callback invoked from DTLS during handshake,
     // it is safer to free the ICE agent after DTLS session
@@ -1168,10 +1210,6 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
         MUTEX_LOCK(pKvsPeerConnection->twccLock);
         twccLocked = TRUE;
 
-        if (STATUS_SUCCEEDED(hashTableGetCount(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, &twccHashTableCount))) {
-            DLOGI("Number of TWCC info packets in memory: %d", twccHashTableCount);
-        }
-
         CHK_LOG_ERR(hashTableIterateEntries(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, 0, freeHashEntry));
         CHK_LOG_ERR(hashTableFree(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable));
 
@@ -1188,6 +1226,16 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
         }
         MUTEX_FREE(pKvsPeerConnection->twccLock);
         pKvsPeerConnection->twccLock = INVALID_MUTEX_VALUE;
+    }
+
+    // Free TWCC receiver manager
+    if (pKvsPeerConnection->pTwccReceiverManager != NULL) {
+        CHK_LOG_ERR(freeTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccReceiverLock)) {
+        MUTEX_FREE(pKvsPeerConnection->twccReceiverLock);
+        pKvsPeerConnection->twccReceiverLock = INVALID_MUTEX_VALUE;
     }
 
     PROFILE_WITH_START_TIME_OBJ(startTime, pKvsPeerConnection->peerConnectionDiagnostics.freePeerConnectionTime, "Free peer connection");
@@ -1489,6 +1537,13 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         DLOGD("REMOTE_SDP:%s\n", pSessionDescriptionInit->sdp);
     }
 
+    // Start TWCC feedback timer when remote offers TWCC
+    if (pKvsPeerConnection->twccExtId != 0 && pKvsPeerConnection->twccFeedbackTimerId == MAX_UINT32) {
+        CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, TWCC_FEEDBACK_INITIAL_DELAY, TIMER_QUEUE_SINGLE_INVOCATION_PERIOD,
+                                      twccFeedbackCallback, (UINT64) pKvsPeerConnection, &pKvsPeerConnection->twccFeedbackTimerId));
+        DLOGI("Started TWCC feedback timer with extension ID %u", pKvsPeerConnection->twccExtId);
+    }
+
 CleanUp:
     if (pKvsPeerConnection != NULL && pKvsPeerConnection->isOffer) {
         SAFE_MEMFREE(pKvsPeerConnection->pRemoteSessionDescription);
@@ -1775,6 +1830,24 @@ STATUS closePeerConnection(PRtcPeerConnection pPeerConnection)
     CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
     CHK_LOG_ERR(dtlsSessionShutdown(pKvsPeerConnection->pDtlsSession));
     CHK_LOG_ERR(iceAgentShutdown(pKvsPeerConnection->pIceAgent));
+
+    // Cancel TWCC feedback timer so it stops re-scheduling itself.
+    // This is needed because on Android THREAD_CANCEL is a no-op, so
+    // timerQueueShutdown cannot forcefully stop the executor thread.
+    // Cancelling timers first lets the executor exit cleanly.
+    // Snapshot and reset twccFeedbackTimerId under twccLock to avoid
+    // racing with twccFeedbackCallback which writes it on the timer thread.
+    if (IS_VALID_TIMER_QUEUE_HANDLE(pKvsPeerConnection->timerQueueHandle) && IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccLock)) {
+        UINT32 twccTimerId;
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        twccTimerId = pKvsPeerConnection->twccFeedbackTimerId;
+        pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32;
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+        if (twccTimerId != MAX_UINT32) {
+            timerQueueCancelTimer(pKvsPeerConnection->timerQueueHandle, twccTimerId, (UINT64) pKvsPeerConnection);
+        }
+    }
+
     PROFILE_WITH_START_TIME_OBJ(startTime, pKvsPeerConnection->peerConnectionDiagnostics.closePeerConnectionTime, "Close peer connection");
 
 CleanUp:

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -160,6 +160,8 @@ typedef struct {
     PTwccManager pTwccManager;
     RtcOnSenderBandwidthEstimation onSenderBandwidthEstimation;
     UINT64 onSenderBandwidthEstimationCustomData;
+    RtcOnTwccPacketReport onTwccPacketReport;
+    UINT64 onTwccPacketReportCustomData;
 
     // TWCC feedback generation (receiver side)
     MUTEX twccReceiverLock;

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -61,6 +61,21 @@ typedef struct {
     UINT16 prevReportedBaseSeqNum;        // To monitor the base seqNum in the TWCC response
 } TwccManager, *PTwccManager;
 
+// Receiver-side TWCC tracking for feedback generation
+typedef struct {
+    UINT64 arrivalTimeKvs; // Local arrival time in 100ns units
+} TwccReceivedPacketInfo, *PTwccReceivedPacketInfo;
+
+typedef struct {
+    PHashTable pReceivedPktsHashTable; // Hash table of [seqNum -> PTwccReceivedPacketInfo]
+    UINT16 firstSeqNum;                // First seq in current feedback window
+    UINT16 lastSeqNum;                 // Last seq received
+    BOOL firstPacketReceived;          // Any packet received yet?
+    UINT8 feedbackPacketCount;         // Counter for fb pkt. count field
+    UINT32 mediaSourceSsrc;            // SSRC we're providing feedback for
+    UINT64 baseTimeKvs;                // Base time for relative arrival timestamps
+} TwccReceiverManager, *PTwccReceiverManager;
+
 typedef struct {
     UINT64 peerConnectionCreationTime;
     UINT64 dtlsSessionSetupTime;
@@ -138,13 +153,18 @@ typedef struct {
 
     NullableBool canTrickleIce;
 
-    // congestion control
+    // congestion control (sender side)
     // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
     UINT16 twccExtId;
     MUTEX twccLock;
     PTwccManager pTwccManager;
     RtcOnSenderBandwidthEstimation onSenderBandwidthEstimation;
     UINT64 onSenderBandwidthEstimationCustomData;
+
+    // TWCC feedback generation (receiver side)
+    MUTEX twccReceiverLock;
+    PTwccReceiverManager pTwccReceiverManager;
+    UINT32 twccFeedbackTimerId;
 
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -405,26 +405,72 @@ STATUS onRtcpTwccPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConn
     UINT64 sentBytes = 0, receivedBytes = 0;
     UINT64 sentPackets = 0, receivedPackets = 0;
     INT64 duration = 0;
+    PTwccPacketReport pReports = NULL;
+    UINT32 reportCount = 0;
+    UINT16 seqNum = 0;
+    UINT64 twccPktValue = 0;
+    PTwccRtpPacketInfo pTwccPacket = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-    CHK(pKvsPeerConnection->pTwccManager != NULL && pKvsPeerConnection->onSenderBandwidthEstimation != NULL, STATUS_SUCCESS);
+    // Allow processing if either callback is registered
+    CHK(pKvsPeerConnection->pTwccManager != NULL &&
+            (pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onTwccPacketReport != NULL),
+        STATUS_SUCCESS);
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
     locked = TRUE;
     pTwccManager = pKvsPeerConnection->pTwccManager;
     CHK_STATUS(parseRtcpTwccPacket(pRtcpPacket, pTwccManager));
 
+    // Build per-packet reports for the new callback BEFORE updateTwccHashTable removes them
+    if (pKvsPeerConnection->onTwccPacketReport != NULL) {
+        // Calculate the number of packets in this report
+        UINT16 baseSeqNum = pTwccManager->prevReportedBaseSeqNum;
+        UINT16 lastSeqNum = pTwccManager->lastReportedSeqNum;
+        UINT32 maxReports = (UINT32) ((UINT16) (lastSeqNum - baseSeqNum + 1));
+
+        if (maxReports > 0 && maxReports < 65536) {
+            pReports = (PTwccPacketReport) MEMCALLOC(maxReports, SIZEOF(TwccPacketReport));
+            if (pReports != NULL) {
+                // Iterate through sequence numbers and build reports
+                for (seqNum = baseSeqNum; seqNum != (UINT16) (lastSeqNum + 1); seqNum++) {
+                    if (STATUS_SUCCEEDED(hashTableGet(pTwccManager->pTwccRtpPktInfosHashTable, seqNum, &twccPktValue))) {
+                        pTwccPacket = (PTwccRtpPacketInfo) twccPktValue;
+                        if (pTwccPacket != NULL) {
+                            pReports[reportCount].seqNum = seqNum;
+                            pReports[reportCount].sendTimeKvs = pTwccPacket->localTimeKvs;
+                            pReports[reportCount].arrivalTimeKvs = pTwccPacket->remoteTimeKvs;
+                            pReports[reportCount].packetSize = pTwccPacket->packetSize;
+                            pReports[reportCount].received = (pTwccPacket->remoteTimeKvs != TWCC_PACKET_LOST_TIME);
+                            reportCount++;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     updateTwccHashTable(pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets);
 
-    if (duration > 0) {
-        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
-        locked = FALSE;
+    // Unlock before callbacks to avoid holding lock during application code
+    MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+    locked = FALSE;
+
+    // Invoke the new per-packet callback
+    if (pKvsPeerConnection->onTwccPacketReport != NULL && pReports != NULL && reportCount > 0) {
+        pKvsPeerConnection->onTwccPacketReport(pKvsPeerConnection->onTwccPacketReportCustomData, pReports, reportCount,
+                                               0); // RTT estimate - could be computed from SR/RR
+    }
+
+    // Invoke the existing bandwidth estimation callback
+    if (pKvsPeerConnection->onSenderBandwidthEstimation != NULL && duration > 0) {
         pKvsPeerConnection->onSenderBandwidthEstimation(pKvsPeerConnection->onSenderBandwidthEstimationCustomData, sentBytes, receivedBytes,
                                                         sentPackets, receivedPackets, duration);
     }
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
+    SAFE_MEMFREE(pReports);
     if (locked) {
         MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
     }

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -686,3 +686,531 @@ STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UIN
 CleanUp:
     return retStatus;
 }
+
+//
+// TWCC Feedback Generation (Receiver Side)
+//
+
+STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+
+    CHK(ppManager != NULL, STATUS_NULL_ARG);
+
+    pManager = (PTwccReceiverManager) MEMCALLOC(1, SIZEOF(TwccReceiverManager));
+    CHK(pManager != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    CHK_STATUS(hashTableCreateWithParams(TWCC_RECEIVER_HASH_BUCKET_COUNT, TWCC_RECEIVER_HASH_BUCKET_LENGTH, &pManager->pReceivedPktsHashTable));
+
+    pManager->firstPacketReceived = FALSE;
+    pManager->feedbackPacketCount = 0;
+    pManager->firstSeqNum = 0;
+    pManager->lastSeqNum = 0;
+    pManager->mediaSourceSsrc = 0;
+
+    *ppManager = pManager;
+    pManager = NULL;
+
+CleanUp:
+    if (pManager != NULL) {
+        freeTwccReceiverManager(&pManager);
+    }
+    return retStatus;
+}
+
+static STATUS twccReceiverFreeHashEntry(UINT64 customData, PHashEntry pHashEntry)
+{
+    UNUSED_PARAM(customData);
+    if (pHashEntry != NULL && pHashEntry->value != 0) {
+        MEMFREE((PVOID) pHashEntry->value);
+    }
+    return STATUS_SUCCESS;
+}
+
+STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+
+    CHK(ppManager != NULL, STATUS_NULL_ARG);
+    pManager = *ppManager;
+    CHK(pManager != NULL, retStatus);
+
+    if (pManager->pReceivedPktsHashTable != NULL) {
+        hashTableIterateEntries(pManager->pReceivedPktsHashTable, 0, twccReceiverFreeHashEntry);
+        hashTableFree(pManager->pReceivedPktsHashTable);
+    }
+
+    MEMFREE(pManager);
+    *ppManager = NULL;
+
+CleanUp:
+    return retStatus;
+}
+
+// Helper function to find a specific extension by ID in one-byte header extension payload (0xBEDE format)
+// Returns pointer to extension data (after ID|L byte) or NULL if not found
+static PBYTE findOneByteExtension(PBYTE pExtPayload, UINT32 extLength, UINT8 targetId, PUINT8 pDataLen)
+{
+    UINT32 offset = 0;
+    UINT8 id, len;
+
+    while (offset < extLength) {
+        UINT8 byte = pExtPayload[offset];
+
+        // Skip padding bytes (0x00)
+        if (byte == 0) {
+            offset++;
+            continue;
+        }
+
+        // Parse ID (4 bits) and L (4 bits)
+        id = (byte >> 4) & 0x0F;
+        len = (byte & 0x0F) + 1; // L=0 means 1 byte of data, L=1 means 2 bytes, etc.
+
+        // ID 15 is reserved for future two-byte header, skip rest
+        if (id == 15) {
+            break;
+        }
+
+        // Check if this is the extension we're looking for
+        if (id == targetId) {
+            if (pDataLen != NULL) {
+                *pDataLen = len;
+            }
+            return pExtPayload + offset + 1; // Return pointer to data after ID|L byte
+        }
+
+        // Move to next extension
+        offset += 1 + len;
+    }
+
+    return NULL;
+}
+
+STATUS twccReceiverOnPacketReceived(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PTwccReceiverManager pManager = NULL;
+    PTwccReceivedPacketInfo pPacketInfo = NULL;
+    UINT16 twccSeqNum = 0;
+    UINT64 existingValue = 0;
+    PBYTE pTwccExtData = NULL;
+
+    CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pRtpPacket->header.extension && pRtpPacket->header.extensionProfile == TWCC_EXT_PROFILE, retStatus);
+    CHK(pRtpPacket->header.extensionPayload != NULL, retStatus);
+
+    pManager = pKvsPeerConnection->pTwccReceiverManager;
+    CHK(pManager != NULL, retStatus);
+
+    // Find TWCC extension by ID in the one-byte header extension payload
+    pTwccExtData =
+        findOneByteExtension(pRtpPacket->header.extensionPayload, pRtpPacket->header.extensionLength, (UINT8) pKvsPeerConnection->twccExtId, NULL);
+    if (pTwccExtData == NULL) {
+        DLOGW("TWCC extension ID %u not found in payload (extLen=%u)", pKvsPeerConnection->twccExtId, pRtpPacket->header.extensionLength);
+        CHK(FALSE, retStatus);
+    }
+
+    // Extract TWCC sequence number (16-bit big-endian)
+    twccSeqNum = (UINT16) getUnalignedInt16BigEndian(pTwccExtData);
+    DLOGD("TWCC packet received: seq=%u", twccSeqNum);
+
+    MUTEX_LOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Check if packet already exists (duplicate)
+    if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, twccSeqNum, &existingValue))) {
+        // Already tracked, skip
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    // Allocate packet info
+    pPacketInfo = (PTwccReceivedPacketInfo) MEMCALLOC(1, SIZEOF(TwccReceivedPacketInfo));
+    if (pPacketInfo == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Set base time once (on first ever packet), then store relative arrival time
+    if (pManager->baseTimeKvs == 0) {
+        pManager->baseTimeKvs = pRtpPacket->receivedTime;
+    }
+    pPacketInfo->arrivalTimeKvs = pRtpPacket->receivedTime - pManager->baseTimeKvs;
+
+    // Store in hash table
+    retStatus = hashTablePut(pManager->pReceivedPktsHashTable, twccSeqNum, (UINT64) pPacketInfo);
+    if (STATUS_FAILED(retStatus)) {
+        MEMFREE(pPacketInfo);
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    // Update sequence number tracking
+    if (!pManager->firstPacketReceived) {
+        pManager->firstSeqNum = twccSeqNum;
+        pManager->lastSeqNum = twccSeqNum;
+        pManager->firstPacketReceived = TRUE;
+    } else {
+        // Handle sequence number wraparound using signed comparison
+        INT16 diffFromFirst = (INT16) (twccSeqNum - pManager->firstSeqNum);
+        INT16 diffFromLast = (INT16) (twccSeqNum - pManager->lastSeqNum);
+
+        if (diffFromFirst < 0) {
+            // New packet is before current first (wraparound or out of order)
+            pManager->firstSeqNum = twccSeqNum;
+        }
+        if (diffFromLast > 0) {
+            // New packet is after current last
+            pManager->lastSeqNum = twccSeqNum;
+        }
+    }
+
+    // Store media SSRC for feedback
+    pManager->mediaSourceSsrc = pRtpPacket->header.ssrc;
+
+    MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+
+CleanUp:
+    return retStatus;
+}
+
+// Helper function to determine packet status and delta
+static TWCC_STATUS_SYMBOL getTwccPacketStatus(UINT64 arrivalTimeKvs, UINT64 referenceTimeKvs, PINT32 pDeltaTicks)
+{
+    INT64 deltaKvs;
+    INT64 deltaTicks;
+
+    // Calculate delta from reference time
+    deltaKvs = (INT64) arrivalTimeKvs - (INT64) referenceTimeKvs;
+
+    // Convert from 100ns to 250us ticks
+    // 100ns * (1us/10 * 100ns) * (1 tick / 250us) = 100ns / 2500
+    deltaTicks = deltaKvs / 2500;
+
+    *pDeltaTicks = (INT32) deltaTicks;
+
+    // Determine which delta encoding to use
+    if (deltaTicks >= 0 && deltaTicks <= 255) {
+        return TWCC_STATUS_SYMBOL_SMALLDELTA;
+    } else if (deltaTicks >= -32768 && deltaTicks <= 32767) {
+        return TWCC_STATUS_SYMBOL_LARGEDELTA;
+    } else {
+        // Delta too large - treat as not received
+        return TWCC_STATUS_SYMBOL_NOTRECEIVED;
+    }
+}
+
+STATUS sendRtcpTwccFeedback(PKvsPeerConnection pKvsPeerConnection)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL hasSrtpSession = FALSE;
+    PTwccReceiverManager pManager = NULL;
+    PBYTE pPacket = NULL;
+    UINT32 packetLen = 0;
+    UINT32 allocSize = 0;
+    UINT16 baseSeqNum = 0;
+    UINT16 packetStatusCount = 0;
+    UINT32 currentTime = 0;
+    UINT64 referenceTimeKvs = 0;
+    UINT32 referenceTime24 = 0;
+    UINT16 seqNum = 0;
+    UINT32 offset = 0;
+    UINT64 packetInfoValue = 0;
+    PTwccReceivedPacketInfo pPacketInfo = NULL;
+    INT32 deltaTicks = 0;
+    TWCC_STATUS_SYMBOL status = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+    UINT32 senderSsrc = 0;
+
+    // Arrays to store packet statuses and deltas
+    TWCC_STATUS_SYMBOL* pStatuses = NULL;
+    INT32* pDeltas = NULL;
+    UINT32 i = 0;
+    UINT32 chunkOffset = 0;
+    UINT32 deltaOffset = 0;
+    UINT16 runLength = 0;
+    TWCC_STATUS_SYMBOL runStatus = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    hasSrtpSession = pKvsPeerConnection->pSrtpSession != NULL;
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    CHK(hasSrtpSession, retStatus);
+
+    pManager = pKvsPeerConnection->pTwccReceiverManager;
+    CHK(pManager != NULL, retStatus);
+
+    MUTEX_LOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Check if we have packets to report
+    if (!pManager->firstPacketReceived) {
+        DLOGD("TWCC sendFeedback: no packets received yet");
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        CHK(FALSE, retStatus);
+    }
+
+    baseSeqNum = pManager->firstSeqNum;
+    // Calculate packet status count (handles wraparound)
+    packetStatusCount = (UINT16) ((pManager->lastSeqNum - pManager->firstSeqNum) + 1);
+
+    // Limit packet status count to avoid huge packets
+    if (packetStatusCount > TWCC_MAX_PACKET_STATUS_COUNT) {
+        packetStatusCount = TWCC_MAX_PACKET_STATUS_COUNT;
+    }
+
+    // Allocate arrays for statuses and deltas
+    pStatuses = (TWCC_STATUS_SYMBOL*) MEMCALLOC(packetStatusCount, SIZEOF(TWCC_STATUS_SYMBOL));
+    pDeltas = (INT32*) MEMCALLOC(packetStatusCount, SIZEOF(INT32));
+    if (pStatuses == NULL || pDeltas == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Find first received packet to use as reference time base
+    // Per TWCC spec, reference time should be based on arrival time of first packet in report
+    seqNum = baseSeqNum;
+    referenceTimeKvs = 0;
+    BOOL foundPacket = FALSE;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            referenceTimeKvs = pPacketInfo->arrivalTimeKvs;
+            foundPacket = TRUE;
+            break;
+        }
+        seqNum++;
+    }
+
+    // If no packets found, bail out
+    if (!foundPacket) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, retStatus);
+    }
+
+    // Calculate reference time in 64ms units (24-bit field) for the packet
+    // Convert from 100ns to ms, then divide by 64
+    currentTime = (UINT32) (referenceTimeKvs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    referenceTime24 = (currentTime / TWCC_REFERENCE_TIME_DIVISOR) & 0xFFFFFF;
+
+    // Deltas are incremental: delta[i] = arrival[i] - arrival[i-1]
+    // First delta uses 64ms-aligned reference (Chrome reconstructs: referenceTime24 * 64ms + delta * 0.25ms)
+    // Arrival times are relative to stream start, so values are small and won't overflow
+    UINT64 lastArrivalTimeKvs =
+        (UINT64) (currentTime / TWCC_REFERENCE_TIME_DIVISOR) * TWCC_REFERENCE_TIME_DIVISOR * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    DLOGD("TWCC ref: refTimeKvs=%llu currentTime=%u refTime24=%u lastArrival=%llu", (unsigned long long) referenceTimeKvs, currentTime,
+          referenceTime24, (unsigned long long) lastArrivalTimeKvs);
+    INT32 minDelta = INT32_MAX, maxDelta = INT32_MIN;
+    UINT32 receivedCount = 0, lostCount = 0;
+    seqNum = baseSeqNum;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            status = getTwccPacketStatus(pPacketInfo->arrivalTimeKvs, lastArrivalTimeKvs, &deltaTicks);
+            pStatuses[i] = status;
+            pDeltas[i] = deltaTicks;
+            if (status == TWCC_STATUS_SYMBOL_NOTRECEIVED) {
+                DLOGD("TWCC delta overflow: seq=%u i=%u delta=%d arrival=%llu la    stArrival=%llu", seqNum, i, deltaTicks,
+                      (unsigned long long) pPacketInfo->arrivalTimeKvs, (unsigned long long) lastArrivalTimeKvs);
+                lostCount++;
+            } else {
+                receivedCount++;
+                if (deltaTicks < minDelta)
+                    minDelta = deltaTicks;
+                if (deltaTicks > maxDelta)
+                    maxDelta = deltaTicks;
+            }
+            lastArrivalTimeKvs = pPacketInfo->arrivalTimeKvs; // Update for next packet's delta
+        } else {
+            pStatuses[i] = TWCC_STATUS_SYMBOL_NOTRECEIVED;
+            pDeltas[i] = 0;
+            lostCount++;
+        }
+        seqNum++;
+    }
+    DLOGD("TWCC feedback: base=%u count=%u received=%u lost=%u minDelta=%d maxDelta=%d", baseSeqNum, packetStatusCount, receivedCount, lostCount,
+          minDelta, maxDelta);
+
+    // Calculate packet size:
+    // Header: 20 bytes (4 RTCP header + 4 sender SSRC + 4 media SSRC + 4 base seq + 4 ref time)
+    // Chunks: variable (2 bytes each, worst case is status vector with 7 packets = packetStatusCount/7 chunks)
+    // Deltas: variable (1 byte for small, 2 bytes for large)
+    // Add SRTP overhead
+    allocSize = 20; // Fixed header size
+
+    // Estimate chunk size (worst case: all status vectors with 7 packets each)
+    allocSize += ((packetStatusCount + 6) / 7) * 2;
+
+    // Estimate delta size (worst case: all large deltas)
+    for (i = 0; i < packetStatusCount; i++) {
+        if (pStatuses[i] == TWCC_STATUS_SYMBOL_SMALLDELTA) {
+            allocSize += 1;
+        } else if (pStatuses[i] == TWCC_STATUS_SYMBOL_LARGEDELTA) {
+            allocSize += 2;
+        }
+    }
+
+    // Pad to 32-bit boundary + SRTP overhead
+    allocSize = (allocSize + 3) & ~3;
+    allocSize += SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
+
+    pPacket = (PBYTE) MEMCALLOC(1, allocSize);
+    if (pPacket == NULL) {
+        MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+        SAFE_MEMFREE(pStatuses);
+        SAFE_MEMFREE(pDeltas);
+        CHK(FALSE, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Get sender SSRC (use first transceiver's receive SSRC or generate one)
+    // For simplicity, we'll use a fixed SSRC derived from the connection
+    senderSsrc = (UINT32) ((UINT64) pKvsPeerConnection & 0xFFFFFFFF);
+
+    // Build RTCP TWCC Feedback packet
+    // Byte 0: V=2, P=0, FMT=15
+    pPacket[0] = (RTCP_PACKET_VERSION_VAL << 6) | RTCP_FEEDBACK_MESSAGE_TYPE_TWCC;
+    // Byte 1: PT=205 (Generic RTP Feedback)
+    pPacket[1] = RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK;
+    // Bytes 2-3: Length (fill in later)
+    offset = 4;
+
+    // Bytes 4-7: Sender SSRC
+    putUnalignedInt32BigEndian(pPacket + offset, senderSsrc);
+    offset += 4;
+
+    // Bytes 8-11: Media source SSRC
+    putUnalignedInt32BigEndian(pPacket + offset, pManager->mediaSourceSsrc);
+    offset += 4;
+
+    // Bytes 12-13: Base sequence number
+    putUnalignedInt16BigEndian(pPacket + offset, baseSeqNum);
+    offset += 2;
+
+    // Bytes 14-15: Packet status count
+    putUnalignedInt16BigEndian(pPacket + offset, packetStatusCount);
+    offset += 2;
+
+    // Bytes 16-18: Reference time (24-bit)
+    pPacket[offset++] = (referenceTime24 >> 16) & 0xFF;
+    pPacket[offset++] = (referenceTime24 >> 8) & 0xFF;
+    pPacket[offset++] = referenceTime24 & 0xFF;
+
+    // Byte 19: Feedback packet count
+    pPacket[offset++] = pManager->feedbackPacketCount++;
+
+    // Build packet chunks using run-length encoding
+    chunkOffset = offset;
+    i = 0;
+    while (i < packetStatusCount) {
+        // Count run of same status
+        runStatus = pStatuses[i];
+        runLength = 1;
+        while (i + runLength < packetStatusCount && pStatuses[i + runLength] == runStatus && runLength < TWCC_MAX_PACKET_STATUS_COUNT) {
+            runLength++;
+        }
+
+        // Write run-length chunk
+        putUnalignedInt16BigEndian(pPacket + chunkOffset, TWCC_MAKE_RUNLEN(runStatus, runLength));
+        chunkOffset += 2;
+        i += runLength;
+    }
+
+    // Build receive deltas
+    deltaOffset = chunkOffset;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (pStatuses[i] == TWCC_STATUS_SYMBOL_SMALLDELTA) {
+            pPacket[deltaOffset++] = (UINT8) pDeltas[i];
+        } else if (pStatuses[i] == TWCC_STATUS_SYMBOL_LARGEDELTA) {
+            putUnalignedInt16BigEndian(pPacket + deltaOffset, (INT16) pDeltas[i]);
+            deltaOffset += 2;
+        }
+    }
+
+    // Pad to 32-bit boundary
+    while ((deltaOffset % 4) != 0) {
+        pPacket[deltaOffset++] = 0;
+    }
+
+    packetLen = deltaOffset;
+
+    // Fill in length field (length in 32-bit words minus 1)
+    putUnalignedInt16BigEndian(pPacket + 2, (packetLen / 4) - 1);
+
+    // Clear processed packets from hash table
+    seqNum = baseSeqNum;
+    for (i = 0; i < packetStatusCount; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pManager->pReceivedPktsHashTable, seqNum, &packetInfoValue))) {
+            pPacketInfo = (PTwccReceivedPacketInfo) packetInfoValue;
+            hashTableRemove(pManager->pReceivedPktsHashTable, seqNum);
+            MEMFREE(pPacketInfo);
+        }
+        seqNum++;
+    }
+
+    // Reset tracking for next feedback
+    pManager->firstPacketReceived = FALSE;
+    pManager->firstSeqNum = 0;
+    pManager->lastSeqNum = 0;
+
+    MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // Encrypt and send
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    retStatus = encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, pPacket, (PINT32) &packetLen);
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    CHK_STATUS(retStatus);
+
+    CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pPacket, packetLen));
+
+CleanUp:
+    SAFE_MEMFREE(pPacket);
+    SAFE_MEMFREE(pStatuses);
+    SAFE_MEMFREE(pDeltas);
+    return retStatus;
+}
+
+STATUS twccFeedbackCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData)
+{
+    UNUSED_PARAM(timerId);
+    UNUSED_PARAM(currentTime);
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
+    UINT64 delay = 0;
+    BOOL srtpReady = FALSE;
+
+    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+
+    // Skip if SRTP not ready yet - must lock to avoid race with allocateSrtp
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    srtpReady = pKvsPeerConnection->pSrtpSession != NULL;
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+
+    if (srtpReady) {
+        // Send TWCC feedback (ignore errors - will try again next interval)
+        sendRtcpTwccFeedback(pKvsPeerConnection);
+    } else {
+        DLOGD("TWCC callback: SRTP not ready yet");
+    }
+
+    // Reschedule timer with jitter (80-120ms).
+    // Write to a local first, then copy under twccLock to avoid racing
+    // with closePeerConnection which reads twccFeedbackTimerId.
+    {
+        UINT32 newTimerId = MAX_UINT32;
+        delay = 80 + (RAND() % 40);
+        CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, delay * HUNDREDS_OF_NANOS_IN_A_MILLISECOND,
+                                      TIMER_QUEUE_SINGLE_INVOCATION_PERIOD, twccFeedbackCallback, (UINT64) pKvsPeerConnection, &newTimerId));
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        pKvsPeerConnection->twccFeedbackTimerId = newTimerId;
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    return retStatus;
+}

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -16,6 +16,13 @@ STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUIN
 STATUS sendRtcpPLI(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc);
 STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc, UINT8* pSeqNum);
 
+// TWCC feedback generation (receiver side)
+STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager);
+STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager);
+STATUS twccReceiverOnPacketReceived(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket);
+STATUS sendRtcpTwccFeedback(PKvsPeerConnection pKvsPeerConnection);
+STATUS twccFeedbackCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData);
+
 // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
 // Deltas are represented as multiples of 250us:
 #define TWCC_TICKS_PER_SECOND        (1000000LL / 250)
@@ -45,6 +52,26 @@ typedef enum {
     (((packetChunk) >> (14u - (i) * TWCC_STATUSVECTOR_SSIZE(packetChunk))) & TWCC_STATUSVECTOR_SMASK(packetChunk))
 #define TWCC_STATUSVECTOR_COUNT(packetChunk) (TWCC_STATUSVECTOR_IS_2BIT(packetChunk) ? 7 : 14)
 #define TWCC_PACKET_STATUS_COUNT(payload)    (getUnalignedInt16BigEndian((payload) + 10))
+
+// TWCC feedback generation constants
+#define TWCC_FEEDBACK_INITIAL_DELAY      (100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define TWCC_FEEDBACK_INTERVAL_MS        100
+#define TWCC_RECEIVER_HASH_BUCKET_COUNT  100
+#define TWCC_RECEIVER_HASH_BUCKET_LENGTH 2
+#define TWCC_REFERENCE_TIME_DIVISOR      64     // 64ms granularity for reference time
+#define TWCC_MAX_PACKET_STATUS_COUNT     0x1FFF // Max run-length count (13 bits)
+
+// TWCC chunk encoding macros for feedback generation
+// Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
+#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) &0x1FFF)))
+// Status vector chunk (2-bit): bit 15 = 1, bit 14 = 1, bits 13-0 = 7 status symbols (2 bits each)
+#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) &0x3FFF)))
+// Status vector chunk (1-bit): bit 15 = 1, bit 14 = 0, bits 13-0 = 14 status symbols (1 bit each)
+#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) &0x3FFF)))
+
+// TWCC feedback packet type
+#define RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK 205
+#define RTCP_FEEDBACK_MESSAGE_TYPE_TWCC       15
 
 #ifdef __cplusplus
 }

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -63,11 +63,11 @@ typedef enum {
 
 // TWCC chunk encoding macros for feedback generation
 // Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
-#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) &0x1FFF)))
+#define TWCC_MAKE_RUNLEN(status, count) ((UINT16) (((status) << 13) | ((count) & 0x1FFF)))
 // Status vector chunk (2-bit): bit 15 = 1, bit 14 = 1, bits 13-0 = 7 status symbols (2 bits each)
-#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) &0x3FFF)))
+#define TWCC_MAKE_STATUS_VECTOR_2BIT(symbols) ((UINT16) (0xC000 | ((symbols) & 0x3FFF)))
 // Status vector chunk (1-bit): bit 15 = 1, bit 14 = 0, bits 13-0 = 14 status symbols (1 bit each)
-#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) &0x3FFF)))
+#define TWCC_MAKE_STATUS_VECTOR_1BIT(symbols) ((UINT16) (0x8000 | ((symbols) & 0x3FFF)))
 
 // TWCC feedback packet type
 #define RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK 205

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -901,6 +901,13 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
                      SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%" PRId64 " " TWCC_SDP_ATTR, payloadType);
         CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full rtcp-fb twcc could not be written");
         attributeCount++;
+
+        STRCPY(pSdpMediaDescription->sdpAttributes[attributeCount].attributeName, "extmap");
+        amountWritten = SNPRINTF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue,
+                                 SIZEOF(pSdpMediaDescription->sdpAttributes[attributeCount].attributeValue), "%u %s", pKvsPeerConnection->twccExtId,
+                                 TWCC_EXT_URL);
+        CHK_ERR(amountWritten > 0, STATUS_INTERNAL_ERROR, "Full extmap twcc could not be written");
+        attributeCount++;
     }
 
     pSdpMediaDescription->mediaAttributesCount = attributeCount;

--- a/tst/GccFunctionalityTest.cpp
+++ b/tst/GccFunctionalityTest.cpp
@@ -1,0 +1,704 @@
+/*******************************************
+GCC (Google Congestion Control) Unit Tests
+Based on draft-ietf-rmcat-gcc-02
+*******************************************/
+
+#include "WebRTCClientTestFixture.h"
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+class GccFunctionalityTest : public WebRtcClientTestBase {
+  public:
+    PGccController pController = nullptr;
+
+    void SetUp() override
+    {
+        WebRtcClientTestBase::SetUp();
+    }
+
+    void TearDown() override
+    {
+        if (pController != nullptr) {
+            freeGccController(&pController);
+        }
+        WebRtcClientTestBase::TearDown();
+    }
+
+    // Helper to create mock TwccPacketReports
+    void createMockReports(TwccPacketReport* pReports, UINT32 count, UINT64 baseTimeSendKvs, UINT64 baseTimeArriveKvs, UINT32 packetSize,
+                           DOUBLE delayVariationMs, DOUBLE lossRatio)
+    {
+        UINT64 sendInterval = 33 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND; // ~30fps
+        UINT64 arrivalDrift = (UINT64)(delayVariationMs * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+
+        for (UINT32 i = 0; i < count; i++) {
+            pReports[i].seqNum = (UINT16) i;
+            pReports[i].sendTimeKvs = baseTimeSendKvs + i * sendInterval;
+            pReports[i].packetSize = packetSize;
+
+            // Simulate loss based on ratio
+            if (lossRatio > 0 && ((DOUBLE) rand() / RAND_MAX) < lossRatio) {
+                pReports[i].received = FALSE;
+                pReports[i].arrivalTimeKvs = 0;
+            } else {
+                pReports[i].received = TRUE;
+                // Add progressive delay drift to simulate congestion
+                pReports[i].arrivalTimeKvs = baseTimeArriveKvs + i * sendInterval + (i * arrivalDrift);
+            }
+        }
+    }
+};
+
+//
+// Kalman Filter Tests
+//
+
+TEST_F(GccFunctionalityTest, kalmanInit)
+{
+    GccKalmanState kalman;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanInit(&kalman));
+
+    EXPECT_DOUBLE_EQ(0.0, kalman.m_hat);
+    EXPECT_DOUBLE_EQ(GCC_INITIAL_ERROR_COV, kalman.e);
+    EXPECT_DOUBLE_EQ(1.0, kalman.var_v_hat);
+    EXPECT_DOUBLE_EQ(GCC_STATE_NOISE_COV, kalman.q);
+}
+
+TEST_F(GccFunctionalityTest, kalmanInitNullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, gccKalmanInit(nullptr));
+}
+
+TEST_F(GccFunctionalityTest, kalmanUpdateBasic)
+{
+    GccKalmanState kalman;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanInit(&kalman));
+
+    // Initial m_hat is 0, if we observe d_i = 5ms, m_hat should move toward 5
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanUpdate(&kalman, 5.0));
+    EXPECT_GT(kalman.m_hat, 0.0);
+    EXPECT_LT(kalman.m_hat, 5.0); // Should not fully jump to 5
+}
+
+TEST_F(GccFunctionalityTest, kalmanConvergence)
+{
+    GccKalmanState kalman;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanInit(&kalman));
+
+    // Feed the same value multiple times - m_hat should converge toward it
+    for (int i = 0; i < 100; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, gccKalmanUpdate(&kalman, 10.0));
+    }
+
+    // Should be close to 10 after many iterations
+    EXPECT_GT(kalman.m_hat, 9.0);
+    EXPECT_LT(kalman.m_hat, 11.0);
+}
+
+TEST_F(GccFunctionalityTest, kalmanOutlierFiltering)
+{
+    GccKalmanState kalman;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanInit(&kalman));
+
+    // First, establish a baseline
+    for (int i = 0; i < 20; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, gccKalmanUpdate(&kalman, 5.0));
+    }
+
+    DOUBLE m_hat_before = kalman.m_hat;
+
+    // Now inject a large outlier
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanUpdate(&kalman, 500.0));
+
+    // m_hat should not jump dramatically due to outlier filtering in variance
+    EXPECT_LT(kalman.m_hat, m_hat_before + 50.0); // Should be damped
+}
+
+TEST_F(GccFunctionalityTest, kalmanVarianceUpdate)
+{
+    GccKalmanState kalman;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccKalmanInit(&kalman));
+
+    DOUBLE initialVar = kalman.var_v_hat;
+
+    // Feed noisy data - variance should update
+    for (int i = 0; i < 50; i++) {
+        DOUBLE noise = (i % 2 == 0) ? 10.0 : -10.0;
+        EXPECT_EQ(STATUS_SUCCESS, gccKalmanUpdate(&kalman, noise));
+    }
+
+    // Variance should have changed from initial
+    EXPECT_NE(kalman.var_v_hat, initialVar);
+    EXPECT_GE(kalman.var_v_hat, 1.0); // Should be clamped to minimum of 1.0
+}
+
+//
+// Over-use Detector Tests
+//
+
+TEST_F(GccFunctionalityTest, overuseDetectorInit)
+{
+    GccOveruseDetector overuse;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    EXPECT_DOUBLE_EQ(GCC_INITIAL_THRESHOLD_MS, overuse.del_var_th);
+    EXPECT_EQ(0ULL, overuse.overuseStartTimeKvs);
+    EXPECT_DOUBLE_EQ(0.0, overuse.prevM_hat);
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorInitNullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, gccOveruseDetectorInit(nullptr));
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorNormalSignal)
+{
+    GccOveruseDetector overuse;
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    // m_hat within threshold should give NORMAL signal
+    GccSignal signal = gccDetectOveruse(&overuse, 5.0, HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    EXPECT_EQ(GCC_SIGNAL_NORMAL, signal);
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorUnderuseSignal)
+{
+    GccOveruseDetector overuse;
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    // m_hat below -threshold should give UNDERUSE signal
+    GccSignal signal = gccDetectOveruse(&overuse, -20.0, HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    EXPECT_EQ(GCC_SIGNAL_UNDERUSE, signal);
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorOveruseSignalRequiresTime)
+{
+    GccOveruseDetector overuse;
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    // m_hat above threshold once should NOT immediately give OVERUSE
+    // because it needs to persist for overuse_time_th
+    GccSignal signal = gccDetectOveruse(&overuse, 20.0, HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+
+    // Should start tracking overuse but not signal yet
+    EXPECT_NE(0ULL, overuse.overuseStartTimeKvs);
+    EXPECT_EQ(GCC_SIGNAL_NORMAL, signal); // Not enough time elapsed
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorThresholdAdaptation)
+{
+    GccOveruseDetector overuse;
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    DOUBLE initialThreshold = overuse.del_var_th;
+
+    // Feed values below threshold - should decrease threshold (slowly)
+    for (int i = 0; i < 100; i++) {
+        gccDetectOveruse(&overuse, 2.0, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    EXPECT_LT(overuse.del_var_th, initialThreshold);
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorThresholdClamping)
+{
+    GccOveruseDetector overuse;
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+
+    // Try to push threshold below minimum
+    for (int i = 0; i < 1000; i++) {
+        gccDetectOveruse(&overuse, 0.1, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    EXPECT_GE(overuse.del_var_th, GCC_THRESHOLD_MIN_MS);
+
+    // Reset and try to push above maximum
+    EXPECT_EQ(STATUS_SUCCESS, gccOveruseDetectorInit(&overuse));
+    for (int i = 0; i < 1000; i++) {
+        gccDetectOveruse(&overuse, 100.0, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    EXPECT_LE(overuse.del_var_th, GCC_THRESHOLD_MAX_MS);
+}
+
+TEST_F(GccFunctionalityTest, overuseDetectorNullReturnsNormal)
+{
+    GccSignal signal = gccDetectOveruse(nullptr, 10.0, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(GCC_SIGNAL_NORMAL, signal);
+}
+
+//
+// Rate Controller Tests
+//
+
+TEST_F(GccFunctionalityTest, rateControllerInit)
+{
+    GccRateController rateCtrl;
+
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    EXPECT_EQ(GCC_STATE_INCREASE, rateCtrl.state);
+    EXPECT_EQ(500000ULL, rateCtrl.A_hat);
+    EXPECT_EQ(500000ULL, rateCtrl.As_hat);
+    EXPECT_EQ(500000ULL, rateCtrl.targetBitrate);
+    EXPECT_FALSE(rateCtrl.nearConvergence);
+}
+
+TEST_F(GccFunctionalityTest, rateControllerInitNullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, gccRateControllerInit(nullptr, 500000));
+}
+
+TEST_F(GccFunctionalityTest, rateControllerStateTransitions)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    // Initial state is INCREASE
+    EXPECT_EQ(GCC_STATE_INCREASE, rateCtrl.state);
+
+    // INCREASE + OVERUSE -> DECREASE
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_OVERUSE, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    EXPECT_EQ(GCC_STATE_DECREASE, rateCtrl.state);
+
+    // DECREASE + NORMAL -> HOLD
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_NORMAL, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    EXPECT_EQ(GCC_STATE_HOLD, rateCtrl.state);
+
+    // HOLD + NORMAL -> INCREASE
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_NORMAL, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    EXPECT_EQ(GCC_STATE_INCREASE, rateCtrl.state);
+
+    // INCREASE + UNDERUSE -> HOLD
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_UNDERUSE, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    EXPECT_EQ(GCC_STATE_HOLD, rateCtrl.state);
+}
+
+TEST_F(GccFunctionalityTest, rateControllerIncreaseBehavior)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    UINT64 initialRate = rateCtrl.A_hat;
+
+    // In INCREASE state with NORMAL signal, rate should increase
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_NORMAL, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_GT(rateCtrl.A_hat, initialRate);
+}
+
+TEST_F(GccFunctionalityTest, rateControllerDecreaseBehavior)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    // Trigger DECREASE state
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_OVERUSE, HUNDREDS_OF_NANOS_IN_A_SECOND, 500000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_EQ(GCC_STATE_DECREASE, rateCtrl.state);
+
+    // In DECREASE state, rate should be reduced to beta * incomingBitrate
+    EXPECT_LT(rateCtrl.A_hat, 500000ULL);
+    EXPECT_EQ((UINT64)(GCC_BETA * 500000), rateCtrl.A_hat);
+}
+
+TEST_F(GccFunctionalityTest, rateControllerBoundsEnforcement)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    // Try to increase beyond max
+    for (int i = 0; i < 100; i++) {
+        gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_NORMAL, HUNDREDS_OF_NANOS_IN_A_SECOND, GCC_DEFAULT_MAX_BITRATE, GCC_DEFAULT_MIN_BITRATE,
+                                 GCC_DEFAULT_MAX_BITRATE);
+    }
+
+    EXPECT_LE(rateCtrl.A_hat, GCC_DEFAULT_MAX_BITRATE);
+
+    // Try to decrease below min
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+    for (int i = 0; i < 100; i++) {
+        gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_OVERUSE, HUNDREDS_OF_NANOS_IN_A_SECOND, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MIN_BITRATE,
+                                 GCC_DEFAULT_MAX_BITRATE);
+    }
+
+    EXPECT_GE(rateCtrl.A_hat, GCC_DEFAULT_MIN_BITRATE);
+}
+
+TEST_F(GccFunctionalityTest, rateControllerConvergenceTracking)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 1000000));
+
+    // Initially not near convergence
+    EXPECT_FALSE(rateCtrl.nearConvergence);
+
+    // Multiple decrease events should establish avgMaxBitrate
+    gccUpdateDelayController(&rateCtrl, GCC_SIGNAL_OVERUSE, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000000, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_GT(rateCtrl.avgMaxBitrate, 0.0);
+}
+
+//
+// Loss Controller Tests
+//
+
+TEST_F(GccFunctionalityTest, lossControllerLowLossIncrease)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    UINT64 initialAsHat = rateCtrl.As_hat;
+
+    // Less than 2% loss should increase rate by 5%
+    gccUpdateLossController(&rateCtrl, 0.01, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_GT(rateCtrl.As_hat, initialAsHat);
+    EXPECT_EQ((UINT64)(initialAsHat * 1.05), rateCtrl.As_hat);
+}
+
+TEST_F(GccFunctionalityTest, lossControllerMidLossHold)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    UINT64 initialAsHat = rateCtrl.As_hat;
+
+    // 2-10% loss should hold steady
+    gccUpdateLossController(&rateCtrl, 0.05, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_EQ(initialAsHat, rateCtrl.As_hat);
+}
+
+TEST_F(GccFunctionalityTest, lossControllerHighLossDecrease)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    UINT64 initialAsHat = rateCtrl.As_hat;
+
+    // More than 10% loss should decrease by half the loss ratio
+    gccUpdateLossController(&rateCtrl, 0.20, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+
+    EXPECT_LT(rateCtrl.As_hat, initialAsHat);
+    EXPECT_EQ((UINT64)(initialAsHat * (1.0 - 0.5 * 0.20)), rateCtrl.As_hat);
+}
+
+TEST_F(GccFunctionalityTest, lossControllerBoundsEnforcement)
+{
+    GccRateController rateCtrl;
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+
+    // Try to increase beyond max
+    for (int i = 0; i < 200; i++) {
+        gccUpdateLossController(&rateCtrl, 0.0, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    }
+
+    EXPECT_LE(rateCtrl.As_hat, GCC_DEFAULT_MAX_BITRATE);
+
+    // Try to decrease below min
+    EXPECT_EQ(STATUS_SUCCESS, gccRateControllerInit(&rateCtrl, 500000));
+    for (int i = 0; i < 50; i++) {
+        gccUpdateLossController(&rateCtrl, 0.50, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
+    }
+
+    EXPECT_GE(rateCtrl.As_hat, GCC_DEFAULT_MIN_BITRATE);
+}
+
+//
+// Packet Grouping / Pre-filtering Tests
+//
+
+TEST_F(GccFunctionalityTest, packetGroupingBasic)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    UINT64 baseTime = GETTIME();
+
+    // First packet
+    EXPECT_EQ(STATUS_SUCCESS, gccProcessPacket(pController, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0));
+
+    EXPECT_EQ(1, pController->currentGroup.packetCount);
+    EXPECT_EQ(1200U, pController->currentGroup.totalBytes);
+    EXPECT_EQ(0, pController->currentGroup.firstSeqNum);
+}
+
+TEST_F(GccFunctionalityTest, packetGroupingBurstTime)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    UINT64 baseTime = GETTIME();
+
+    // First packet
+    gccProcessPacket(pController, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0);
+
+    // Second packet within burst time (5ms)
+    gccProcessPacket(pController, baseTime + 2 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, baseTime + 52 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 1);
+
+    // Should be in same group
+    EXPECT_EQ(2, pController->currentGroup.packetCount);
+    EXPECT_EQ(2400U, pController->currentGroup.totalBytes);
+}
+
+TEST_F(GccFunctionalityTest, packetGroupingNewGroup)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    UINT64 baseTime = GETTIME();
+
+    // First packet
+    gccProcessPacket(pController, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0);
+
+    // Second packet outside burst time (>5ms)
+    gccProcessPacket(pController, baseTime + 33 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, baseTime + 83 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 1);
+
+    // Should start new group
+    EXPECT_EQ(1, pController->currentGroup.packetCount);
+    EXPECT_TRUE(pController->hasPrevGroup);
+    EXPECT_EQ(1, pController->prevGroup.packetCount);
+}
+
+TEST_F(GccFunctionalityTest, packetGroupingFinalizeGroup)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    UINT64 baseTime = GETTIME();
+
+    // First group
+    gccProcessPacket(pController, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0);
+
+    // Second group (different time)
+    gccProcessPacket(pController, baseTime + 33 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, baseTime + 83 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 1);
+
+    // Third group to trigger finalization of second
+    gccProcessPacket(pController, baseTime + 66 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, baseTime + 116 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 2);
+
+    DOUBLE d_i = 0.0;
+    BOOL hasValue = gccFinalizeGroup(pController, &d_i);
+
+    EXPECT_TRUE(hasValue);
+    // d_i should be close to 0 if delays are consistent
+}
+
+TEST_F(GccFunctionalityTest, packetGroupingSkipsLostPackets)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    UINT64 baseTime = GETTIME();
+
+    // First packet received
+    gccProcessPacket(pController, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0);
+
+    // Lost packet (arrivalTime = 0)
+    gccProcessPacket(pController, baseTime + 33 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 0, 1200, 1);
+
+    // Should still have only 1 packet
+    EXPECT_EQ(1, pController->currentGroup.packetCount);
+}
+
+//
+// GCC Controller Integration Tests
+//
+
+TEST_F(GccFunctionalityTest, createFreeLifecycle)
+{
+    // Create with defaults
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    EXPECT_NE(nullptr, pController);
+    EXPECT_EQ(GCC_DEFAULT_MIN_BITRATE, pController->minBitrate);
+    EXPECT_EQ(GCC_DEFAULT_MAX_BITRATE, pController->maxBitrate);
+    EXPECT_EQ(GCC_DEFAULT_INITIAL_BITRATE, pController->initialBitrate);
+
+    // Verify initial state
+    EXPECT_EQ(GCC_STATE_INCREASE, pController->rateCtrl.state);
+    EXPECT_EQ(GCC_DEFAULT_INITIAL_BITRATE, pController->rateCtrl.targetBitrate);
+
+    // Free
+    EXPECT_EQ(STATUS_SUCCESS, freeGccController(&pController));
+    EXPECT_EQ(nullptr, pController);
+
+    // Free again should be idempotent
+    EXPECT_EQ(STATUS_SUCCESS, freeGccController(&pController));
+}
+
+TEST_F(GccFunctionalityTest, createWithConfig)
+{
+    GccConfig config;
+    config.minBitrateBps = 200000;
+    config.maxBitrateBps = 5000000;
+    config.initialBitrateBps = 1000000;
+
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, &config));
+
+    EXPECT_EQ(200000ULL, pController->minBitrate);
+    EXPECT_EQ(5000000ULL, pController->maxBitrate);
+    EXPECT_EQ(1000000ULL, pController->initialBitrate);
+    EXPECT_EQ(1000000ULL, pController->rateCtrl.targetBitrate);
+}
+
+TEST_F(GccFunctionalityTest, createNullArg)
+{
+    EXPECT_EQ(STATUS_NULL_ARG, createGccController(nullptr, nullptr));
+}
+
+TEST_F(GccFunctionalityTest, fullPipelineWithReports)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    static constexpr UINT32 reportCount = 30;
+    TwccPacketReport reports[reportCount];
+    UINT64 baseTime = GETTIME();
+
+    // Create reports with no delay variation and no loss
+    createMockReports(reports, reportCount, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0.0, 0.0);
+
+    EXPECT_EQ(STATUS_SUCCESS, gccOnTwccPacketReports(pController, reports, reportCount, 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND));
+
+    // With no congestion, rate should stay or increase
+    UINT64 targetBitrate = gccGetTargetBitrate(pController);
+    EXPECT_GE(targetBitrate, GCC_DEFAULT_INITIAL_BITRATE);
+
+    // Check loss ratio should be 0
+    DOUBLE lossRatio = gccGetLossRatio(pController);
+    EXPECT_DOUBLE_EQ(0.0, lossRatio);
+
+    // State should be INCREASE or HOLD
+    GccState state = gccGetState(pController);
+    EXPECT_TRUE(state == GCC_STATE_INCREASE || state == GCC_STATE_HOLD);
+}
+
+TEST_F(GccFunctionalityTest, pipelineWithPacketLoss)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    static constexpr UINT32 reportCount = 100;
+    TwccPacketReport reports[reportCount];
+    UINT64 baseTime = GETTIME();
+
+    // Seed random for reproducible tests
+    srand(42);
+
+    // Create reports with 15% loss (high loss)
+    createMockReports(reports, reportCount, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 0.0, 0.15);
+
+    EXPECT_EQ(STATUS_SUCCESS, gccOnTwccPacketReports(pController, reports, reportCount, 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND));
+
+    // With high loss, loss ratio should be detected
+    DOUBLE lossRatio = gccGetLossRatio(pController);
+    EXPECT_GT(lossRatio, 0.0);
+
+    // Target bitrate might be reduced due to loss
+    UINT64 targetBitrate = gccGetTargetBitrate(pController);
+    EXPECT_GE(targetBitrate, GCC_DEFAULT_MIN_BITRATE);
+    EXPECT_LE(targetBitrate, GCC_DEFAULT_MAX_BITRATE);
+}
+
+TEST_F(GccFunctionalityTest, pipelineWithDelayVariation)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    static constexpr UINT32 reportCount = 50;
+    TwccPacketReport reports[reportCount];
+    UINT64 baseTime = GETTIME();
+
+    // Create reports with increasing delay (simulating congestion buildup)
+    createMockReports(reports, reportCount, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, 2.0, // 2ms delay drift per packet
+                      0.0);
+
+    EXPECT_EQ(STATUS_SUCCESS, gccOnTwccPacketReports(pController, reports, reportCount, 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND));
+
+    // With progressive delay, the Kalman filter should detect the trend
+    EXPECT_GT(pController->kalman.m_hat, 0.0);
+}
+
+TEST_F(GccFunctionalityTest, onTwccPacketReportsNullArgs)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    TwccPacketReport reports[10];
+
+    EXPECT_EQ(STATUS_NULL_ARG, gccOnTwccPacketReports(nullptr, reports, 10, 0));
+    EXPECT_EQ(STATUS_NULL_ARG, gccOnTwccPacketReports(pController, nullptr, 10, 0));
+    EXPECT_EQ(STATUS_NULL_ARG, gccOnTwccPacketReports(pController, reports, 0, 0));
+}
+
+TEST_F(GccFunctionalityTest, getTargetBitrateNullArg)
+{
+    UINT64 bitrate = gccGetTargetBitrate(nullptr);
+    EXPECT_EQ(0ULL, bitrate);
+}
+
+TEST_F(GccFunctionalityTest, getStateNullArg)
+{
+    GccState state = gccGetState(nullptr);
+    EXPECT_EQ(GCC_STATE_HOLD, state);
+}
+
+TEST_F(GccFunctionalityTest, getLossRatioNullArg)
+{
+    DOUBLE loss = gccGetLossRatio(nullptr);
+    EXPECT_DOUBLE_EQ(0.0, loss);
+}
+
+TEST_F(GccFunctionalityTest, threadSafetyMultipleAccess)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    // Simulate concurrent access by calling APIs multiple times
+    // (actual thread safety would require spawning threads, but this tests the locking paths)
+    for (int i = 0; i < 100; i++) {
+        UINT64 bitrate = gccGetTargetBitrate(pController);
+        GccState state = gccGetState(pController);
+        DOUBLE loss = gccGetLossRatio(pController);
+
+        EXPECT_GE(bitrate, GCC_DEFAULT_MIN_BITRATE);
+        EXPECT_LE(bitrate, GCC_DEFAULT_MAX_BITRATE);
+        EXPECT_TRUE(state == GCC_STATE_HOLD || state == GCC_STATE_INCREASE || state == GCC_STATE_DECREASE);
+        EXPECT_GE(loss, 0.0);
+        EXPECT_LE(loss, 1.0);
+    }
+}
+
+TEST_F(GccFunctionalityTest, multipleFeedbackCycles)
+{
+    EXPECT_EQ(STATUS_SUCCESS, createGccController(&pController, nullptr));
+
+    static constexpr UINT32 reportCount = 30;
+    TwccPacketReport reports[reportCount];
+
+    // Simulate multiple feedback cycles
+    for (int cycle = 0; cycle < 10; cycle++) {
+        UINT64 baseTime = GETTIME() + cycle * 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+        // Alternate between good and bad conditions
+        DOUBLE delayVariation = (cycle % 2 == 0) ? 0.0 : 1.0;
+        DOUBLE lossRatio = (cycle % 3 == 0) ? 0.15 : 0.0;
+
+        createMockReports(reports, reportCount, baseTime, baseTime + 50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND, 1200, delayVariation, lossRatio);
+
+        EXPECT_EQ(STATUS_SUCCESS, gccOnTwccPacketReports(pController, reports, reportCount, 100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND));
+
+        UINT64 targetBitrate = gccGetTargetBitrate(pController);
+        EXPECT_GE(targetBitrate, GCC_DEFAULT_MIN_BITRATE);
+        EXPECT_LE(targetBitrate, GCC_DEFAULT_MAX_BITRATE);
+    }
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -1605,6 +1605,292 @@ TEST_F(PeerConnectionFunctionalityTest, firRequestTriggersKeyFrame)
     EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.firResponseFrameReceived)) << "Receiver should have received the I-frame sent in response to FIR";
 }
 
+// Test TWCC (Transport-Wide Congestion Control) feedback functionality
+// Sender sends video frames to receiver
+// Receiver generates TWCC feedback for incoming RTP packets
+// When sender receives TWCC feedback, RtcOnSenderBandwidthEstimation callback is fired
+TEST_F(PeerConnectionFunctionalityTest, twccFeedbackTriggersBandwidthEstimation)
+{
+    // Frame size for test frames
+    auto const frameBufferSize = 1200;
+
+    // Context structure for sharing state between callbacks
+    struct TwccTestContext {
+        ATOMIC_BOOL bandwidthEstimationReceived;
+        ATOMIC_BOOL frameReceived;
+        ATOMIC_BOOL testComplete;
+        SIZE_T callbackCount;
+        UINT32 totalTxBytes;
+        UINT32 totalRxBytes;
+        UINT32 totalTxPackets;
+        UINT32 totalRxPackets;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    TwccTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(TwccTestContext));
+
+    // Allocate frame buffer
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+    MEMSET(videoFrame.frameData, 0xAB, videoFrame.size);
+
+    // Initialize atomic flags
+    ATOMIC_STORE_BOOL(&context.bandwidthEstimationReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.frameReceived, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+    context.callbackCount = 0;
+
+    // Create peer connections
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Manually enable TWCC extension on both peers
+    // In real scenarios, this is negotiated via SDP when connecting to browsers
+    // For peer-to-peer testing between SDK instances, we need to set it manually
+    PKvsPeerConnection pOfferKvs = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pAnswerKvs = (PKvsPeerConnection) answerPc;
+    pOfferKvs->twccExtId = 1;  // Standard TWCC extension ID
+    pAnswerKvs->twccExtId = 1;
+
+    // Add video tracks to both peers (VP8 codec supports TWCC)
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    // Callback for when sender receives TWCC feedback and computes bandwidth estimation
+    auto onBandwidthEstimationHandler = [](UINT64 customData, UINT32 txBytes, UINT32 rxBytes,
+                                           UINT32 txPackets, UINT32 rxPackets, UINT64 duration) -> void {
+        UNUSED_PARAM(duration);
+        TwccTestContext* pContext = (TwccTestContext*) customData;
+
+        pContext->callbackCount++;
+        pContext->totalTxBytes += txBytes;
+        pContext->totalRxBytes += rxBytes;
+        pContext->totalTxPackets += txPackets;
+        pContext->totalRxPackets += rxPackets;
+
+        ATOMIC_STORE_BOOL(&pContext->bandwidthEstimationReceived, TRUE);
+        DLOGD("Bandwidth estimation callback: txBytes=%u rxBytes=%u txPackets=%u rxPackets=%u",
+              txBytes, rxBytes, txPackets, rxPackets);
+
+        // Mark test complete if we've received enough callbacks
+        if (pContext->callbackCount >= 2) {
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+        }
+    };
+
+    // Register bandwidth estimation callback on sender (offer peer)
+    EXPECT_EQ(peerConnectionOnSenderBandwidthEstimation(offerPc, (UINT64) &context, onBandwidthEstimationHandler), STATUS_SUCCESS);
+
+    // Callback for when receiver gets a frame
+    auto onFrameHandler = [](UINT64 customData, PFrame pFrame) -> void {
+        UNUSED_PARAM(pFrame);
+        TwccTestContext* pContext = (TwccTestContext*) customData;
+        ATOMIC_STORE_BOOL(&pContext->frameReceived, TRUE);
+    };
+
+    // Register frame callback on receiver's transceiver
+    EXPECT_EQ(transceiverOnFrame(answerVideoTransceiver, (UINT64) &context, onFrameHandler), STATUS_SUCCESS);
+
+    // Connect the two peers
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Verify TWCC extension ID is set
+    DLOGD("Offer TWCC ext ID: %u, Answer TWCC ext ID: %u", pOfferKvs->twccExtId, pAnswerKvs->twccExtId);
+
+    // Send video frames from offer to answer
+    // TWCC feedback is generated every ~100ms, so we need to send for a while
+    for (auto i = 0; i < 300 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        // Send video frame
+        videoFrame.flags = (i % 30 == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 30);  // 30 fps
+
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 33);  // ~30fps timing
+    }
+
+    // Cleanup
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify test succeeded
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.frameReceived)) << "Receiver should have received video frames";
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.bandwidthEstimationReceived))
+        << "Sender should have received TWCC feedback and bandwidth estimation callback should have been fired";
+    EXPECT_GT(context.callbackCount, 0) << "Bandwidth estimation callback should have been called at least once";
+    EXPECT_GT(context.totalTxPackets, 0) << "Should have reported transmitted packets";
+    EXPECT_GT(context.totalRxPackets, 0) << "Should have reported received packets";
+
+    DLOGD("TWCC test completed: %zu callbacks, txPackets=%u rxPackets=%u",
+          context.callbackCount, context.totalTxPackets, context.totalRxPackets);
+}
+
+// Test TWCC feedback generation on the receiver side
+// This verifies the receiver correctly generates TWCC feedback packets
+// with proper incremental deltas (not absolute timestamps)
+// Bug history: Chrome reported 300kbps stable bitrate because:
+// 1. Delta calculation was absolute instead of incremental
+// 2. 24-bit reference time wraparound caused delta overflow
+// 3. First packet with relative time=0 was treated as "no packet found"
+TEST_F(PeerConnectionFunctionalityTest, twccReceiverGeneratesFeedback)
+{
+    auto const frameBufferSize = 1200;
+
+    struct TwccReceiverTestContext {
+        ATOMIC_BOOL feedbackSent;
+        SIZE_T feedbackCount;
+        ATOMIC_BOOL testComplete;
+        UINT32 totalTxPackets;
+        UINT32 totalRxPackets;
+        SIZE_T validDurationCount;
+        SIZE_T invalidDurationCount;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver;
+    Frame videoFrame;
+    TwccReceiverTestContext context;
+
+    MEMSET(&configuration, 0x00, SIZEOF(RtcConfiguration));
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&context, 0x00, SIZEOF(TwccReceiverTestContext));
+
+    videoFrame.frameData = (PBYTE) MEMALLOC(frameBufferSize);
+    videoFrame.size = frameBufferSize;
+    ASSERT_NE(videoFrame.frameData, nullptr);
+    MEMSET(videoFrame.frameData, 0xAB, videoFrame.size);
+
+    ATOMIC_STORE_BOOL(&context.feedbackSent, FALSE);
+    ATOMIC_STORE_BOOL(&context.testComplete, FALSE);
+    context.feedbackCount = 0;
+    context.totalTxPackets = 0;
+    context.totalRxPackets = 0;
+    context.validDurationCount = 0;
+    context.invalidDurationCount = 0;
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Enable TWCC on both peers
+    PKvsPeerConnection pOfferKvs = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pAnswerKvs = (PKvsPeerConnection) answerPc;
+    pOfferKvs->twccExtId = 1;
+    pAnswerKvs->twccExtId = 1;
+
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+
+    // Bandwidth estimation callback on SENDER (offer) proves receiver sent feedback
+    auto onBandwidthEstimationHandler = [](UINT64 customData, UINT32 txBytes, UINT32 rxBytes,
+                                           UINT32 txPackets, UINT32 rxPackets, UINT64 duration) -> void {
+        UNUSED_PARAM(txBytes);
+        UNUSED_PARAM(rxBytes);
+        TwccReceiverTestContext* pContext = (TwccReceiverTestContext*) customData;
+
+        pContext->feedbackCount++;
+        pContext->totalTxPackets += txPackets;
+        pContext->totalRxPackets += rxPackets;
+        ATOMIC_STORE_BOOL(&pContext->feedbackSent, TRUE);
+
+        // Verify we're getting reasonable packet counts (not zero due to delta overflow)
+        // This would fail with the old bugs where packets were marked as "lost"
+        EXPECT_GT(rxPackets, 0) << "rxPackets should be > 0 (not marked as lost due to delta overflow)";
+
+        // Verify duration is reasonable (not negative or huge due to delta overflow)
+        // Duration is in 100ns units, should be positive and less than 10 seconds for each feedback
+        INT64 signedDuration = (INT64) duration;
+        if (signedDuration >= 0 && signedDuration <= 10 * HUNDREDS_OF_NANOS_IN_A_SECOND) {
+            pContext->validDurationCount++;
+        } else {
+            pContext->invalidDurationCount++;
+            DLOGW("Invalid TWCC duration: %lld (possible delta overflow)", (long long) signedDuration);
+        }
+
+        // Verify receive ratio is reasonable (> 50% of packets should be marked received)
+        // With delta overflow bugs, most packets would be marked as "lost"
+        if (txPackets > 0) {
+            UINT32 receivePercent = (rxPackets * 100) / txPackets;
+            EXPECT_GE(receivePercent, 50) << "Receive ratio should be >= 50% (was " << receivePercent
+                                          << "%), low ratio indicates delta calculation bugs";
+        }
+
+        // After several feedbacks, mark complete
+        if (pContext->feedbackCount >= 3) {
+            ATOMIC_STORE_BOOL(&pContext->testComplete, TRUE);
+        }
+    };
+
+    EXPECT_EQ(peerConnectionOnSenderBandwidthEstimation(offerPc, (UINT64) &context, onBandwidthEstimationHandler), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Verify TWCC receiver manager is initialized on answer peer
+    EXPECT_NE(pAnswerKvs->pTwccReceiverManager, nullptr) << "TWCC receiver manager should be initialized";
+
+    // Send frames - receiver (answer) should generate TWCC feedback
+    for (auto i = 0; i < 300 && !ATOMIC_LOAD_BOOL(&context.testComplete); i++) {
+        videoFrame.flags = (i % 30 == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoFrame.presentationTs += (HUNDREDS_OF_NANOS_IN_A_SECOND / 30);
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_MILLISECOND * 33);
+    }
+
+    MEMFREE(videoFrame.frameData);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+
+    // Verify receiver generated feedback
+    EXPECT_TRUE(ATOMIC_LOAD_BOOL(&context.feedbackSent))
+        << "Receiver should have sent TWCC feedback";
+    EXPECT_GE(context.feedbackCount, 3)
+        << "Should have received multiple TWCC feedbacks";
+    EXPECT_GT(context.totalRxPackets, 0)
+        << "Should have reported received packets (not all marked lost due to delta bugs)";
+
+    // Verify duration checks actually ran and ALL passed
+    // Using total ensures we don't pass by doing nothing (0 == 0 would be meaningless)
+    SIZE_T totalDurationChecks = context.validDurationCount + context.invalidDurationCount;
+    EXPECT_GT(totalDurationChecks, 0)
+        << "Should have performed duration checks (test did nothing if 0)";
+    EXPECT_EQ(context.validDurationCount, totalDurationChecks)
+        << "All duration checks should pass (had " << context.invalidDurationCount
+        << " invalid out of " << totalDurationChecks << ", indicates delta overflow bugs)";
+
+    // Final receive ratio check - should be high if deltas are correct
+    EXPECT_GT(context.totalTxPackets, 0)
+        << "Should have transmitted packets";
+    if (context.totalTxPackets > 0) {
+        UINT32 overallReceivePercent = (context.totalRxPackets * 100) / context.totalTxPackets;
+        EXPECT_GE(overallReceivePercent, 80)
+            << "Overall receive ratio should be >= 80% (was " << overallReceivePercent
+            << "%), low ratio indicates TWCC delta calculation bugs";
+    }
+
+    DLOGD("TWCC receiver test completed: %zu feedbacks, txPackets=%u rxPackets=%u ratio=%u%% validDurations=%zu invalidDurations=%zu",
+          context.feedbackCount, context.totalTxPackets, context.totalRxPackets,
+          context.totalTxPackets > 0 ? (context.totalRxPackets * 100) / context.totalTxPackets : 0,
+          context.validDurationCount, context.invalidDurationCount);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -512,6 +512,251 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
+//
+// TWCC Feedback Generation (Receiver Side) Tests
+//
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedBasic)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+    UINT64 packetInfoValue = 0;
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+
+    // Verify receiver manager was created
+    EXPECT_NE(nullptr, pKvsPeerConnection->pTwccReceiverManager);
+
+    // Set up TWCC extension ID (simulating SDP negotiation)
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Create a mock RTP packet with TWCC extension
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.receivedTime = GETTIME();
+
+    // Create TWCC extension payload for sequence number 100
+    // Format: ID (4 bits) | Length-1 (4 bits) | SeqNum (16 bits) | Padding
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    // Track the packet
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Verify packet was tracked
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+    EXPECT_EQ(TRUE, pManager->firstPacketReceived);
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(100, pManager->lastSeqNum);
+    EXPECT_EQ(0x12345678, pManager->mediaSourceSsrc);
+
+    // Verify packet is in hash table
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGet(pManager->pReceivedPktsHashTable, 100, &packetInfoValue));
+    EXPECT_NE(0, packetInfoValue);
+
+    // Add another packet with sequence number 101
+    twccPayload = htonl((1 << 28) | (1 << 24) | (101 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Verify sequence tracking updated
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(101, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedOutOfOrder)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet 100 first
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(100, pManager->lastSeqNum);
+
+    // Add packet 102 (skip 101)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (102 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(100, pManager->firstSeqNum);
+    EXPECT_EQ(102, pManager->lastSeqNum);
+
+    // Add packet 99 (out of order, before first)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (99 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(99, pManager->firstSeqNum);  // Updated to earlier packet
+    EXPECT_EQ(102, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedSeqNumWraparound)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet at UINT16_MAX - 1
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | ((UINT16_MAX - 1) << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(UINT16_MAX - 1, pManager->lastSeqNum);
+
+    // Add packet at UINT16_MAX
+    twccPayload = htonl((1 << 28) | (1 << 24) | (UINT16_MAX << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(UINT16_MAX, pManager->lastSeqNum);
+
+    // Add packet at 0 (wrapped around)
+    twccPayload = htonl((1 << 28) | (1 << 24) | (0 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(0, pManager->lastSeqNum);  // Wrapped to 0
+
+    // Add packet at 1
+    twccPayload = htonl((1 << 28) | (1 << 24) | (1 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+    EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
+    EXPECT_EQ(1, pManager->lastSeqNum);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccReceiverDuplicatePacketHandling)
+{
+    PRtcPeerConnection pRtcPeerConnection = NULL;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    RtcConfiguration config{};
+    RtpPacket rtpPacket;
+    BYTE extensionPayload[4];
+    UINT32 itemCount = 0;
+
+    // Create peer connection
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
+    pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
+    pKvsPeerConnection->twccExtId = 1;
+
+    // Set up mock RTP packet
+    MEMSET(&rtpPacket, 0, SIZEOF(RtpPacket));
+    rtpPacket.header.extension = TRUE;
+    rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
+    rtpPacket.header.ssrc = 0x12345678;
+    rtpPacket.header.extensionPayload = extensionPayload;
+    rtpPacket.header.extensionLength = 4;
+
+    PTwccReceiverManager pManager = pKvsPeerConnection->pTwccReceiverManager;
+
+    // Add packet 100
+    UINT32 twccPayload = htonl((1 << 28) | (1 << 24) | (100 << 8));
+    MEMCPY(extensionPayload, &twccPayload, 4);
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Get initial count
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGetCount(pManager->pReceivedPktsHashTable, &itemCount));
+    EXPECT_EQ(1, itemCount);
+
+    // Try to add duplicate packet 100 - should be silently ignored
+    rtpPacket.receivedTime = GETTIME();
+    EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
+
+    // Count should still be 1
+    EXPECT_EQ(STATUS_SUCCESS, hashTableGetCount(pManager->pReceivedPktsHashTable, &itemCount));
+    EXPECT_EQ(1, itemCount);
+
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, twccMakeRunlenMacro)
+{
+    // Test run-length chunk creation macro
+    // Run-length chunk: bit 15 = 0, bits 14-13 = status symbol, bits 12-0 = run length
+
+    // Test with NOT_RECEIVED status (00), run length 10
+    UINT16 chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_NOTRECEIVED, 10);
+    EXPECT_EQ(0, (chunk >> 15) & 1);  // Bit 15 should be 0 for run-length
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_NOTRECEIVED, (chunk >> 13) & 3);
+    EXPECT_EQ(10, chunk & 0x1FFF);
+
+    // Test with SMALL_DELTA status (01), run length 100
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_SMALLDELTA, 100);
+    EXPECT_EQ(0, (chunk >> 15) & 1);
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_SMALLDELTA, (chunk >> 13) & 3);
+    EXPECT_EQ(100, chunk & 0x1FFF);
+
+    // Test with LARGE_DELTA status (10), run length 1000
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_LARGEDELTA, 1000);
+    EXPECT_EQ(0, (chunk >> 15) & 1);
+    EXPECT_EQ(TWCC_STATUS_SYMBOL_LARGEDELTA, (chunk >> 13) & 3);
+    EXPECT_EQ(1000, chunk & 0x1FFF);
+
+    // Test max run length (0x1FFF = 8191)
+    chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_SMALLDELTA, 0x1FFF);
+    EXPECT_EQ(0x1FFF, chunk & 0x1FFF);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
> **Stacked on:** #15 (TWCC receiver-side feedback generation)

*Issue #, if available:*
- N/A

*What was changed?*
- Added a GCC (Google Congestion Control) implementation that consumes TWCC feedback to estimate available bandwidth
- Added `RtcOnTwccPacketReport` callback that exposes per-packet arrival time and loss data to applications
- Added public API: `createGccController`, `freeGccController`, `gccOnTwccPacketReports`, `gccGetTargetBitrate`, `gccGetState`, `gccGetLossRatio`
- Added `peerConnectionOnTwccPacketReport` registration API

*Why was it changed?*
- The existing `RtcOnSenderBandwidthEstimation` callback only provides aggregate stats. Applications need per-packet TWCC data to implement proper congestion control. GCC is the standard WebRTC congestion control algorithm needed for adaptive bitrate streaming.

*How was it changed?*
- New files: `Gcc.h` (public API), `Gcc_i.h` (internal types), `Gcc.c` (implementation)
- GCC implementation includes: Kalman filter for inter-arrival delay estimation, overuse detector with adaptive threshold, rate controller with hold/increase/decrease states, loss-based controller, and packet grouping by burst time
- Added `TwccPacketReport` struct and `RtcOnTwccPacketReport` callback type to Include.h
- Modified TWCC feedback processing in Rtcp.c to fire the new per-packet report callback alongside the existing aggregate callback
- Linked libm on non-Windows platforms for `exp`/`sqrt` used by the Kalman filter

*What testing was done for the changes?*
- Added `GccFunctionalityTest` suite with 42 unit tests covering: Kalman filter init/convergence/outlier filtering, overuse detector signal classification and threshold adaptation, rate controller state transitions/increase/decrease/bounds, loss controller at different loss ratios, packet grouping, full pipeline with reports/loss/delay variation, thread safety, and null argument handling
- Added end-to-end tests `twccFeedbackTriggersBandwidthEstimation` and `twccReceiverGeneratesFeedback` in PeerConnectionFunctionalityTest

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.