### PR TITLE
Add getLocalhostIpAddresses unit tests

### DIFF
--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -711,6 +711,131 @@ TEST_F(IceFunctionalityTest, IceAgentPruneUnconnectedIceCandidatePairUnitTest)
     EXPECT_EQ(STATUS_SUCCESS, doubleListFree(iceAgent.iceCandidatePairs));
 }
 
+///////////////////////////////////////////////
+// getLocalhostIpAddresses Test
+///////////////////////////////////////////////
+
+static BOOL rejectAllInterfacesFilter(UINT64 customData, PCHAR interfaceName)
+{
+    UNUSED_PARAM(interfaceName);
+    UNUSED_PARAM(customData);
+    return FALSE;
+}
+
+static BOOL acceptAllInterfacesFilter(UINT64 customData, PCHAR interfaceName)
+{
+    UNUSED_PARAM(interfaceName);
+    UNUSED_PARAM(customData);
+    return TRUE;
+}
+
+static BOOL countingFilter(UINT64 customData, PCHAR interfaceName)
+{
+    UNUSED_PARAM(interfaceName);
+    PUINT32 pCount = (PUINT32) customData;
+    (*pCount)++;
+    return TRUE;
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesNullArgTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCount = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+
+    EXPECT_EQ(STATUS_NULL_ARG, getLocalhostIpAddresses(NULL, &ipCount, NULL, 0));
+    EXPECT_EQ(STATUS_NULL_ARG, getLocalhostIpAddresses(ipAddresses, NULL, NULL, 0));
+    EXPECT_EQ(STATUS_NULL_ARG, getLocalhostIpAddresses(NULL, NULL, NULL, 0));
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesZeroLenTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCount = 0;
+
+    EXPECT_EQ(STATUS_INVALID_ARG, getLocalhostIpAddresses(ipAddresses, &ipCount, NULL, 0));
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesBasicTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCount = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCount, NULL, 0));
+
+    // Any machine running tests should have at least one non-loopback interface
+    EXPECT_GT(ipCount, (UINT32) 0);
+
+    // Verify returned addresses have valid family types and port is 0
+    CHAR ipAddrStr[KVS_IP_ADDRESS_STRING_BUFFER_LEN];
+    for (UINT32 i = 0; i < ipCount; i++) {
+        EXPECT_TRUE(ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV4 || ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV6);
+        EXPECT_EQ((UINT16) 0, ipAddresses[i].port);
+        EXPECT_EQ(STATUS_SUCCESS, getIpAddrStr(&ipAddresses[i], ipAddrStr, SIZEOF(ipAddrStr)));
+        DLOGD("Found interface %u: %s (%s)", i, ipAddrStr,
+              ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV4 ? "IPv4" : "IPv6");
+    }
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesFilterRejectAllTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCount = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCount, rejectAllInterfacesFilter, 0));
+
+    // Filter rejects everything, so no IPs should be returned
+    EXPECT_EQ((UINT32) 0, ipCount);
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesFilterAcceptAllTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCountNoFilter = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+    UINT32 ipCountWithFilter = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCountNoFilter, NULL, 0));
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCountWithFilter, acceptAllInterfacesFilter, 0));
+
+    // Accept-all filter should yield the same count as no filter
+    EXPECT_EQ(ipCountNoFilter, ipCountWithFilter);
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesSmallBufferTest)
+{
+    KvsIpAddress ipAddresses[1];
+    UINT32 ipCount = 1;
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCount, NULL, 0));
+
+    // With buffer size 1, should return at most 1
+    EXPECT_TRUE(ipCount <= 1);
+    if (ipCount == 1) {
+        EXPECT_TRUE(ipAddresses[0].family == KVS_IP_FAMILY_TYPE_IPV4 || ipAddresses[0].family == KVS_IP_FAMILY_TYPE_IPV6);
+    }
+}
+
+TEST_F(IceFunctionalityTest, getLocalhostIpAddressesFilterCustomDataTest)
+{
+    KvsIpAddress ipAddresses[MAX_LOCAL_NETWORK_INTERFACE_COUNT];
+    UINT32 ipCount = MAX_LOCAL_NETWORK_INTERFACE_COUNT;
+    UINT32 filterCallCount = 0;
+
+    MEMSET(ipAddresses, 0x00, SIZEOF(ipAddresses));
+    EXPECT_EQ(STATUS_SUCCESS, getLocalhostIpAddresses(ipAddresses, &ipCount, countingFilter, (UINT64) &filterCallCount));
+
+    // The filter should have been called at least once (once per candidate interface)
+    EXPECT_GT(filterCallCount, (UINT32) 0);
+    // filterCallCount >= ipCount because some IPv6 link-local/site-local addresses
+    // are skipped after the filter runs
+    EXPECT_GE(filterCallCount, ipCount);
+}
+
 TEST_F(IceFunctionalityTest, DISABLED_IceAgentCandidateGatheringTest)
 {
     ASSERT_EQ(TRUE, mAccessKeyIdSet);


### PR DESCRIPTION
*What was changed?*

Added unit tests for the `getLocalhostIpAddresses` function covering null/invalid arguments, basic enumeration, interface filtering (reject-all, accept-all, custom data), and small buffer handling.

*Why was it changed?*

To improve test coverage for the localhost IP address enumeration logic and verify that the interface filter callback and custom data parameter work correctly.

*How was it changed?*

Added 7 new test cases in IceFunctionalityTest:
- Null argument validation (STATUS_NULL_ARG)
- Zero-length buffer validation (STATUS_INVALID_ARG)
- Basic enumeration verifying valid address families and zero port
- Reject-all filter returning zero addresses
- Accept-all filter matching no-filter count
- Small buffer (size 1) returning at most one address
- Counting filter verifying custom data passthrough and call count

*What testing was done for the changes?*

The changes are new tests themselves. They were compiled and run successfully as part of the existing test suite.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.