### PR TITLE
potential null ptr dereference fix

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1445,7 +1445,7 @@ UINT32 parseExtId(PCHAR extmapValue)
 {
     ENTERS();
     UINT32 extid = 0;
-    if (extmapValue == NULL && STRCHR(extmapValue, ' ') == NULL) {
+    if (extmapValue == NULL || STRCHR(extmapValue, ' ') == NULL) {
         LEAVES();
         return 0;
     }


### PR DESCRIPTION
*What was changed?*

Fixed a logic error in `parseExtId` in PeerConnection.c where `&&` was used instead of `||` for a null pointer guard.

*Why was it changed?*

The original condition `extmapValue == NULL && STRCHR(extmapValue, ' ') == NULL` would dereference `extmapValue` even when it was NULL, causing a potential null pointer dereference crash.

*How was it changed?*

Changed the `&&` operator to `||` so the function returns early if `extmapValue` is NULL *or* if it does not contain a space character, preventing the null dereference.

*What testing was done for the changes?*

Code review confirmed the fix matches the intended short-circuit logic. Existing unit tests continue to pass.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.