### PR TITLE
timestamp conversion tests

### DIFF
--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -631,6 +631,51 @@ TEST_F(RtpFunctionalityTest, twccPayload)
     EXPECT_EQ(0, ptr[3]);
 }
 
+TEST_F(RtpFunctionalityTest, rtpTimestampConversion)
+{
+    UINT64 rtpTs, hundredNsTs;
+
+    // Video 90kHz: 1 second of RTP timestamps should equal HUNDREDS_OF_NANOS_IN_A_SECOND
+    rtpTs = VIDEO_CLOCKRATE; // 90000 = 1 second
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, VIDEO_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_SECOND, hundredNsTs);
+
+    // Opus 48kHz: 1 second
+    rtpTs = OPUS_CLOCKRATE; // 48000 = 1 second
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, OPUS_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_SECOND, hundredNsTs);
+
+    // G.711 8kHz: 1 second
+    rtpTs = PCM_CLOCKRATE; // 8000 = 1 second
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, PCM_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(HUNDREDS_OF_NANOS_IN_A_SECOND, hundredNsTs);
+
+    // Roundtrip: 100ns -> RTP -> 100ns should preserve the value
+    // Video at 25fps: each frame is 1/25 second (divides evenly into 90kHz)
+    UINT64 originalTs = HUNDREDS_OF_NANOS_IN_A_SECOND / 25;
+    rtpTs = CONVERT_TIMESTAMP_TO_RTP(VIDEO_CLOCKRATE, originalTs);
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, VIDEO_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(originalTs, hundredNsTs);
+
+    // Opus at 20ms frames (typical)
+    originalTs = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    rtpTs = CONVERT_TIMESTAMP_TO_RTP(OPUS_CLOCKRATE, originalTs);
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, OPUS_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(originalTs, hundredNsTs);
+
+    // G.711 at 20ms frames
+    originalTs = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    rtpTs = CONVERT_TIMESTAMP_TO_RTP(PCM_CLOCKRATE, originalTs);
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, PCM_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(originalTs, hundredNsTs);
+
+    // Larger timestamp: 60 seconds of video
+    originalTs = 60 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    rtpTs = CONVERT_TIMESTAMP_TO_RTP(VIDEO_CLOCKRATE, originalTs);
+    hundredNsTs = KVS_CONVERT_TIMESCALE(rtpTs, VIDEO_CLOCKRATE, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    EXPECT_EQ(originalTs, hundredNsTs);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*What was changed?*

Added unit tests for RTP timestamp conversion functions (KVS_CONVERT_TIMESCALE and CONVERT_TIMESTAMP_TO_RTP) covering Video 90kHz, Opus 48kHz, and G.711 8kHz clock rates.

*Why was it changed?*

To verify correctness of timestamp conversion between 100-nanosecond units and RTP timescales, ensuring roundtrip conversions preserve values for all supported codec clock rates.

*How was it changed?*

Added a new test case `rtpTimestampConversion` in RtpFunctionalityTest that validates:
- 1-second conversions for each clock rate (90kHz, 48kHz, 8kHz)
- Roundtrip 100ns-to-RTP-to-100ns at typical frame intervals (25fps video, 20ms Opus, 20ms G.711)
- Larger timestamp roundtrip (60 seconds of video)

*What testing was done for the changes?*

The change itself is a new test. It was compiled and run successfully as part of the existing test suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.