### PR TITLE
Fix duplicate struct members in KvsPeerConnection

### DIFF
--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -168,11 +168,6 @@ typedef struct {
     PTwccReceiverManager pTwccReceiverManager;
     UINT32 twccFeedbackTimerId;
 
-    // TWCC feedback generation (receiver side)
-    MUTEX twccReceiverLock;
-    PTwccReceiverManager pTwccReceiverManager;
-    UINT32 twccFeedbackTimerId;
-
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;
 } KvsPeerConnection, *PKvsPeerConnection;


### PR DESCRIPTION
*Issue #, if available:*
- N/A

*What was changed?*
- Removed duplicate struct members (`twccReceiverLock`, `pTwccReceiverManager`, `twccFeedbackTimerId`) from the `KvsPeerConnection` struct in `PeerConnection.h`

*Why was it changed?*
- PR #17 (GCC/TWCC) was stacked on PR #15 and squash-merged without rebasing onto updated main, causing the TWCC receiver-side fields to appear twice. This breaks compilation on all platforms with `error: duplicate member` errors.

*How was it changed?*
- Deleted the duplicate 5-line block (lines 171-175) in `src/source/PeerConnection/PeerConnection.h` that was an exact copy of lines 166-170

*What testing was done for the changes?*
- Verified the previously failing translation units (`PeerConnection.c`, `Dtls.c`, `IceAgent.c`) compile successfully after the fix
- CI should pass on all platforms (Linux, macOS, Android)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.