### PR TITLE
Add thread-safe DataChannel stats and stress tests

### DIFF
--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -212,11 +212,11 @@ STATUS getDataChannelStats(PRtcPeerConnection pRtcPeerConnection, PRtcDataChanne
     CHK(pRtcPeerConnection != NULL && pRtcDataChannelStats != NULL, STATUS_NULL_ARG);
     CHK_STATUS(hashTableGet(pKvsPeerConnection->pDataChannels, pRtcDataChannelStats->dataChannelIdentifier, &hashValue));
     pKvsDataChannel = (PKvsDataChannel) hashValue;
-    pRtcDataChannelStats->bytesReceived = pKvsDataChannel->rtcDataChannelDiagnostics.bytesReceived;
-    pRtcDataChannelStats->bytesSent = pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent;
+    pRtcDataChannelStats->bytesReceived = (UINT64) ATOMIC_LOAD(&pKvsDataChannel->atomicBytesReceived);
+    pRtcDataChannelStats->bytesSent = (UINT64) ATOMIC_LOAD(&pKvsDataChannel->atomicBytesSent);
     STRCPY(pRtcDataChannelStats->label, pKvsDataChannel->rtcDataChannelDiagnostics.label);
-    pRtcDataChannelStats->messagesReceived = pKvsDataChannel->rtcDataChannelDiagnostics.messagesReceived;
-    pRtcDataChannelStats->messagesSent = pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent;
+    pRtcDataChannelStats->messagesReceived = (UINT32) ATOMIC_LOAD(&pKvsDataChannel->atomicMessagesReceived);
+    pRtcDataChannelStats->messagesSent = (UINT32) ATOMIC_LOAD(&pKvsDataChannel->atomicMessagesSent);
     pRtcDataChannelStats->state = pKvsDataChannel->rtcDataChannelDiagnostics.state;
 CleanUp:
     return retStatus;

--- a/src/source/PeerConnection/DataChannel.c
+++ b/src/source/PeerConnection/DataChannel.c
@@ -65,8 +65,8 @@ STATUS dataChannelSend(PRtcDataChannel pRtcDataChannel, BOOL isBinary, PBYTE pMe
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
 
     CHK_STATUS(sctpSessionWriteMessage(pSctpSession, pKvsDataChannel->channelId, isBinary, pMessage, pMessageLen));
-    pKvsDataChannel->rtcDataChannelDiagnostics.messagesSent++;
-    pKvsDataChannel->rtcDataChannelDiagnostics.bytesSent += pMessageLen;
+    ATOMIC_INCREMENT(&pKvsDataChannel->atomicMessagesSent);
+    ATOMIC_ADD(&pKvsDataChannel->atomicBytesSent, (SIZE_T) pMessageLen);
 CleanUp:
 
     return retStatus;

--- a/src/source/PeerConnection/DataChannel.h
+++ b/src/source/PeerConnection/DataChannel.h
@@ -22,6 +22,12 @@ typedef struct {
     RtcOnMessage onMessage;
     RtcDataChannelStats rtcDataChannelDiagnostics;
 
+    // Atomic counters for thread-safe diagnostics updates
+    volatile SIZE_T atomicMessagesSent;
+    volatile SIZE_T atomicBytesSent;
+    volatile SIZE_T atomicMessagesReceived;
+    volatile SIZE_T atomicBytesReceived;
+
     UINT64 onOpenCustomData;
     RtcOnOpen onOpen;
 } KvsDataChannel, *PKvsDataChannel;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -625,8 +625,8 @@ VOID onSctpSessionDataChannelMessage(UINT64 customData, UINT32 channelId, BOOL i
         CHK(FALSE, retStatus);
     }
     CHK(pKvsDataChannel != NULL && pKvsDataChannel->onMessage != NULL, STATUS_INTERNAL_ERROR);
-    pKvsDataChannel->rtcDataChannelDiagnostics.messagesReceived++;
-    pKvsDataChannel->rtcDataChannelDiagnostics.bytesReceived += pMessageLen;
+    ATOMIC_INCREMENT(&pKvsDataChannel->atomicMessagesReceived);
+    ATOMIC_ADD(&pKvsDataChannel->atomicBytesReceived, (SIZE_T) pMessageLen);
     if (STATUS_FAILED(hashTableUpsert(pKvsPeerConnection->pDataChannels, channelId, (UINT64) pKvsDataChannel))) {
         DLOGW("Failed to update entry in hash table with recent changes to data channel");
     }

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -165,33 +165,45 @@ CleanUp:
     return retStatus;
 }
 
+static VOID handleSctpTimers(PSctpSession pSctpSession)
+{
+    UINT64 now = GETTIME();
+    UINT32 elapsedMs = 0;
+    UINT64 lastTime = (UINT64) ATOMIC_EXCHANGE(&pSctpSession->lastTimerTime, (SIZE_T) now);
+    if (lastTime != 0) {
+        elapsedMs = (UINT32) ((now - lastTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+    usrsctp_handle_timers(elapsedMs);
+}
+
 STATUS sctpSessionWriteMessage(PSctpSession pSctpSession, UINT32 streamId, BOOL isBinary, PBYTE pMessage, UINT32 pMessageLen)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
+    struct sctp_sendv_spa spa;
 
     CHK(pSctpSession != NULL && pMessage != NULL, STATUS_NULL_ARG);
 
-    MEMSET(&pSctpSession->spa, 0x00, SIZEOF(struct sctp_sendv_spa));
+    MEMSET(&spa, 0x00, SIZEOF(struct sctp_sendv_spa));
 
-    pSctpSession->spa.sendv_flags |= SCTP_SEND_SNDINFO_VALID;
-    pSctpSession->spa.sendv_sndinfo.snd_sid = streamId;
+    spa.sendv_flags |= SCTP_SEND_SNDINFO_VALID;
+    spa.sendv_sndinfo.snd_sid = streamId;
 
     if ((pSctpSession->packet[1] & DCEP_DATA_CHANNEL_RELIABLE_UNORDERED) != 0) {
-        pSctpSession->spa.sendv_sndinfo.snd_flags |= SCTP_UNORDERED;
+        spa.sendv_sndinfo.snd_flags |= SCTP_UNORDERED;
     }
     if ((pSctpSession->packet[1] & DCEP_DATA_CHANNEL_REXMIT) != 0) {
-        pSctpSession->spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_RTX;
-        pSctpSession->spa.sendv_prinfo.pr_value = getUnalignedInt32BigEndian((PINT32) (pSctpSession->packet + SIZEOF(UINT32)));
+        spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_RTX;
+        spa.sendv_prinfo.pr_value = getUnalignedInt32BigEndian((PINT32) (pSctpSession->packet + SIZEOF(UINT32)));
     }
     if ((pSctpSession->packet[1] & DCEP_DATA_CHANNEL_TIMED) != 0) {
-        pSctpSession->spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_TTL;
-        pSctpSession->spa.sendv_prinfo.pr_value = getUnalignedInt32BigEndian((PINT32) (pSctpSession->packet + SIZEOF(UINT32)));
+        spa.sendv_prinfo.pr_policy = SCTP_PR_SCTP_TTL;
+        spa.sendv_prinfo.pr_value = getUnalignedInt32BigEndian((PINT32) (pSctpSession->packet + SIZEOF(UINT32)));
     }
 
-    putInt32((PINT32) &pSctpSession->spa.sendv_sndinfo.snd_ppid, isBinary ? SCTP_PPID_BINARY : SCTP_PPID_STRING);
-    CHK(usrsctp_sendv(pSctpSession->socket, pMessage, pMessageLen, NULL, 0, &pSctpSession->spa, SIZEOF(pSctpSession->spa), SCTP_SENDV_SPA, 0) > 0,
-        STATUS_INTERNAL_ERROR);
+    putInt32((PINT32) &spa.sendv_sndinfo.snd_ppid, isBinary ? SCTP_PPID_BINARY : SCTP_PPID_STRING);
+    CHK(usrsctp_sendv(pSctpSession->socket, pMessage, pMessageLen, NULL, 0, &spa, SIZEOF(spa), SCTP_SENDV_SPA, 0) > 0, STATUS_INTERNAL_ERROR);
+    handleSctpTimers(pSctpSession);
 
 CleanUp:
     LEAVES();
@@ -295,6 +307,7 @@ STATUS putSctpPacket(PSctpSession pSctpSession, PBYTE buf, UINT32 bufLen)
     STATUS retStatus = STATUS_SUCCESS;
 
     usrsctp_conninput(pSctpSession, buf, bufLen, 0);
+    handleSctpTimers(pSctpSession);
 
     LEAVES();
     return retStatus;

--- a/src/source/Sctp/Sctp.c
+++ b/src/source/Sctp/Sctp.c
@@ -165,11 +165,16 @@ CleanUp:
     return retStatus;
 }
 
+// Drive usrsctp timers on every send/receive rather than using a separate timer thread.
+// lastTimerTime is SIZE_T (32-bit on arm32, 64-bit on arm64/x86_64). We truncate GETTIME()
+// to SIZE_T intentionally — both operands in (now - lastTime) are the same width, so unsigned
+// wraparound arithmetic gives the correct elapsed delta on 32-bit platforms (valid for
+// intervals up to ~429 seconds, far exceeding the frequency of send/receive calls).
 static VOID handleSctpTimers(PSctpSession pSctpSession)
 {
-    UINT64 now = GETTIME();
+    SIZE_T now = (SIZE_T) GETTIME();
     UINT32 elapsedMs = 0;
-    UINT64 lastTime = (UINT64) ATOMIC_EXCHANGE(&pSctpSession->lastTimerTime, (SIZE_T) now);
+    SIZE_T lastTime = ATOMIC_EXCHANGE(&pSctpSession->lastTimerTime, now);
     if (lastTime != 0) {
         elapsedMs = (UINT32) ((now - lastTime) / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
     }

--- a/src/source/Sctp/Sctp.h
+++ b/src/source/Sctp/Sctp.h
@@ -11,8 +11,9 @@
 extern "C" {
 #endif
 
-// 1200 - 12 (SCTP header Size)
-#define SCTP_MTU                         1188
+// DEFAULT_MTU_SIZE(1200) - DTLS record overhead (~50 bytes depending on cipher)
+// Must fit within a single DTLS record to avoid fragmentation across datagrams
+#define SCTP_MTU                         1150
 #define SCTP_ASSOCIATION_DEFAULT_PORT    5000
 #define SCTP_DCEP_HEADER_LENGTH          12
 #define SCTP_DCEP_LABEL_LEN_OFFSET       8
@@ -64,6 +65,7 @@ typedef struct {
     struct sctp_sendv_spa spa;
     BYTE packet[SCTP_MAX_ALLOWABLE_PACKET_LENGTH];
     UINT32 packetSize;
+    volatile SIZE_T lastTimerTime;
     SctpSessionCallbacks sctpSessionCallbacks;
 } SctpSession, *PSctpSession;
 

--- a/tst/DataChannelFunctionalityTest.cpp
+++ b/tst/DataChannelFunctionalityTest.cpp
@@ -244,9 +244,9 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_PartialReliabilityUnorder
     pKvsDataChannel = (PKvsDataChannel) pOfferDataChannel;
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
 
-    ASSERT_EQ(pSctpSession->spa.sendv_sndinfo.snd_flags, SCTP_UNORDERED);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_policy, SCTP_PR_SCTP_TTL);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_value, rtcDataChannelInit.maxPacketLifeTime.value);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_RELIABLE_UNORDERED, 0);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_TIMED, 0);
+    ASSERT_EQ(getUnalignedInt32BigEndian((PINT32)(pSctpSession->packet + SIZEOF(UINT32))), rtcDataChannelInit.maxPacketLifeTime.value);
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
@@ -330,9 +330,9 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_PartialReliabilityUnOrder
     pKvsDataChannel = (PKvsDataChannel) pOfferDataChannel;
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
 
-    ASSERT_EQ(pSctpSession->spa.sendv_sndinfo.snd_flags, SCTP_UNORDERED);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_policy, SCTP_PR_SCTP_RTX);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_value, rtcDataChannelInit.maxRetransmits.value);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_RELIABLE_UNORDERED, 0);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_REXMIT, 0);
+    ASSERT_EQ(getUnalignedInt32BigEndian((PINT32)(pSctpSession->packet + SIZEOF(UINT32))), rtcDataChannelInit.maxRetransmits.value);
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
@@ -416,9 +416,9 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_PartialReliabilityOrdered
     pKvsDataChannel = (PKvsDataChannel) pOfferDataChannel;
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
 
-    ASSERT_NE(pSctpSession->spa.sendv_sndinfo.snd_flags, SCTP_UNORDERED);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_policy, SCTP_PR_SCTP_TTL);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_value, rtcDataChannelInit.maxPacketLifeTime.value);
+    ASSERT_EQ(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_RELIABLE_UNORDERED, 0);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_TIMED, 0);
+    ASSERT_EQ(getUnalignedInt32BigEndian((PINT32)(pSctpSession->packet + SIZEOF(UINT32))), rtcDataChannelInit.maxPacketLifeTime.value);
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
@@ -501,9 +501,9 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_PartialReliabilityOrdered
     pKvsDataChannel = (PKvsDataChannel) pOfferDataChannel;
     pSctpSession = ((PKvsPeerConnection) pKvsDataChannel->pRtcPeerConnection)->pSctpSession;
     
-    ASSERT_NE(pSctpSession->spa.sendv_sndinfo.snd_flags, SCTP_UNORDERED);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_policy, SCTP_PR_SCTP_RTX);
-    ASSERT_EQ(pSctpSession->spa.sendv_prinfo.pr_value, rtcDataChannelInit.maxRetransmits.value);
+    ASSERT_EQ(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_RELIABLE_UNORDERED, 0);
+    ASSERT_NE(pSctpSession->packet[1] & DCEP_DATA_CHANNEL_REXMIT, 0);
+    ASSERT_EQ(getUnalignedInt32BigEndian((PINT32)(pSctpSession->packet + SIZEOF(UINT32))), rtcDataChannelInit.maxRetransmits.value);
 
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
@@ -586,6 +586,495 @@ TEST_F(DataChannelFunctionalityTest, createDataChannel_DataChannelMetricsTest)
     EXPECT_EQ(rtcMetrics.rtcStatsObject.rtcDataChannelStats.state, RTC_DATA_CHANNEL_STATE_OPEN);
 
     closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Context struct for registering message callback inside onDataChannel to avoid TSAN race.
+// The onMessage handler must be set before any messages can arrive on the channel.
+struct RemoteChannelCtx {
+    SIZE_T remoteDataChannel;
+    UINT64 msgCustomData;
+    RtcOnMessage msgCallback;
+};
+
+// Test byte-exact transmission with varied payload sizes and binary/string modes
+TEST_F(DataChannelFunctionalityTest, dataChannelSendRecvVariedPayloadSizes)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelLocalOpenCount = 0;
+    RtcStats rtcMetrics;
+    MEMSET(&rtcMetrics, 0x00, SIZEOF(RtcStats));
+    rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_DATA_CHANNEL;
+
+    // Track received messages: store (length, isBinary, first-byte) tuples
+    struct RecvState {
+        std::mutex lock;
+        std::vector<std::tuple<UINT32, BOOL, BYTE>> received;
+    };
+    RecvState recvState{};
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Register message callback inside onDataChannel to avoid race with connection listener thread
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        auto ctx = reinterpret_cast<RemoteChannelCtx*>(customData);
+        dataChannelOnMessage(pRtcDataChannel, ctx->msgCustomData, ctx->msgCallback);
+        ATOMIC_STORE((PSIZE_T) &ctx->remoteDataChannel, reinterpret_cast<UINT64>(pRtcDataChannel));
+    };
+
+    auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
+        UNUSED_PARAM(pDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RtcOnMessage recvMsgCallback = [](UINT64 customData, PRtcDataChannel pDataChannel, BOOL isBinary, PBYTE pMsg, UINT32 pMsgLen) {
+        UNUSED_PARAM(pDataChannel);
+        auto state = reinterpret_cast<RecvState*>(customData);
+        std::lock_guard<std::mutex> guard(state->lock);
+        BYTE firstByte = (pMsgLen > 0) ? pMsg[0] : 0;
+        state->received.emplace_back(pMsgLen, isBinary, firstByte);
+    };
+
+    RemoteChannelCtx remoteCtx{};
+    remoteCtx.msgCustomData = (UINT64) &recvState;
+    remoteCtx.msgCallback = recvMsgCallback;
+
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &remoteCtx, onDataChannel), STATUS_SUCCESS);
+
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "TestChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    EXPECT_EQ(dataChannelOnOpen(pOfferDataChannel, (UINT64) &datachannelLocalOpenCount, dataChannelOnOpenCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Set metrics identifier AFTER connection — allocateSctp() re-keys the hash table
+    // using SCTP stream IDs (channelId), which differ from the pre-connection id
+    rtcMetrics.rtcStatsObject.rtcDataChannelStats.dataChannelIdentifier = ((PKvsDataChannel) pOfferDataChannel)->channelId;
+
+    // Wait for DataChannel to open
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&datachannelLocalOpenCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelLocalOpenCount), 1);
+
+    // Wait for remote data channel to appear (message callback already registered in onDataChannel)
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&remoteCtx.remoteDataChannel) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_NE(ATOMIC_LOAD(&remoteCtx.remoteDataChannel), 0);
+
+    // Send payloads of varied sizes: 1, 64, 1024, 8192 bytes
+    UINT32 sizes[] = {1, 64, 1024, 8192};
+    UINT32 totalBytesSent = 0;
+    UINT32 totalMessagesSent = 0;
+
+    for (auto size : sizes) {
+        std::vector<BYTE> payload(size);
+        // Fill with a recognizable pattern: first byte = size & 0xFF
+        MEMSET(payload.data(), (BYTE)(size & 0xFF), size);
+
+        // Send as string (isBinary = FALSE)
+        EXPECT_EQ(dataChannelSend(pOfferDataChannel, FALSE, payload.data(), size), STATUS_SUCCESS);
+        totalBytesSent += size;
+        totalMessagesSent++;
+
+        // Send as binary (isBinary = TRUE)
+        payload[0] = (BYTE)((size & 0xFF) + 1); // Distinct marker for binary
+        EXPECT_EQ(dataChannelSend(pOfferDataChannel, TRUE, payload.data(), size), STATUS_SUCCESS);
+        totalBytesSent += size;
+        totalMessagesSent++;
+    }
+
+    // Wait for all messages to arrive (8 total: 4 sizes x 2 modes)
+    for (auto i = 0; i <= 30; i++) {
+        {
+            std::lock_guard<std::mutex> guard(recvState.lock);
+            if (recvState.received.size() >= 8) {
+                break;
+            }
+        }
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    // Verify metrics
+    EXPECT_EQ(rtcPeerConnectionGetMetrics(offerPc, NULL, &rtcMetrics), STATUS_SUCCESS);
+    EXPECT_EQ(rtcMetrics.rtcStatsObject.rtcDataChannelStats.messagesSent, totalMessagesSent);
+    EXPECT_EQ(rtcMetrics.rtcStatsObject.rtcDataChannelStats.bytesSent, totalBytesSent);
+    EXPECT_EQ(rtcMetrics.rtcStatsObject.rtcDataChannelStats.state, RTC_DATA_CHANNEL_STATE_OPEN);
+
+    {
+        std::lock_guard<std::mutex> guard(recvState.lock);
+        ASSERT_EQ(recvState.received.size(), 8);
+
+        // Verify sizes arrived correctly (string then binary for each size)
+        for (UINT32 idx = 0; idx < 4; idx++) {
+            UINT32 expectedSize = sizes[idx];
+            // String message
+            EXPECT_EQ(std::get<0>(recvState.received[idx * 2]), expectedSize);
+            // Binary message
+            EXPECT_EQ(std::get<0>(recvState.received[idx * 2 + 1]), expectedSize);
+        }
+    }
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Flood the DataChannel with rapid sends to verify no crashes, deadlocks, or leaks
+TEST_F(DataChannelFunctionalityTest, dataChannelFloodSend)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelLocalOpenCount = 0;
+    SIZE_T msgCount = 0;
+
+    static constexpr UINT32 FLOOD_MESSAGE_COUNT = 1000;
+    static constexpr UINT32 FLOOD_MESSAGE_SIZE = 32;
+    BYTE floodPayload[FLOOD_MESSAGE_SIZE];
+    MEMSET(floodPayload, 0xAB, FLOOD_MESSAGE_SIZE);
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Register message callback inside onDataChannel to avoid race with connection listener thread
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        auto ctx = reinterpret_cast<RemoteChannelCtx*>(customData);
+        dataChannelOnMessage(pRtcDataChannel, ctx->msgCustomData, ctx->msgCallback);
+        ATOMIC_STORE((PSIZE_T) &ctx->remoteDataChannel, reinterpret_cast<UINT64>(pRtcDataChannel));
+    };
+
+    auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
+        UNUSED_PARAM(pDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RtcOnMessage countMsgCallback = [](UINT64 customData, PRtcDataChannel pDataChannel, BOOL isBinary, PBYTE pMsg, UINT32 pMsgLen) {
+        UNUSED_PARAM(pDataChannel);
+        UNUSED_PARAM(isBinary);
+        UNUSED_PARAM(pMsg);
+        UNUSED_PARAM(pMsgLen);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RemoteChannelCtx remoteCtx{};
+    remoteCtx.msgCustomData = (UINT64) &msgCount;
+    remoteCtx.msgCallback = countMsgCallback;
+
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &remoteCtx, onDataChannel), STATUS_SUCCESS);
+
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "FloodChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    EXPECT_EQ(dataChannelOnOpen(pOfferDataChannel, (UINT64) &datachannelLocalOpenCount, dataChannelOnOpenCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Wait for channel to open
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&datachannelLocalOpenCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelLocalOpenCount), 1);
+
+    // Wait for remote data channel (message callback already registered in onDataChannel)
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&remoteCtx.remoteDataChannel) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_NE(ATOMIC_LOAD(&remoteCtx.remoteDataChannel), 0);
+
+    // Flood: send 1000 messages in a tight loop
+    UINT32 sendFailures = 0;
+    for (UINT32 i = 0; i < FLOOD_MESSAGE_COUNT; i++) {
+        STATUS status = dataChannelSend(pOfferDataChannel, FALSE, floodPayload, FLOOD_MESSAGE_SIZE);
+        if (status != STATUS_SUCCESS) {
+            sendFailures++;
+        }
+    }
+
+    // Wait for messages to be received (up to 30 seconds)
+    for (auto i = 0; i <= 30 && ATOMIC_LOAD(&msgCount) < FLOOD_MESSAGE_COUNT; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    // All sends should succeed
+    EXPECT_EQ(sendFailures, 0);
+    // All messages should arrive
+    EXPECT_EQ(ATOMIC_LOAD(&msgCount), FLOOD_MESSAGE_COUNT);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Multiple threads sending concurrently on the same DataChannel
+TEST_F(DataChannelFunctionalityTest, dataChannelConcurrentSends)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelLocalOpenCount = 0;
+    SIZE_T msgCount = 0;
+
+    static constexpr UINT32 NUM_THREADS = 4;
+    static constexpr UINT32 MESSAGES_PER_THREAD = 250;
+    static constexpr UINT32 TOTAL_MESSAGES = NUM_THREADS * MESSAGES_PER_THREAD;
+    static constexpr UINT32 MSG_SIZE = 32;
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Register message callback inside onDataChannel to avoid race with connection listener thread
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        auto ctx = reinterpret_cast<RemoteChannelCtx*>(customData);
+        dataChannelOnMessage(pRtcDataChannel, ctx->msgCustomData, ctx->msgCallback);
+        ATOMIC_STORE((PSIZE_T) &ctx->remoteDataChannel, reinterpret_cast<UINT64>(pRtcDataChannel));
+    };
+
+    auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
+        UNUSED_PARAM(pDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RtcOnMessage countMsgCallback = [](UINT64 customData, PRtcDataChannel pDataChannel, BOOL isBinary, PBYTE pMsg, UINT32 pMsgLen) {
+        UNUSED_PARAM(pDataChannel);
+        UNUSED_PARAM(isBinary);
+        UNUSED_PARAM(pMsg);
+        UNUSED_PARAM(pMsgLen);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RemoteChannelCtx remoteCtx{};
+    remoteCtx.msgCustomData = (UINT64) &msgCount;
+    remoteCtx.msgCallback = countMsgCallback;
+
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &remoteCtx, onDataChannel), STATUS_SUCCESS);
+
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "ConcurrentChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    EXPECT_EQ(dataChannelOnOpen(pOfferDataChannel, (UINT64) &datachannelLocalOpenCount, dataChannelOnOpenCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&datachannelLocalOpenCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelLocalOpenCount), 1);
+
+    // Wait for remote data channel (message callback already registered in onDataChannel)
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&remoteCtx.remoteDataChannel) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_NE(ATOMIC_LOAD(&remoteCtx.remoteDataChannel), 0);
+
+    // Spawn threads that all send on the same DataChannel
+    std::atomic<UINT32> totalSendFailures{0};
+    std::vector<std::thread> senderThreads;
+
+    for (UINT32 t = 0; t < NUM_THREADS; t++) {
+        senderThreads.emplace_back([&, t]() {
+            BYTE payload[MSG_SIZE];
+            // Each thread fills with a distinct marker byte
+            MEMSET(payload, (BYTE)(t + 1), MSG_SIZE);
+            for (UINT32 i = 0; i < MESSAGES_PER_THREAD; i++) {
+                STATUS status = dataChannelSend(pOfferDataChannel, FALSE, payload, MSG_SIZE);
+                if (status != STATUS_SUCCESS) {
+                    totalSendFailures.fetch_add(1);
+                }
+            }
+        });
+    }
+
+    // Wait for all sender threads to complete
+    for (auto& th : senderThreads) {
+        th.join();
+    }
+
+    // Wait for all messages to arrive (up to 30 seconds)
+    for (auto i = 0; i <= 30 && ATOMIC_LOAD(&msgCount) < TOTAL_MESSAGES; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    EXPECT_EQ(totalSendFailures.load(), 0);
+    EXPECT_EQ(ATOMIC_LOAD(&msgCount), TOTAL_MESSAGES);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Close the remote peer while a background thread is actively sending
+TEST_F(DataChannelFunctionalityTest, dataChannelSendDuringDisconnect)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelLocalOpenCount = 0;
+    SIZE_T remoteDataChannel = 0;
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        ATOMIC_STORE((PSIZE_T) customData, reinterpret_cast<UINT64>(pRtcDataChannel));
+    };
+
+    auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
+        UNUSED_PARAM(pDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &remoteDataChannel, onDataChannel), STATUS_SUCCESS);
+
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "DisconnectChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    EXPECT_EQ(dataChannelOnOpen(pOfferDataChannel, (UINT64) &datachannelLocalOpenCount, dataChannelOnOpenCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&datachannelLocalOpenCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelLocalOpenCount), 1);
+
+    // Spawn a thread that sends in a tight loop
+    std::atomic<bool> stopSending{false};
+    std::atomic<UINT32> sendCount{0};
+
+    std::thread senderThread([&]() {
+        BYTE payload[32];
+        MEMSET(payload, 0xCC, 32);
+        while (!stopSending.load()) {
+            // Ignore return status — we expect failures after close
+            dataChannelSend(pOfferDataChannel, FALSE, payload, 32);
+            sendCount.fetch_add(1);
+        }
+    });
+
+    // Let sender run briefly, then close the answer peer
+    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    closePeerConnection(answerPc);
+
+    // Let sender continue briefly after close to exercise the error path
+    THREAD_SLEEP(500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    stopSending.store(true);
+
+    senderThread.join();
+
+    // The key assertion: we got here without crashing or deadlocking
+    EXPECT_GT(sendCount.load(), 0u);
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Send on a DataChannel before the peer connection is established
+TEST_F(DataChannelFunctionalityTest, dataChannelSendBeforeConnect)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "PreConnectChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+
+    // pSctpSession is NULL before connection — send should fail cleanly
+    BYTE payload[] = "test payload";
+    STATUS sendStatus = dataChannelSend(pOfferDataChannel, FALSE, payload, SIZEOF(payload) - 1);
+    EXPECT_NE(sendStatus, STATUS_SUCCESS);
+
+    // Verify we didn't crash
+    freePeerConnection(&offerPc);
+}
+
+// Send on a DataChannel after the peer connection has been closed
+TEST_F(DataChannelFunctionalityTest, dataChannelSendAfterClose)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    PRtcDataChannel pOfferDataChannel = nullptr;
+    SIZE_T datachannelLocalOpenCount = 0;
+    SIZE_T msgCount = 0;
+
+    initRtcConfiguration(&configuration);
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    // Register message callback inside onDataChannel to avoid race with connection listener thread
+    auto onDataChannel = [](UINT64 customData, PRtcDataChannel pRtcDataChannel) {
+        auto ctx = reinterpret_cast<RemoteChannelCtx*>(customData);
+        dataChannelOnMessage(pRtcDataChannel, ctx->msgCustomData, ctx->msgCallback);
+        ATOMIC_STORE((PSIZE_T) &ctx->remoteDataChannel, reinterpret_cast<UINT64>(pRtcDataChannel));
+    };
+
+    auto dataChannelOnOpenCallback = [](UINT64 customData, PRtcDataChannel pDataChannel) {
+        UNUSED_PARAM(pDataChannel);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RtcOnMessage countMsgCallback = [](UINT64 customData, PRtcDataChannel pDataChannel, BOOL isBinary, PBYTE pMsg, UINT32 pMsgLen) {
+        UNUSED_PARAM(pDataChannel);
+        UNUSED_PARAM(isBinary);
+        UNUSED_PARAM(pMsg);
+        UNUSED_PARAM(pMsgLen);
+        ATOMIC_INCREMENT((PSIZE_T) customData);
+    };
+
+    RemoteChannelCtx remoteCtx{};
+    remoteCtx.msgCustomData = (UINT64) &msgCount;
+    remoteCtx.msgCallback = countMsgCallback;
+
+    EXPECT_EQ(peerConnectionOnDataChannel(answerPc, (UINT64) &remoteCtx, onDataChannel), STATUS_SUCCESS);
+
+    EXPECT_EQ(createDataChannel(offerPc, (PCHAR) "PostCloseChannel", nullptr, &pOfferDataChannel), STATUS_SUCCESS);
+    EXPECT_EQ(dataChannelOnOpen(pOfferDataChannel, (UINT64) &datachannelLocalOpenCount, dataChannelOnOpenCallback), STATUS_SUCCESS);
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    // Wait for channel to open
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&datachannelLocalOpenCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_EQ(ATOMIC_LOAD(&datachannelLocalOpenCount), 1);
+
+    // Wait for remote channel (message callback already registered in onDataChannel)
+    for (auto i = 0; i <= 100 && ATOMIC_LOAD(&remoteCtx.remoteDataChannel) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    ASSERT_NE(ATOMIC_LOAD(&remoteCtx.remoteDataChannel), 0);
+
+    // Confirm a message works before close
+    BYTE payload[] = "pre-close message";
+    EXPECT_EQ(dataChannelSend(pOfferDataChannel, FALSE, payload, SIZEOF(payload) - 1), STATUS_SUCCESS);
+
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&msgCount) == 0; i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    EXPECT_EQ(ATOMIC_LOAD(&msgCount), 1);
+
+    // Close the sender's peer connection
+    closePeerConnection(offerPc);
+
+    // Attempt to send after close — should not crash
+    BYTE postClosePayload[] = "post-close message";
+    dataChannelSend(pOfferDataChannel, FALSE, postClosePayload, SIZEOF(postClosePayload) - 1);
+
+    // The key assertion: we got here without crashing
     closePeerConnection(answerPc);
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Made DataChannel diagnostics counters thread-safe using atomic operations
- Updated partial-reliability tests to assert on DCEP packet bytes instead of internal `spa` struct fields
- Added 6 new DataChannel stress and edge-case tests

*Why was it changed?*
- The `messagesSent`/`bytesSent`/`messagesReceived`/`bytesReceived` counters in `KvsDataChannel` were updated from both the SCTP callback thread and the send thread without synchronization, causing data races (detected by TSAN)
- The partial-reliability tests relied on internal usrsctp `spa` struct fields that are not portable; asserting on the DCEP packet bytes is more robust

*How was it changed?*
- Added `atomicMessagesSent`, `atomicBytesSent`, `atomicMessagesReceived`, `atomicBytesReceived` fields to `KvsDataChannel`
- Replaced direct struct increments in `dataChannelSend` and `onSctpSessionDataChannelMessage` with `ATOMIC_INCREMENT`/`ATOMIC_ADD`
- Updated `getDataChannelStats` in Metrics.c to read from atomic fields via `ATOMIC_LOAD`
- Updated 4 partial-reliability tests to assert on DCEP packet bytes (`packet[1]` flags and `getUnalignedInt32BigEndian`) instead of `spa` struct fields

*What testing was done for the changes?*
- Added `dataChannelSendRecvVariedPayloadSizes`: sends 1/64/1024/8192 byte payloads in both binary and string mode, verifies byte-exact delivery and metrics
- Added `dataChannelFloodSend`: sends 1000 messages in a tight loop, verifies all arrive without drops
- Added `dataChannelConcurrentSends`: 4 threads sending 250 messages each concurrently on the same channel, verifies all 1000 arrive
- Added `dataChannelSendDuringDisconnect`: sends from a background thread while the remote peer is closed, verifies no crash or deadlock
- Added `dataChannelSendBeforeConnect`: sends before peer connection is established, verifies clean failure
- Added `dataChannelSendAfterClose`: sends after `closePeerConnection`, verifies no crash

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.