### PR TITLE
Jitter buffer improvements with partial frame callback 

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -2020,6 +2020,17 @@ PUBLIC_API STATUS addTransceiver(PRtcPeerConnection, PRtcMediaStreamTrack, PRtcR
 PUBLIC_API STATUS transceiverOnFrame(PRtcRtpTransceiver, UINT64, RtcOnFrame);
 
 /**
+ * @brief Set a callback for partially delivered frames (when some packets are lost/dropped)
+ *
+ * @param[in] PRtcRtpTransceiver Populated RtcRtpTransceiver struct
+ * @param[in] UINT64 User customData that will be passed along when RtcOnFrame is called
+ * @param[in] RtcOnFrame User RtcOnFrame callback for partial frames
+ *
+ * @return STATUS code of the execution. STATUS_SUCCESS on success
+ */
+PUBLIC_API STATUS transceiverOnPartialFrame(PRtcRtpTransceiver, UINT64, RtcOnFrame);
+
+/**
  * @brief Set a callback for bandwidth estimation results
  *
  * @param[in] PRtcRtpTransceiver Populated RtcRtpTransceiver struct

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -74,8 +74,29 @@ STATUS freeJitterBuffer(PJitterBuffer* ppJitterBuffer)
 
     pJitterBuffer = *ppJitterBuffer;
 
-    jitterBufferInternalParse(pJitterBuffer, TRUE);
-    jitterBufferDropBufferData(pJitterBuffer, 0, MAX_RTP_SEQUENCE_NUM, 0);
+    // Parse repeatedly until all frames are processed.
+    // After marker bit delivery, the parse breaks early, so we need to loop
+    // to ensure all remaining frames are delivered/dropped.
+    if (pJitterBuffer->started) {
+        UINT16 prevHead = pJitterBuffer->headSequenceNumber;
+        UINT32 maxIterations = 65536; // Safety limit to prevent infinite loops
+        while (maxIterations-- > 0) {
+            jitterBufferInternalParse(pJitterBuffer, TRUE);
+            // If head didn't advance, we're done or stuck
+            if (pJitterBuffer->headSequenceNumber == prevHead) {
+                break;
+            }
+            // If we've processed everything, we're done
+            // Use signed comparison to handle wraparound
+            INT32 remaining = (INT32) ((UINT16) (pJitterBuffer->tailSequenceNumber - pJitterBuffer->headSequenceNumber + 1));
+            if (remaining <= 0) {
+                break;
+            }
+            prevHead = pJitterBuffer->headSequenceNumber;
+        }
+        // Clean up any remaining packets that weren't delivered/dropped
+        jitterBufferDropBufferData(pJitterBuffer, pJitterBuffer->headSequenceNumber, pJitterBuffer->tailSequenceNumber, 0);
+    }
     hashTableFree(pJitterBuffer->pPkgBufferHashTable);
 
     SAFE_MEMFREE(*ppJitterBuffer);
@@ -259,7 +280,10 @@ BOOL enterTimestampOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPac
         }
         // underflow check
         else if (pJitterBuffer->headTimestamp < pRtpPacket->header.timestamp && pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
-            if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+            // Only detect underflow if headSequenceNumberCheck actually updates the head (meaning packet is EARLIER than expected).
+            // Don't trigger underflow if packet is exactly at headSequenceNumber (that's the expected next packet, not underflow).
+            UINT16 prevHead = pJitterBuffer->headSequenceNumber;
+            if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket) && pJitterBuffer->headSequenceNumber != prevHead) {
                 underflow = TRUE;
             }
         }
@@ -472,6 +496,7 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     UINT16 lastIndex;
     UINT32 earliestAllowedTimestamp = 0;
     BOOL isFrameDataContinuous = TRUE;
+    BOOL headFrameIsContiguous = TRUE; // Track continuity for head frame only
     UINT32 curTimestamp = 0;
     UINT16 startDropIndex = 0;
     UINT32 curFrameSize = 0;
@@ -479,6 +504,11 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     UINT64 hashValue = 0;
     BOOL isStart = FALSE, containStartForEarliestFrame = FALSE, hasEntry = FALSE;
     UINT16 lastNonNullIndex = 0;
+    UINT16 lastHeadFrameSeqNum = 0;    // Last seq number seen with head timestamp
+    BOOL seenHeadFramePacket = FALSE;  // Whether we've seen any packet from head frame
+    UINT16 firstGapIndex = 0;          // First gap sequence number since last frame boundary
+    BOOL sawGapSinceLastFrame = FALSE; // Whether we've seen any gap since last frame boundary
+    BOOL headFrameEnded = FALSE;       // Whether head frame's last packet had marker bit (complete frame)
     PRtpPacket pCurPacket = NULL;
 
     CHK(pJitterBuffer != NULL && pJitterBuffer->onFrameDroppedFn != NULL && pJitterBuffer->onFrameReadyFn != NULL, STATUS_NULL_ARG);
@@ -510,6 +540,17 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
         CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
         if (!hasEntry) {
             isFrameDataContinuous = FALSE;
+            // Track where first gap is found - we'll determine at frame boundary if it's in head frame
+            if (!sawGapSinceLastFrame) {
+                firstGapIndex = index;
+                sawGapSinceLastFrame = TRUE;
+            }
+            // If we've seen head frame packets but not the marker bit yet, this gap might be in the head frame.
+            // Set headFrameIsContiguous=FALSE proactively to prevent incorrect marker bit delivery.
+            // If the gap turns out to be in a later frame, headFrameIsContiguous will be reset at frame boundary.
+            if (seenHeadFramePacket && !headFrameEnded) {
+                headFrameIsContiguous = FALSE;
+            }
             // if the max latency has not been reached, or the buffer is not being closed, exit parse when a missing entry is found
             CHK(pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed, retStatus);
         } else {
@@ -524,10 +565,38 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
             pCurPacket = (PRtpPacket) hashValue;
             CHK(pCurPacket != NULL, STATUS_NULL_ARG);
             curTimestamp = pCurPacket->header.timestamp;
+
+            // Track packets belonging to the head frame
+            if (curTimestamp == pJitterBuffer->headTimestamp) {
+                lastHeadFrameSeqNum = index;
+                seenHeadFramePacket = TRUE;
+                // Track if this packet has marker bit (indicates end of frame)
+                if (pCurPacket->header.marker) {
+                    headFrameEnded = TRUE;
+                }
+            }
+
             // new timestamp on an RTP packet means new frame
             if (curTimestamp != pJitterBuffer->headTimestamp) {
+                // Determine if head frame is contiguous by checking if any gaps are within its range
+                // Key insight: If head frame's last packet had marker bit, the frame is complete.
+                // Any gap AFTER that is in the next frame, not the head frame.
+                if (sawGapSinceLastFrame && seenHeadFramePacket) {
+                    // Only evaluate continuity if we've actually seen head frame packets.
+                    // If seenHeadFramePacket=FALSE, the head frame was already delivered via marker
+                    // and any gaps are in inter-frame space, not the head frame.
+                    if (firstGapIndex <= lastHeadFrameSeqNum) {
+                        // Gap is within head frame's known packet range
+                        headFrameIsContiguous = FALSE;
+                    } else if (!headFrameEnded) {
+                        // Gap is after last seen head packet, but head frame didn't have marker bit
+                        // The gap might still be in the head frame (frame not complete)
+                        headFrameIsContiguous = FALSE;
+                    }
+                    // else: gap is AFTER head frame's marker bit, so it's in next frame
+                }
                 // was previous frame complete? Deliver it
-                if (containStartForEarliestFrame && isFrameDataContinuous) {
+                if (containStartForEarliestFrame && headFrameIsContiguous) {
                     // Decrement the index because this is an inclusive end parser, and we don't want to include the current index in the processed
                     // frame.
                     CHK_STATUS(pJitterBuffer->onFrameReadyFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), curFrameSize));
@@ -535,19 +604,52 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                     pJitterBuffer->firstFrameProcessed = TRUE;
                     startDropIndex = index;
                     containStartForEarliestFrame = FALSE;
+                    // Reset tracking for the new head frame
+                    headFrameIsContiguous = TRUE;
+                    sawGapSinceLastFrame = FALSE;
+                    // Track the current packet as the new head frame's first packet
+                    // (headTimestamp was just updated to curTimestamp by jitterBufferDropBufferData)
+                    lastHeadFrameSeqNum = index;
+                    seenHeadFramePacket = TRUE;
+                    headFrameEnded = pCurPacket->header.marker;
                 }
                 // are we forcibly clearing out the buffer? if so drop the contents of incomplete frame
-                else if (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed) {
+                // Only force clear if:
+                // 1. We've seen head frame packets (seenHeadFramePacket) - otherwise there's nothing to drop
+                // 2. There are packets to drop (startDropIndex != index)
+                // If seenHeadFramePacket=FALSE, the head frame was already delivered via marker bit
+                // and we should go to the else block to reset state for the new frame.
+                else if (seenHeadFramePacket && startDropIndex != index &&
+                         (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed)) {
                     // do not CHK_STATUS of onFrameDropped because we need to clear the jitter buffer no matter what else happens.
                     pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp);
                     CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));
                     pJitterBuffer->firstFrameProcessed = TRUE;
                     isFrameDataContinuous = TRUE;
+                    // Reset tracking for the new head frame
+                    headFrameIsContiguous = TRUE;
+                    sawGapSinceLastFrame = FALSE;
+                    // Track the current packet as the new head frame's first packet
+                    // (headTimestamp was just updated to curTimestamp by jitterBufferDropBufferData)
+                    lastHeadFrameSeqNum = index;
+                    seenHeadFramePacket = TRUE;
+                    headFrameEnded = pCurPacket->header.marker;
                     startDropIndex = index;
-                } else {
+                } else if (seenHeadFramePacket) {
                     // if you're here, it means we're not force clearing the buffer, and the previous frame must be missing its starting packet.
                     // The starting packet isn't going to be found at an incremental sequence number, so we can save some time and break here.
                     break;
+                } else {
+                    // No head frame packets were seen - the head frame was likely already delivered via marker bit.
+                    // Update state for the new frame and continue processing.
+                    pJitterBuffer->headTimestamp = curTimestamp;
+                    startDropIndex = index;
+                    // Track the current packet as the new head frame's first packet
+                    lastHeadFrameSeqNum = index;
+                    seenHeadFramePacket = TRUE;
+                    headFrameEnded = pCurPacket->header.marker;
+                    headFrameIsContiguous = TRUE;
+                    sawGapSinceLastFrame = FALSE;
                 }
                 // new timestamp means new frame, drop tracking for previous frame size
                 curFrameSize = 0;
@@ -559,6 +661,25 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
             curFrameSize += partialFrameSize;
             if (isStart && pJitterBuffer->headTimestamp == curTimestamp) {
                 containStartForEarliestFrame = TRUE;
+            }
+
+            // Immediate marker bit delivery: if we have a complete frame (start + marker + no gaps), deliver now
+            // This reduces latency by not waiting for the next frame's first packet
+            // Use headFrameIsContiguous (per-frame tracking) instead of isFrameDataContinuous (global) for consistency
+            // with the frame boundary delivery logic
+            if (curTimestamp == pJitterBuffer->headTimestamp && pCurPacket->header.marker && containStartForEarliestFrame && headFrameIsContiguous) {
+                // Frame is complete: has start, has marker, all packets contiguous
+                CHK_STATUS(pJitterBuffer->onFrameReadyFn(pJitterBuffer->customData, startDropIndex, index, curFrameSize));
+                CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, index, curTimestamp));
+                pJitterBuffer->firstFrameProcessed = TRUE;
+                // Update startDropIndex so the bufferClosed block doesn't try to re-deliver
+                startDropIndex = index + 1;
+                curFrameSize = 0;
+                // Note: jitterBufferDropBufferData sets headTimestamp to curTimestamp (delivered frame's timestamp)
+                // since we don't know the next frame's timestamp yet. Break here and let the next parse
+                // correctly detect the frame boundary via the else branch at lines 606-617.
+                // When buffer is being closed, freeJitterBuffer will call parse repeatedly until all frames are done.
+                break;
             }
         }
     }

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -500,6 +500,7 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     UINT32 curTimestamp = 0;
     UINT16 startDropIndex = 0;
     UINT32 curFrameSize = 0;
+    BOOL sizeCalcIsFirst = TRUE; // tracks first packet in frame for start code size calculation
     UINT32 partialFrameSize = 0;
     UINT64 hashValue = 0;
     BOOL isStart = FALSE, containStartForEarliestFrame = FALSE, hasEntry = FALSE;
@@ -653,12 +654,15 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                 }
                 // new timestamp means new frame, drop tracking for previous frame size
                 curFrameSize = 0;
+                sizeCalcIsFirst = TRUE;
             }
 
-            // With the missing output buffer parameter, this will only return the size of the packet, and identify if it is a starting packet of a
-            // frame
+            // Size-only call: pass sizeCalcIsFirst as input so start code size matches jitterBufferFillFrameData.
+            // The depayloader reads *pIsStart for start code choice, then overwrites with isStartingPacket output.
+            isStart = sizeCalcIsFirst;
             CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
             curFrameSize += partialFrameSize;
+            sizeCalcIsFirst = FALSE;
             if (isStart && pJitterBuffer->headTimestamp == curTimestamp) {
                 containStartForEarliestFrame = TRUE;
             }
@@ -675,6 +679,7 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
                 // Update startDropIndex so the bufferClosed block doesn't try to re-deliver
                 startDropIndex = index + 1;
                 curFrameSize = 0;
+                sizeCalcIsFirst = TRUE;
                 // Note: jitterBufferDropBufferData sets headTimestamp to curTimestamp (delivered frame's timestamp)
                 // since we don't know the next frame's timestamp yet. Break here and let the next parse
                 // correctly detect the frame boundary via the else branch at lines 606-617.
@@ -687,14 +692,17 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     // Deal with last frame, we're force clearing the entire buffer.
     if (bufferClosed && curFrameSize > 0) {
         curFrameSize = 0;
+        sizeCalcIsFirst = TRUE;
         hasEntry = TRUE;
         for (index = startDropIndex; UINT16_DEC(index) != lastNonNullIndex && hasEntry; index++) {
             CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
             if (hasEntry) {
                 CHK_STATUS(hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
                 pCurPacket = (PRtpPacket) hashValue;
-                CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, NULL));
+                isStart = sizeCalcIsFirst;
+                CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
                 curFrameSize += partialFrameSize;
+                sizeCalcIsFirst = FALSE;
             }
         }
 
@@ -767,15 +775,17 @@ STATUS jitterBufferFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT
     UINT32 partialFrameSize = 0;
 
     CHK(pJitterBuffer != NULL && pFrame != NULL && pFilledSize != NULL, STATUS_NULL_ARG);
+    BOOL isFirstInFrame = TRUE;
     for (; UINT16_DEC(index) != endIndex; index++) {
         hashValue = 0;
         CHK_STATUS(hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
         pCurPacket = (PRtpPacket) hashValue;
         CHK(pCurPacket != NULL, STATUS_NULL_ARG);
         partialFrameSize = remainingFrameSize;
-        CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, NULL));
+        CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &isFirstInFrame));
         pCurPtrInFrame += partialFrameSize;
         remainingFrameSize -= partialFrameSize;
+        isFirstInFrame = FALSE;
     }
 
 CleanUp:

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -497,13 +497,27 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     CHK(pTransceiver->onPartialFrame != NULL, retStatus);
 
     // Calculate total size of available packets
+    // NOTE: use local status instead of CHK_STATUS to avoid aborting the entire
+    // frame when a single packet's depay fails (e.g. truncated FU-A fragment).
+    BOOL isFirstInFrame = TRUE;
     for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
-        CHK_STATUS(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        if (STATUS_FAILED(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry))) {
+            continue;
+        }
         if (hasEntry) {
-            CHK_STATUS(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+            if (STATUS_FAILED(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue))) {
+                continue;
+            }
             pPacket = (PRtpPacket) hashValue;
-            CHK_STATUS(pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, NULL, &partialFrameSize, NULL));
+            partialFrameSize = 0;
+            BOOL depayIsFirst = isFirstInFrame;
+            if (STATUS_FAILED(
+                    pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, NULL, &partialFrameSize, &depayIsFirst))) {
+                DLOGW("depayPayloadFn size query failed for packet index %u, skipping", index);
+                continue;
+            }
             totalPartialSize += partialFrameSize;
+            isFirstInFrame = FALSE;
         }
     }
 
@@ -519,17 +533,28 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     }
 
     // Fill partial frame data (skipping missing packets)
+    // NOTE: continue on failure — same rationale as the size calculation loop.
+    isFirstInFrame = TRUE;
     pCurPtrInFrame = pTransceiver->peerFrameBuffer;
     for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
-        CHK_STATUS(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        if (STATUS_FAILED(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry))) {
+            continue;
+        }
         if (hasEntry) {
-            CHK_STATUS(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+            if (STATUS_FAILED(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue))) {
+                continue;
+            }
             pPacket = (PRtpPacket) hashValue;
             partialFrameSize = totalPartialSize - filledSize;
-            CHK_STATUS(
-                pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, NULL));
+            BOOL depayIsFirst = isFirstInFrame;
+            if (STATUS_FAILED(pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize,
+                                                                          &depayIsFirst))) {
+                DLOGW("depayPayloadFn fill failed for packet index %u, skipping", index);
+                continue;
+            }
             pCurPtrInFrame += partialFrameSize;
             filledSize += partialFrameSize;
+            isFirstInFrame = FALSE;
         }
     }
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -459,28 +459,91 @@ CleanUp:
 STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, UINT32 timestamp)
 {
     ENTERS();
-    UNUSED_PARAM(endIndex);
     STATUS retStatus = STATUS_SUCCESS;
     UINT64 hashValue = 0;
     PRtpPacket pPacket = NULL;
+    PRtpPacket pFirstPacket = NULL;
     PKvsRtpTransceiver pTransceiver = (PKvsRtpTransceiver) customData;
-    DLOGW("Frame with timestamp %ld is dropped!", timestamp);
+    UINT16 index;
+    UINT32 partialFrameSize = 0;
+    UINT32 totalPartialSize = 0;
+    UINT32 filledSize = 0;
+    PBYTE pCurPtrInFrame = NULL;
+    Frame frame;
+    BOOL hasEntry = FALSE;
+
+    DLOGW("Frame with timestamp %u is dropped!", timestamp);
     CHK(pTransceiver != NULL, STATUS_NULL_ARG);
+
+    // Get first available packet for stats and timestamp
     retStatus = hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, startIndex, &hashValue);
-    pPacket = (PRtpPacket) hashValue;
+    pFirstPacket = (PRtpPacket) hashValue;
     if (retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT) {
         retStatus = STATUS_SUCCESS;
     } else {
         CHK(FALSE, retStatus);
     }
-    CHK(pPacket != NULL, STATUS_NULL_ARG);
+    CHK(pFirstPacket != NULL, STATUS_NULL_ARG);
+
     MUTEX_LOCK(pTransceiver->statsLock);
     // https://www.w3.org/TR/webrtc-stats/#dom-rtcinboundrtpstreamstats-jitterbufferdelay
-    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pTransceiver->inboundStats.jitterBufferDelay += (DOUBLE) (GETTIME() - pFirstPacket->receivedTime) / HUNDREDS_OF_NANOS_IN_A_SECOND;
     pTransceiver->inboundStats.jitterBufferEmittedCount++;
     pTransceiver->inboundStats.received.framesDropped++;
     pTransceiver->inboundStats.received.fullFramesLost++;
     MUTEX_UNLOCK(pTransceiver->statsLock);
+
+    // If no partial frame callback registered, skip partial frame extraction
+    CHK(pTransceiver->onPartialFrame != NULL, retStatus);
+
+    // Calculate total size of available packets
+    for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
+        CHK_STATUS(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        if (hasEntry) {
+            CHK_STATUS(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+            pPacket = (PRtpPacket) hashValue;
+            CHK_STATUS(pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, NULL, &partialFrameSize, NULL));
+            totalPartialSize += partialFrameSize;
+        }
+    }
+
+    // If no data available, skip callback
+    CHK(totalPartialSize > 0, retStatus);
+
+    // Ensure buffer is large enough
+    if (totalPartialSize > pTransceiver->peerFrameBufferSize) {
+        MEMFREE(pTransceiver->peerFrameBuffer);
+        pTransceiver->peerFrameBufferSize = (UINT32) (totalPartialSize * PEER_FRAME_BUFFER_SIZE_INCREMENT_FACTOR);
+        pTransceiver->peerFrameBuffer = (PBYTE) MEMALLOC(pTransceiver->peerFrameBufferSize);
+        CHK(pTransceiver->peerFrameBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
+    }
+
+    // Fill partial frame data (skipping missing packets)
+    pCurPtrInFrame = pTransceiver->peerFrameBuffer;
+    for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
+        CHK_STATUS(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        if (hasEntry) {
+            CHK_STATUS(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+            pPacket = (PRtpPacket) hashValue;
+            partialFrameSize = totalPartialSize - filledSize;
+            CHK_STATUS(
+                pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, NULL));
+            pCurPtrInFrame += partialFrameSize;
+            filledSize += partialFrameSize;
+        }
+    }
+
+    // Build frame struct and invoke callback
+    frame.version = FRAME_CURRENT_VERSION;
+    frame.decodingTs = pFirstPacket->header.timestamp * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    frame.presentationTs = frame.decodingTs;
+    frame.frameData = pTransceiver->peerFrameBuffer;
+    frame.size = filledSize;
+    frame.duration = 0;
+    frame.index = pTransceiver->inboundStats.jitterBufferEmittedCount - 1;
+    frame.flags = FRAME_FLAG_NONE;
+
+    pTransceiver->onPartialFrame(pTransceiver->onPartialFrameCustomData, &frame);
 
 CleanUp:
     CHK_LOG_ERR(retStatus);

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -198,6 +198,23 @@ CleanUp:
     return retStatus;
 }
 
+STATUS transceiverOnPartialFrame(PRtcRtpTransceiver pRtcRtpTransceiver, UINT64 customData, RtcOnFrame rtcOnPartialFrame)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
+
+    CHK(pKvsRtpTransceiver != NULL && rtcOnPartialFrame != NULL, STATUS_NULL_ARG);
+
+    pKvsRtpTransceiver->onPartialFrame = rtcOnPartialFrame;
+    pKvsRtpTransceiver->onPartialFrameCustomData = customData;
+
+CleanUp:
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS transceiverOnBandwidthEstimation(PRtcRtpTransceiver pRtcRtpTransceiver, UINT64 customData, RtcOnBandwidthEstimation rtcOnBandwidthEstimation)
 {
     ENTERS();

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -68,6 +68,9 @@ typedef struct {
     UINT64 onFrameCustomData;
     RtcOnFrame onFrame;
 
+    UINT64 onPartialFrameCustomData;
+    RtcOnFrame onPartialFrame;
+
     UINT64 onBandwidthEstimationCustomData;
     RtcOnBandwidthEstimation onBandwidthEstimation;
     UINT64 onPictureLossCustomData;

--- a/src/source/Rtp/Codecs/RtpH264Payloader.c
+++ b/src/source/Rtp/Codecs/RtpH264Payloader.c
@@ -462,10 +462,18 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
     UINT16 subNaluSize = 0;
     BOOL firstNaluInStap = TRUE;
 
+    // pIsStart serves as input/output:
+    //   Input:  if non-NULL and *pIsStart == FALSE, this is NOT the first NAL in the frame
+    //           -> use 3-byte start codes instead of 4-byte for the leading NAL.
+    //           NULL or *pIsStart == TRUE -> use 4-byte (backward compatible default).
+    //   Output: set to TRUE if this packet starts a new NAL (FU-A start, single NAL, STAP).
+    BOOL useShortStartCode = (pIsStart != NULL && *pIsStart == FALSE);
+    PBYTE startCode = useShortStartCode ? start3ByteCode : start4ByteCode;
+    UINT32 startCodeSize = useShortStartCode ? SIZEOF(start3ByteCode) : SIZEOF(start4ByteCode);
+
     CHK(pRawPacket != NULL && pNaluLength != NULL, STATUS_NULL_ARG);
     CHK(packetLength > 0, retStatus);
 
-    // TODO: Add support for Aggregate Packets https://tools.ietf.org/html/rfc6184#section-5.7
     // indicator for types https://tools.ietf.org/html/rfc3984#section-5.2
     indicator = *pRawPacket & NAL_TYPE_MASK;
     switch (indicator) {
@@ -491,8 +499,9 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             do {
                 subNaluSize = getUnalignedInt16BigEndian(pCurPtr);
                 pCurPtr += SIZEOF(UINT16);
-                // First NAL gets 4-byte start code, subsequent NALs get 3-byte (same-frame convention)
-                naluLength += subNaluSize + (firstNaluInStap ? SIZEOF(start4ByteCode) : SIZEOF(start3ByteCode));
+                // First NAL in packet uses startCode (4-byte if first in frame, 3-byte otherwise),
+                // subsequent NALs in STAP always use 3-byte
+                naluLength += subNaluSize + (firstNaluInStap ? startCodeSize : SIZEOF(start3ByteCode));
                 firstNaluInStap = FALSE;
                 pCurPtr += subNaluSize;
             } while (subNaluSize > 0 && pCurPtr < pRawPacket + packetLength);
@@ -504,8 +513,7 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             do {
                 subNaluSize = getUnalignedInt16BigEndian(pCurPtr);
                 pCurPtr += SIZEOF(UINT16);
-                // First NAL gets 4-byte start code, subsequent NALs get 3-byte (same-frame convention)
-                naluLength += subNaluSize + (firstNaluInStap ? SIZEOF(start4ByteCode) : SIZEOF(start3ByteCode));
+                naluLength += subNaluSize + (firstNaluInStap ? startCodeSize : SIZEOF(start3ByteCode));
                 firstNaluInStap = FALSE;
                 pCurPtr += subNaluSize;
             } while (subNaluSize > 0 && pCurPtr < pRawPacket + packetLength);
@@ -518,7 +526,7 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
     }
 
     if (isStartingPacket && indicator != STAP_A_INDICATOR && indicator != STAP_B_INDICATOR) {
-        naluLength += SIZEOF(start4ByteCode);
+        naluLength += startCodeSize;
     }
 
     // Only return size if given buffer is NULL
@@ -526,9 +534,9 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
     CHK(naluLength <= *pNaluLength, STATUS_BUFFER_TOO_SMALL);
 
     if (isStartingPacket && indicator != STAP_A_INDICATOR && indicator != STAP_B_INDICATOR) {
-        MEMCPY(pNaluData, start4ByteCode, SIZEOF(start4ByteCode));
-        naluLength -= SIZEOF(start4ByteCode);
-        pNaluData += SIZEOF(start4ByteCode);
+        MEMCPY(pNaluData, startCode, startCodeSize);
+        naluLength -= startCodeSize;
+        pNaluData += startCodeSize;
     }
     switch (indicator) {
         case FU_A_INDICATOR:
@@ -556,11 +564,10 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             do {
                 subNaluSize = getUnalignedInt16BigEndian(pCurPtr);
                 pCurPtr += SIZEOF(UINT16);
-                // First NAL gets 4-byte start code, subsequent NALs get 3-byte (same-frame convention)
                 if (firstNaluInStap) {
-                    MEMCPY(pNaluData, start4ByteCode, SIZEOF(start4ByteCode));
-                    pNaluData += SIZEOF(start4ByteCode);
-                    naluLength += SIZEOF(start4ByteCode);
+                    MEMCPY(pNaluData, startCode, startCodeSize);
+                    pNaluData += startCodeSize;
+                    naluLength += startCodeSize;
                     firstNaluInStap = FALSE;
                 } else {
                     MEMCPY(pNaluData, start3ByteCode, SIZEOF(start3ByteCode));
@@ -581,11 +588,10 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             do {
                 subNaluSize = getUnalignedInt16BigEndian(pCurPtr);
                 pCurPtr += SIZEOF(UINT16);
-                // First NAL gets 4-byte start code, subsequent NALs get 3-byte (same-frame convention)
                 if (firstNaluInStap) {
-                    MEMCPY(pNaluData, start4ByteCode, SIZEOF(start4ByteCode));
-                    pNaluData += SIZEOF(start4ByteCode);
-                    naluLength += SIZEOF(start4ByteCode);
+                    MEMCPY(pNaluData, startCode, startCodeSize);
+                    pNaluData += startCodeSize;
+                    naluLength += startCodeSize;
                     firstNaluInStap = FALSE;
                 } else {
                     MEMCPY(pNaluData, start3ByteCode, SIZEOF(start3ByteCode));
@@ -604,7 +610,7 @@ STATUS depayH264FromRtpPayload(PBYTE pRawPacket, UINT32 packetLength, PBYTE pNal
             MEMCPY(pNaluData, pRawPacket, naluLength);
     }
     if (isStartingPacket && indicator != STAP_A_INDICATOR && indicator != STAP_B_INDICATOR) {
-        naluLength += SIZEOF(start4ByteCode);
+        naluLength += startCodeSize;
     }
     DLOGS("Wrote naluLength %d isStartingPacket %d", naluLength, isStartingPacket);
 

--- a/tst/H264JitterBufferIntegrationTest.cpp
+++ b/tst/H264JitterBufferIntegrationTest.cpp
@@ -1,0 +1,1070 @@
+#include "WebRTCClientTestFixture.h"
+#include <algorithm>
+#include <numeric>
+#include <random>
+#include <set>
+#include <cmath>
+
+namespace com {
+namespace amazonaws {
+namespace kinesis {
+namespace video {
+namespace webrtcclient {
+
+#define H264_INTEGRATION_TEST_CLOCK_RATE 90000
+#define H264_INTEGRATION_TEST_MAX_LATENCY (5000 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND)
+#define H264_INTEGRATION_TEST_MTU 1200
+#define H264_INTEGRATION_TEST_SSRC 0x12345678
+#define H264_INTEGRATION_TEST_PAYLOAD_TYPE 96
+
+// Helper to extract NAL unit info from Annex-B formatted H264 data
+static UINT32 extractNaluInfoForTest(PBYTE data, UINT32 dataLen, PUINT32 naluOffsets, PUINT32 naluLengths, UINT32 maxNalus)
+{
+    UINT32 naluCount = 0;
+    UINT32 i = 0;
+    UINT32 startCodeLen = 0;
+    UINT32 naluStart = 0;
+
+    while (i < dataLen && naluCount < maxNalus) {
+        if (i + 2 < dataLen && data[i] == 0 && data[i + 1] == 0) {
+            if (data[i + 2] == 1) {
+                startCodeLen = 3;
+            } else if (i + 3 < dataLen && data[i + 2] == 0 && data[i + 3] == 1) {
+                startCodeLen = 4;
+            } else {
+                i++;
+                continue;
+            }
+
+            if (naluCount > 0) {
+                naluLengths[naluCount - 1] = i - naluStart;
+            }
+
+            naluStart = i + startCodeLen;
+            naluOffsets[naluCount] = naluStart;
+            naluCount++;
+            i += startCodeLen;
+        } else {
+            i++;
+        }
+    }
+
+    if (naluCount > 0) {
+        naluLengths[naluCount - 1] = dataLen - naluStart;
+    }
+
+    return naluCount;
+}
+
+class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
+protected:
+    // Storage for original frames (Annex-B format with start codes)
+    std::vector<std::vector<BYTE>> mOriginalFrames;
+
+    // Storage for received frames from jitter buffer callback
+    std::vector<std::vector<BYTE>> mReceivedFrames;
+    std::vector<UINT32> mReceivedFrameTimestamps;
+    std::vector<UINT32> mDroppedFrameTimestamps;
+
+    // Storage for RTP packets (for simulation)
+    struct RtpPacketInfo {
+        PRtpPacket pPacket;
+        UINT32 frameIndex;
+        UINT32 timestamp;
+        UINT16 sequenceNumber;  // Saved separately since pPacket may be freed
+        UINT32 payloadLength;   // RTP payload size
+        BYTE nalIndicator;      // First byte of payload (NAL type indicator)
+        BYTE fuHeader;          // Second byte for FU-A packets (contains S/E bits)
+    };
+    std::vector<RtpPacketInfo> mAllPackets;
+
+    // Counters
+    UINT32 mTotalPacketsSent;
+    UINT32 mTotalFramesSent;
+    UINT32 mTotalFramesReceived;
+    UINT32 mTotalFramesDropped;
+
+    // Track intact frames that were incorrectly dropped (jitter buffer deficiency)
+    UINT32 mIntactFramesDropped;
+
+    // Configuration
+    UINT32 mMtu;
+    UINT32 mClockRate;
+
+    void SetUp() override
+    {
+        WebRtcClientTestBase::SetUp();
+        mMtu = H264_INTEGRATION_TEST_MTU;
+        mClockRate = H264_INTEGRATION_TEST_CLOCK_RATE;
+        mTotalPacketsSent = 0;
+        mTotalFramesSent = 0;
+        mTotalFramesReceived = 0;
+        mTotalFramesDropped = 0;
+        mIntactFramesDropped = 0;
+        mJitterBuffer = NULL;
+    }
+
+    void TearDown() override
+    {
+        cleanupTest();
+        WebRtcClientTestBase::TearDown();
+    }
+
+    void cleanupTest()
+    {
+        // Free all stored RTP packets
+        for (auto& info : mAllPackets) {
+            if (info.pPacket != NULL) {
+                freeRtpPacket(&info.pPacket);
+            }
+        }
+        mAllPackets.clear();
+        mOriginalFrames.clear();
+        mReceivedFrames.clear();
+        mReceivedFrameTimestamps.clear();
+        mDroppedFrameTimestamps.clear();
+
+        if (mJitterBuffer != NULL) {
+            freeJitterBuffer(&mJitterBuffer);
+            mJitterBuffer = NULL;
+        }
+    }
+
+    void initializeH264JitterBuffer()
+    {
+        ASSERT_EQ(STATUS_SUCCESS, createJitterBuffer(
+            h264FrameReadyCallback,
+            h264FrameDroppedCallback,
+            depayH264FromRtpPayload,
+            H264_INTEGRATION_TEST_MAX_LATENCY,
+            mClockRate,
+            (UINT64) this,
+            &mJitterBuffer));
+    }
+
+    void loadFramesFromSamples(const char* sampleFolder, UINT32 numFrames)
+    {
+        BYTE frameBuffer[500000];
+        UINT32 frameSize;
+
+        DLOGI("Loading %u frames from %s", numFrames, sampleFolder);
+        for (UINT32 i = 1; i <= numFrames; i++) {
+            ASSERT_EQ(STATUS_SUCCESS, readFrameData(
+                frameBuffer, &frameSize, i, (PCHAR) sampleFolder,
+                RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+            mOriginalFrames.push_back(std::vector<BYTE>(frameBuffer, frameBuffer + frameSize));
+        }
+        DLOGI("Loaded %zu frames", mOriginalFrames.size());
+    }
+
+    STATUS packetizeFrame(UINT32 frameIndex, UINT32 timestamp, UINT16* pSeqNum)
+    {
+        STATUS retStatus = STATUS_SUCCESS;
+        PayloadArray payloadArray = {0};
+        PBYTE frameData = mOriginalFrames[frameIndex].data();
+        UINT32 frameSize = (UINT32) mOriginalFrames[frameIndex].size();
+        PRtpPacket pPacketList = NULL;
+        UINT32 offset = 0;
+        PRtpPacket pPacketCopy = NULL;
+        UINT32 packetSize = 0;
+        PBYTE rawPacket = NULL;
+        UINT32 i = 0;
+
+        // Get required sizes
+        CHK_STATUS(createPayloadForH264(mMtu, frameData, frameSize, NULL,
+                                        &payloadArray.payloadLength, NULL,
+                                        &payloadArray.payloadSubLenSize));
+
+        // Allocate buffers
+        payloadArray.payloadBuffer = (PBYTE) MEMALLOC(payloadArray.payloadLength);
+        payloadArray.payloadSubLength = (PUINT32) MEMALLOC(payloadArray.payloadSubLenSize * SIZEOF(UINT32));
+        CHK(payloadArray.payloadBuffer != NULL && payloadArray.payloadSubLength != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+        // Fill payload data
+        CHK_STATUS(createPayloadForH264(mMtu, frameData, frameSize,
+                                        payloadArray.payloadBuffer, &payloadArray.payloadLength,
+                                        payloadArray.payloadSubLength, &payloadArray.payloadSubLenSize));
+
+        // Create RTP packets
+        pPacketList = (PRtpPacket) MEMALLOC(payloadArray.payloadSubLenSize * SIZEOF(RtpPacket));
+        CHK(pPacketList != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+        CHK_STATUS(constructRtpPackets(&payloadArray, H264_INTEGRATION_TEST_PAYLOAD_TYPE, *pSeqNum,
+                                       timestamp, H264_INTEGRATION_TEST_SSRC,
+                                       pPacketList, payloadArray.payloadSubLenSize));
+
+        // Store packet info for later use (create copies that own their memory)
+        for (i = 0; i < payloadArray.payloadSubLenSize; i++) {
+            pPacketCopy = NULL;
+
+            // Allocate and copy the packet
+            packetSize = RTP_GET_RAW_PACKET_SIZE(&pPacketList[i]);
+            rawPacket = (PBYTE) MEMALLOC(packetSize);
+            CHK(rawPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+            CHK_STATUS(createBytesFromRtpPacket(&pPacketList[i], rawPacket, &packetSize));
+            CHK_STATUS(createRtpPacketFromBytes(rawPacket, packetSize, &pPacketCopy));
+            // createRtpPacketFromBytes takes ownership of rawPacket, don't free it
+            rawPacket = NULL;
+
+            RtpPacketInfo info;
+            info.pPacket = pPacketCopy;
+            info.frameIndex = frameIndex;
+            info.timestamp = timestamp;
+            info.sequenceNumber = pPacketCopy->header.sequenceNumber;
+            info.payloadLength = pPacketCopy->payloadLength;
+            // Save NAL indicator and FU header for debugging
+            info.nalIndicator = (pPacketCopy->payloadLength > 0) ? pPacketCopy->payload[0] : 0;
+            info.fuHeader = (pPacketCopy->payloadLength > 1) ? pPacketCopy->payload[1] : 0;
+            mAllPackets.push_back(info);
+
+            offset += payloadArray.payloadSubLength[i];
+        }
+
+        *pSeqNum = GET_UINT16_SEQ_NUM(*pSeqNum + payloadArray.payloadSubLenSize);
+        mTotalFramesSent++;
+
+    CleanUp:
+        SAFE_MEMFREE(payloadArray.payloadBuffer);
+        SAFE_MEMFREE(payloadArray.payloadSubLength);
+        SAFE_MEMFREE(pPacketList);
+        // Only free rawPacket if we failed before packet took ownership
+        SAFE_MEMFREE(rawPacket);
+
+        return retStatus;
+    }
+
+    void packetizeAllFrames()
+    {
+        UINT16 seqNum = 0;
+        UINT32 timestamp = 0;
+
+        DLOGI("Packetizing %zu frames", mOriginalFrames.size());
+        for (UINT32 i = 0; i < mOriginalFrames.size(); i++) {
+            ASSERT_EQ(STATUS_SUCCESS, packetizeFrame(i, timestamp, &seqNum));
+            timestamp += 3000; // ~30fps at 90kHz clock rate
+        }
+        DLOGI("Created %zu packets from %u frames", mAllPackets.size(), mTotalFramesSent);
+    }
+
+    void pushAllPacketsInOrder()
+    {
+        DLOGI("Pushing %zu packets to jitter buffer", mAllPackets.size());
+        for (size_t i = 0; i < mAllPackets.size(); i++) {
+            auto& info = mAllPackets[i];
+            BOOL discarded = FALSE;
+            STATUS status = jitterBufferPush(mJitterBuffer, info.pPacket, &discarded);
+            ASSERT_EQ(STATUS_SUCCESS, status) << "Failed to push packet " << i;
+            if (discarded) {
+                DLOGW("Packet %zu (seq=%u, ts=%u) was DISCARDED",
+                      i, info.pPacket ? info.pPacket->header.sequenceNumber : 0,
+                      info.timestamp);
+            } else {
+                mTotalPacketsSent++;
+            }
+            // The jitter buffer now owns the packet, clear our reference
+            info.pPacket = NULL;
+        }
+        DLOGI("Pushed %u packets, received %u frames so far", mTotalPacketsSent, mTotalFramesReceived);
+    }
+
+    void pushPacketsWithIndices(const std::vector<UINT32>& indices)
+    {
+        for (UINT32 idx : indices) {
+            if (idx < mAllPackets.size() && mAllPackets[idx].pPacket != NULL) {
+                BOOL discarded = FALSE;
+                ASSERT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mAllPackets[idx].pPacket, &discarded));
+                if (!discarded) {
+                    mTotalPacketsSent++;
+                }
+                mAllPackets[idx].pPacket = NULL;
+            }
+        }
+    }
+
+    void verifyReceivedFrameNalUnits(UINT32 receivedIndex, UINT32 originalIndex)
+    {
+        static constexpr UINT32 MAX_NALUS = 128;
+        UINT32 origNaluOffsets[MAX_NALUS], origNaluLengths[MAX_NALUS];
+        UINT32 recvNaluOffsets[MAX_NALUS], recvNaluLengths[MAX_NALUS];
+
+        UINT32 origNaluCount = extractNaluInfoForTest(
+            mOriginalFrames[originalIndex].data(),
+            (UINT32) mOriginalFrames[originalIndex].size(),
+            origNaluOffsets, origNaluLengths, MAX_NALUS);
+
+        UINT32 recvNaluCount = extractNaluInfoForTest(
+            mReceivedFrames[receivedIndex].data(),
+            (UINT32) mReceivedFrames[receivedIndex].size(),
+            recvNaluOffsets, recvNaluLengths, MAX_NALUS);
+
+        EXPECT_EQ(origNaluCount, recvNaluCount)
+            << "NAL count mismatch for frame " << originalIndex;
+
+        for (UINT32 i = 0; i < MIN(origNaluCount, recvNaluCount); i++) {
+            EXPECT_EQ(origNaluLengths[i], recvNaluLengths[i])
+                << "NAL " << i << " length mismatch for frame " << originalIndex;
+
+            if (origNaluLengths[i] == recvNaluLengths[i]) {
+                EXPECT_EQ(0, MEMCMP(
+                    mOriginalFrames[originalIndex].data() + origNaluOffsets[i],
+                    mReceivedFrames[receivedIndex].data() + recvNaluOffsets[i],
+                    origNaluLengths[i]))
+                    << "NAL " << i << " data mismatch for frame " << originalIndex;
+            }
+        }
+    }
+
+    // Static callbacks for jitter buffer
+    static STATUS h264FrameReadyCallback(UINT64 customData, UINT16 startIndex, UINT16 endIndex, UINT32 frameSize)
+    {
+        H264JitterBufferIntegrationTest* pTest = (H264JitterBufferIntegrationTest*) customData;
+        UINT32 filledSize = 0;
+
+        DLOGS("Frame ready callback: startIndex=%u, endIndex=%u, frameSize=%u", startIndex, endIndex, frameSize);
+
+        if (frameSize == 0) {
+            DLOGW("Frame size is 0, skipping");
+            return STATUS_SUCCESS;
+        }
+
+        PBYTE frameBuffer = (PBYTE) MEMALLOC(frameSize);
+        if (frameBuffer == NULL) {
+            DLOGE("Failed to allocate frame buffer");
+            return STATUS_SUCCESS; // Don't fail the jitter buffer operation
+        }
+
+        STATUS status = jitterBufferFillFrameData(
+            pTest->mJitterBuffer,
+            frameBuffer,
+            frameSize,
+            &filledSize,
+            startIndex,
+            endIndex);
+
+        if (STATUS_SUCCEEDED(status) && filledSize == frameSize) {
+            pTest->mReceivedFrames.push_back(std::vector<BYTE>(frameBuffer, frameBuffer + frameSize));
+            pTest->mTotalFramesReceived++;
+            // Look up timestamp from our packet records using startIndex as sequence number
+            for (const auto& pkt : pTest->mAllPackets) {
+                if (pkt.sequenceNumber == startIndex) {
+                    pTest->mReceivedFrameTimestamps.push_back(pkt.timestamp);
+                    break;
+                }
+            }
+            DLOGS("Received frame %u, size %u, startSeq=%u", pTest->mTotalFramesReceived, frameSize, startIndex);
+        } else {
+            DLOGE("Failed to fill frame data: status=0x%08x, filledSize=%u, expected=%u", status, filledSize, frameSize);
+        }
+
+        MEMFREE(frameBuffer);
+        return STATUS_SUCCESS; // Always return success to not break jitter buffer
+    }
+
+    static STATUS h264FrameDroppedCallback(UINT64 customData, UINT16 startIndex, UINT16 endIndex, UINT32 timestamp)
+    {
+        UNUSED_PARAM(startIndex);
+        UNUSED_PARAM(endIndex);
+        DLOGS("Frame dropped callback: startIndex=%u, endIndex=%u, timestamp=%u", startIndex, endIndex, timestamp);
+
+        H264JitterBufferIntegrationTest* pTest = (H264JitterBufferIntegrationTest*) customData;
+        pTest->mTotalFramesDropped++;
+        pTest->mDroppedFrameTimestamps.push_back(timestamp);
+        return STATUS_SUCCESS;
+    }
+
+    // Generate indices for packet loss simulation
+    std::set<UINT32> generateDropIndices(UINT32 totalPackets, DOUBLE lossRate, UINT32 seed)
+    {
+        std::set<UINT32> dropIndices;
+        std::mt19937 gen(seed);
+        std::uniform_real_distribution<> dis(0.0, 1.0);
+
+        for (UINT32 i = 0; i < totalPackets; i++) {
+            if (dis(gen) < lossRate) {
+                dropIndices.insert(i);
+            }
+        }
+        return dropIndices;
+    }
+
+    // Generate reordered indices
+    std::vector<UINT32> generateReorderedIndices(UINT32 totalPackets, UINT32 maxDistance, UINT32 seed)
+    {
+        std::vector<UINT32> indices(totalPackets);
+        std::iota(indices.begin(), indices.end(), 0);
+
+        std::mt19937 gen(seed);
+        std::uniform_real_distribution<> dis(0.0, 1.0);
+
+        for (UINT32 i = 0; i < totalPackets && maxDistance > 0; i++) {
+            if (dis(gen) < 0.1) { // 10% reorder probability
+                UINT32 maxSwap = MIN(maxDistance, totalPackets - i - 1);
+                if (maxSwap > 0) {
+                    std::uniform_int_distribution<> swapDis(1, maxSwap);
+                    UINT32 swapIdx = i + swapDis(gen);
+                    std::swap(indices[i], indices[swapIdx]);
+                }
+            }
+        }
+        return indices;
+    }
+
+    // Calculate expected frame loss rate given packet loss rate
+    DOUBLE calculateExpectedFrameLoss(DOUBLE packetLossRate) const
+    {
+        if (mTotalFramesSent == 0) return 0.0;
+        DOUBLE avgPacketsPerFrame = (DOUBLE) mAllPackets.size() / mTotalFramesSent;
+        return 1.0 - pow(1.0 - packetLossRate, avgPacketsPerFrame);
+    }
+
+    // Analyze which frames are affected by packet loss
+    // - framesFullyDropped: ALL packets dropped → invisible to jitter buffer
+    // - framesPartiallyDropped: SOME packets dropped, first remaining is NOT a start → dropped
+    // - framesPartiallyDelivered: SOME packets dropped, but first remaining IS a start → delivered (corrupted)
+    // - framesIntact: NO packets dropped → should be received
+    struct FrameLossAnalysis {
+        UINT32 framesFullyDropped;        // All packets lost - invisible
+        UINT32 framesPartiallyDropped;    // Some packets lost, will be dropped by jitter buffer
+        UINT32 framesPartiallyDelivered;  // Some packets lost, but still delivered (corrupted)
+        UINT32 framesIntact;              // No packets lost - should be received
+    };
+
+    // Check if a packet is a "starting" packet for H264
+    // Starting packets: STAP-A, single NAL (1-23), FU-A with Start bit
+    bool isStartingPacket(const RtpPacketInfo& pkt) const
+    {
+        BYTE nalType = pkt.nalIndicator & 0x1F;
+        if (nalType == 28) {
+            // FU-A: check Start bit in FU header
+            return (pkt.fuHeader & 0x80) != 0;
+        } else if (nalType >= 1 && nalType <= 23) {
+            // Single NAL unit
+            return true;
+        } else if (nalType == 24 || nalType == 25) {
+            // STAP-A or STAP-B
+            return true;
+        }
+        return false;
+    }
+
+    FrameLossAnalysis analyzeFrameLoss(const std::set<UINT32>& dropIndices) const
+    {
+        // Group packets by frame and track which are dropped
+        std::map<UINT32, std::vector<UINT32>> packetIndicesByFrame;
+
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            packetIndicesByFrame[mAllPackets[i].frameIndex].push_back(i);
+        }
+
+        FrameLossAnalysis result = {0, 0, 0, 0};
+        for (const auto& kv : packetIndicesByFrame) {
+            const std::vector<UINT32>& packetIndices = kv.second;
+            UINT32 totalPackets = (UINT32) packetIndices.size();
+            UINT32 droppedPackets = 0;
+
+            // Build list of remaining (non-dropped) packets in sequence order
+            std::vector<UINT32> remainingIndices;
+            for (UINT32 pktIdx : packetIndices) {
+                if (dropIndices.find(pktIdx) != dropIndices.end()) {
+                    droppedPackets++;
+                } else {
+                    remainingIndices.push_back(pktIdx);
+                }
+            }
+
+            if (droppedPackets == 0) {
+                result.framesIntact++;
+            } else if (droppedPackets == totalPackets) {
+                result.framesFullyDropped++;
+            } else {
+                // Partial loss - check two conditions for delivery:
+                // 1. First remaining packet must be a starting packet
+                // 2. Remaining packets must be continuous (no gaps in sequence numbers)
+                bool hasStart = !remainingIndices.empty() && isStartingPacket(mAllPackets[remainingIndices[0]]);
+                bool isContinuous = true;
+
+                // Check if remaining packets have continuous sequence numbers
+                for (size_t i = 1; i < remainingIndices.size() && isContinuous; i++) {
+                    UINT16 prevSeq = mAllPackets[remainingIndices[i - 1]].sequenceNumber;
+                    UINT16 curSeq = mAllPackets[remainingIndices[i]].sequenceNumber;
+                    // Handle wraparound
+                    UINT16 expectedSeq = (prevSeq + 1) & 0xFFFF;
+                    if (curSeq != expectedSeq) {
+                        isContinuous = false;
+                    }
+                }
+
+                if (hasStart && isContinuous) {
+                    // Frame will be delivered (corrupted but deliverable)
+                    result.framesPartiallyDelivered++;
+                } else {
+                    // Frame will be dropped (missing start or has gaps)
+                    result.framesPartiallyDropped++;
+                }
+            }
+        }
+        return result;
+    }
+
+    // Debug function to find which frames have unexpected outcomes
+    void analyzeDiscrepancy(const std::set<UINT32>& dropIndices) const
+    {
+        // Build map of timestamp -> frame status (expected)
+        std::map<UINT32, std::string> expectedStatus;  // "intact", "partial", "full"
+        std::map<UINT32, UINT32> timestampToFrameIndex;
+
+        // Count packets per frame and dropped packets per frame
+        std::map<UINT32, UINT32> packetsPerFrame;
+        std::map<UINT32, UINT32> droppedPacketsPerFrame;
+        std::map<UINT32, UINT32> frameTimestamps;  // frameIndex -> timestamp
+
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            UINT32 frameIdx = mAllPackets[i].frameIndex;
+            UINT32 ts = mAllPackets[i].timestamp;
+            packetsPerFrame[frameIdx]++;
+            frameTimestamps[frameIdx] = ts;
+            timestampToFrameIndex[ts] = frameIdx;
+            if (dropIndices.find(i) != dropIndices.end()) {
+                droppedPacketsPerFrame[frameIdx]++;
+            }
+        }
+
+        for (const auto& kv : packetsPerFrame) {
+            UINT32 frameIdx = kv.first;
+            UINT32 totalPackets = kv.second;
+            UINT32 droppedPackets = droppedPacketsPerFrame[frameIdx];
+            UINT32 ts = frameTimestamps[frameIdx];
+
+            if (droppedPackets == 0) {
+                expectedStatus[ts] = "intact";
+            } else if (droppedPackets == totalPackets) {
+                expectedStatus[ts] = "full_drop";
+            } else {
+                expectedStatus[ts] = "partial";
+            }
+        }
+
+        // Build sets of received and dropped timestamps from callbacks
+        std::set<UINT32> actuallyReceivedTimestamps(mReceivedFrameTimestamps.begin(), mReceivedFrameTimestamps.end());
+        std::set<UINT32> actuallyDroppedTimestamps(mDroppedFrameTimestamps.begin(), mDroppedFrameTimestamps.end());
+
+        DLOGI("Received timestamps count: %zu, Dropped timestamps count: %zu",
+              actuallyReceivedTimestamps.size(), actuallyDroppedTimestamps.size());
+
+        // Find discrepancies
+        DLOGI("=== DISCREPANCY ANALYSIS ===");
+        for (const auto& kv : expectedStatus) {
+            UINT32 ts = kv.first;
+            const std::string& expected = kv.second;
+            bool wasDropped = actuallyDroppedTimestamps.find(ts) != actuallyDroppedTimestamps.end();
+
+            if (expected == "intact" && wasDropped) {
+                UINT32 frameIdx = timestampToFrameIndex[ts];
+                UINT32 total = packetsPerFrame[frameIdx];
+                DLOGE("UNEXPECTED: Frame %u (ts=%u) expected INTACT but was DROPPED (%u packets)", frameIdx, ts, total);
+                // Print packet info for this frame
+                for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+                    if (mAllPackets[i].frameIndex == frameIdx) {
+                        BYTE nalType = mAllPackets[i].nalIndicator & 0x1F;
+                        const char* nalTypeName = (nalType == 24) ? "STAP-A" :
+                                                  (nalType == 28) ? "FU-A" :
+                                                  (nalType == 1) ? "slice" :
+                                                  (nalType == 5) ? "IDR" :
+                                                  (nalType == 7) ? "SPS" :
+                                                  (nalType == 8) ? "PPS" :
+                                                  (nalType == 9) ? "AUD" : "other";
+                        DLOGI("  Frame %u: pktIdx=%u, seq=%u, size=%u, nalType=%u (%s)",
+                              frameIdx, i, mAllPackets[i].sequenceNumber, mAllPackets[i].payloadLength, nalType, nalTypeName);
+                    }
+                }
+                // Print adjacent frames
+                if (frameIdx > 0) {
+                    DLOGI("  Previous frame %u:", frameIdx - 1);
+                    for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+                        if (mAllPackets[i].frameIndex == frameIdx - 1) {
+                            bool pktDropped = dropIndices.find(i) != dropIndices.end();
+                            DLOGI("    pktIdx=%u, seq=%u, ts=%u, dropped=%s",
+                                  i, mAllPackets[i].sequenceNumber, mAllPackets[i].timestamp, pktDropped ? "YES" : "NO");
+                        }
+                    }
+                }
+            } else if (expected == "partial" && !wasDropped) {
+                UINT32 frameIdx = timestampToFrameIndex[ts];
+                UINT32 total = packetsPerFrame[frameIdx];
+                UINT32 dropped = droppedPacketsPerFrame[frameIdx];
+                bool wasReceived = actuallyReceivedTimestamps.find(ts) != actuallyReceivedTimestamps.end();
+                UINT32 origFrameSize = (frameIdx < mOriginalFrames.size()) ? (UINT32) mOriginalFrames[frameIdx].size() : 0;
+                DLOGE("UNEXPECTED: Frame %u (ts=%u) expected PARTIAL_DROP but was NOT dropped. "
+                      "OrigSize=%u, Packets: %u total, %u dropped. Was received: %s",
+                      frameIdx, ts, origFrameSize, total, dropped, wasReceived ? "YES" : "NO");
+
+                // Print which specific packets were dropped
+                for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+                    if (mAllPackets[i].frameIndex == frameIdx) {
+                        bool pktDropped = dropIndices.find(i) != dropIndices.end();
+                        BYTE nalType = mAllPackets[i].nalIndicator & 0x1F;
+                        BYTE fuStart = (mAllPackets[i].fuHeader >> 7) & 1;
+                        BYTE fuEnd = (mAllPackets[i].fuHeader >> 6) & 1;
+                        const char* nalTypeName = (nalType == 24) ? "STAP-A" :
+                                                  (nalType == 28) ? "FU-A" :
+                                                  (nalType == 1) ? "slice" :
+                                                  (nalType == 5) ? "IDR" :
+                                                  (nalType == 7) ? "SPS" :
+                                                  (nalType == 8) ? "PPS" :
+                                                  (nalType == 9) ? "AUD" : "other";
+                        DLOGI("  Packet idx=%u, seq=%u, size=%u, nalType=%u (%s), fuStart=%u, fuEnd=%u, dropped=%s",
+                              i, mAllPackets[i].sequenceNumber, mAllPackets[i].payloadLength,
+                              nalType, nalTypeName, fuStart, fuEnd, pktDropped ? "YES" : "NO");
+                    }
+                }
+                // Also print packets for adjacent frames
+                if (frameIdx > 0) {
+                    DLOGI("  Adjacent frame %u:", frameIdx - 1);
+                    for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+                        if (mAllPackets[i].frameIndex == frameIdx - 1) {
+                            BYTE adjNalType = mAllPackets[i].nalIndicator & 0x1F;
+                            DLOGI("    Packet idx=%u, seq=%u, size=%u, nalType=%u, ts=%u",
+                                  i, mAllPackets[i].sequenceNumber, mAllPackets[i].payloadLength,
+                                  adjNalType, mAllPackets[i].timestamp);
+                        }
+                    }
+                }
+                DLOGI("  Adjacent frame %u:", frameIdx + 1);
+                for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+                    if (mAllPackets[i].frameIndex == frameIdx + 1) {
+                        BYTE adjNalType = mAllPackets[i].nalIndicator & 0x1F;
+                        DLOGI("    Packet idx=%u, seq=%u, size=%u, nalType=%u, ts=%u",
+                              i, mAllPackets[i].sequenceNumber, mAllPackets[i].payloadLength,
+                              adjNalType, mAllPackets[i].timestamp);
+                    }
+                }
+            }
+        }
+
+        // Check for dropped frames we didn't predict
+        for (UINT32 ts : actuallyDroppedTimestamps) {
+            if (expectedStatus.find(ts) == expectedStatus.end()) {
+                DLOGE("UNEXPECTED: Unknown timestamp %u was dropped", ts);
+            }
+        }
+        DLOGI("=== END DISCREPANCY ANALYSIS ===");
+    }
+
+    // Count intact frames that were dropped (jitter buffer deficiency)
+    UINT32 countIntactFramesDropped(const std::set<UINT32>& dropIndices) const
+    {
+        // Build map of timestamp -> expected status
+        std::map<UINT32, bool> frameIsIntact;  // timestamp -> true if intact
+        std::map<UINT32, UINT32> packetsPerFrame;
+        std::map<UINT32, UINT32> droppedPacketsPerFrame;
+        std::map<UINT32, UINT32> frameTimestamps;  // frameIndex -> timestamp
+
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            UINT32 frameIdx = mAllPackets[i].frameIndex;
+            UINT32 ts = mAllPackets[i].timestamp;
+            packetsPerFrame[frameIdx]++;
+            frameTimestamps[frameIdx] = ts;
+            if (dropIndices.find(i) != dropIndices.end()) {
+                droppedPacketsPerFrame[frameIdx]++;
+            }
+        }
+
+        for (const auto& kv : packetsPerFrame) {
+            UINT32 frameIdx = kv.first;
+            UINT32 droppedPackets = droppedPacketsPerFrame[frameIdx];
+            UINT32 ts = frameTimestamps[frameIdx];
+            frameIsIntact[ts] = (droppedPackets == 0);
+        }
+
+        // Count intact frames that appear in dropped list
+        UINT32 count = 0;
+        for (UINT32 ts : mDroppedFrameTimestamps) {
+            auto it = frameIsIntact.find(ts);
+            if (it != frameIsIntact.end() && it->second) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    // Save benchmark results to file for comparison
+    void saveBenchmarkResults(const char* filename, const char* testName,
+                              const FrameLossAnalysis& analysis,
+                              UINT32 intactDropped) const
+    {
+        FILE* fp = fopen(filename, "a");
+        if (fp != NULL) {
+            fprintf(fp, "=== %s ===\n", testName);
+            fprintf(fp, "Total frames sent: %u\n", mTotalFramesSent);
+            fprintf(fp, "Analysis:\n");
+            fprintf(fp, "  Intact frames: %u\n", analysis.framesIntact);
+            fprintf(fp, "  Partially dropped: %u\n", analysis.framesPartiallyDropped);
+            fprintf(fp, "  Partially delivered: %u\n", analysis.framesPartiallyDelivered);
+            fprintf(fp, "  Fully dropped (invisible): %u\n", analysis.framesFullyDropped);
+            fprintf(fp, "Results:\n");
+            fprintf(fp, "  Frames received: %u\n", mTotalFramesReceived);
+            fprintf(fp, "  Frames dropped by jitter buffer: %u\n", mTotalFramesDropped);
+            fprintf(fp, "  *** INTACT FRAMES INCORRECTLY DROPPED: %u ***\n", intactDropped);
+            fprintf(fp, "  Extra frames lost due to deficiency: %u\n", intactDropped);
+            fprintf(fp, "\n");
+            fclose(fp);
+            DLOGI("Results saved to %s", filename);
+        } else {
+            DLOGW("Could not open %s for writing", filename);
+        }
+    }
+
+    // Type alias for drop index generator function
+    using DropGenerator = std::function<std::set<UINT32>(UINT32 totalPackets)>;
+
+    // Helper to create a random loss generator with given rate
+    static DropGenerator randomLoss(DOUBLE rate)
+    {
+        return [rate](UINT32 totalPackets) {
+            UINT32 seed = (UINT32)(rate * 100000);
+            std::set<UINT32> dropIndices;
+            std::mt19937 gen(seed);
+            std::uniform_real_distribution<> dis(0.0, 1.0);
+            for (UINT32 i = 0; i < totalPackets; i++) {
+                if (dis(gen) < rate) {
+                    dropIndices.insert(i);
+                }
+            }
+            return dropIndices;
+        };
+    }
+
+    // Helper to create a burst loss generator
+    static DropGenerator burstLoss(UINT32 burstSize, UINT32 numBursts)
+    {
+        return [burstSize, numBursts](UINT32 totalPackets) {
+            std::set<UINT32> dropIndices;
+            UINT32 burstInterval = totalPackets / (numBursts + 1);
+            for (UINT32 b = 0; b < numBursts; b++) {
+                UINT32 burstStart = burstInterval * (b + 1);
+                for (UINT32 i = 0; i < burstSize && (burstStart + i) < totalPackets; i++) {
+                    dropIndices.insert(burstStart + i);
+                }
+            }
+            return dropIndices;
+        };
+    }
+
+    // Helper to create a periodic loss generator (drops every Nth packet)
+    static DropGenerator periodicLoss(UINT32 period)
+    {
+        return [period](UINT32 totalPackets) {
+            std::set<UINT32> dropIndices;
+            for (UINT32 i = period - 1; i < totalPackets; i += period) {
+                dropIndices.insert(i);
+            }
+            return dropIndices;
+        };
+    }
+
+    // Helper to create a Gilbert-Elliott model loss generator (bursty loss)
+    // @param p - probability of transitioning from Good to Bad state
+    // @param r - probability of transitioning from Bad to Good state
+    // @param pLossGood - probability of packet loss in Good state (typically low, e.g., 0.0)
+    // @param pLossBad - probability of packet loss in Bad state (typically high, e.g., 1.0)
+    static DropGenerator gilbertElliottLoss(DOUBLE p, DOUBLE r, DOUBLE pLossGood = 0.0, DOUBLE pLossBad = 1.0)
+    {
+        return [p, r, pLossGood, pLossBad](UINT32 totalPackets) {
+            std::set<UINT32> dropIndices;
+            std::mt19937 gen(42);  // Fixed seed for reproducibility
+            std::uniform_real_distribution<> dis(0.0, 1.0);
+
+            bool inBadState = false;
+            for (UINT32 i = 0; i < totalPackets; i++) {
+                // State transition
+                if (inBadState) {
+                    if (dis(gen) < r) {
+                        inBadState = false;  // Bad -> Good
+                    }
+                } else {
+                    if (dis(gen) < p) {
+                        inBadState = true;   // Good -> Bad
+                    }
+                }
+
+                // Packet loss based on current state
+                DOUBLE pLoss = inBadState ? pLossBad : pLossGood;
+                if (dis(gen) < pLoss) {
+                    dropIndices.insert(i);
+                }
+            }
+            return dropIndices;
+        };
+    }
+
+    // Parameterized packet loss test with optional reordering and custom drop pattern
+    // @param sampleFolder - folder containing h264 sample frames
+    // @param numFrames - number of frames to load and test
+    // @param dropGen - function that generates drop indices given total packet count
+    // @param maxReorderDistance - max distance for packet reordering (0 = no reordering)
+    void runPacketLossTest(const char* sampleFolder, UINT32 numFrames, DropGenerator dropGen, UINT32 maxReorderDistance = 0)
+    {
+        // Clean up any state from previous test run within the same test case
+        cleanupTest();
+        mTotalFramesSent = 0;
+        mTotalFramesReceived = 0;
+        mTotalFramesDropped = 0;
+        mTotalPacketsSent = 0;
+        mIntactFramesDropped = 0;
+
+        initializeH264JitterBuffer();
+        loadFramesFromSamples(sampleFolder, numFrames);
+        packetizeAllFrames();
+
+        UINT32 totalPackets = (UINT32) mAllPackets.size();
+
+        // Generate drop indices using provided generator
+        auto dropIndices = dropGen(totalPackets);
+
+        // Analyze expected frame loss based on which specific packets are dropped
+        auto analysis = analyzeFrameLoss(dropIndices);
+        DLOGI("Frame loss analysis: fullyDropped=%u, partiallyDropped=%u, partiallyDelivered=%u, intact=%u",
+              analysis.framesFullyDropped, analysis.framesPartiallyDropped,
+              analysis.framesPartiallyDelivered, analysis.framesIntact);
+
+        // Build send indices: optionally reordered, with dropped packets removed
+        std::vector<UINT32> sendIndices;
+        if (maxReorderDistance > 0) {
+            auto reorderedIndices = generateReorderedIndices(totalPackets, maxReorderDistance, maxReorderDistance);
+            for (UINT32 idx : reorderedIndices) {
+                if (dropIndices.find(idx) == dropIndices.end()) {
+                    sendIndices.push_back(idx);
+                }
+            }
+        } else {
+            for (UINT32 i = 0; i < totalPackets; i++) {
+                if (dropIndices.find(i) == dropIndices.end()) {
+                    sendIndices.push_back(i);
+                }
+            }
+        }
+
+        pushPacketsWithIndices(sendIndices);
+        UINT32 receivedBeforeFlush = mTotalFramesReceived;
+        UINT32 droppedBeforeFlush = mTotalFramesDropped;
+        DLOGI("Before flush: received=%u, dropped=%u", receivedBeforeFlush, droppedBeforeFlush);
+
+        // Flush jitter buffer
+        freeJitterBuffer(&mJitterBuffer);
+        mJitterBuffer = NULL;
+
+        DLOGI("reorder=%u: received=%u (flush added %u), dropped=%u (flush added %u), packets dropped=%zu",
+              maxReorderDistance,
+              mTotalFramesReceived, mTotalFramesReceived - receivedBeforeFlush,
+              mTotalFramesDropped, mTotalFramesDropped - droppedBeforeFlush,
+              dropIndices.size());
+
+        // Count intact frames that were incorrectly dropped
+        mIntactFramesDropped = countIntactFramesDropped(dropIndices);
+
+        if (mIntactFramesDropped > 0) {
+            DLOGI("*** JITTER BUFFER DEFICIENCY: %u intact frames were dropped ***", mIntactFramesDropped);
+            analyzeDiscrepancy(dropIndices);
+        }
+
+        // FIX VERIFIED: No intact frames should be dropped
+        // The per-frame continuity tracking ensures that intact frames following
+        // dropped frames are correctly delivered.
+        EXPECT_EQ(0u, mIntactFramesDropped)
+            << "Intact frames were incorrectly dropped - fix may have regressed";
+
+        // Upper bound: can't receive more than intact + partiallyDelivered
+        UINT32 maxExpectedReceived = analysis.framesIntact + analysis.framesPartiallyDelivered;
+        EXPECT_LE(mTotalFramesReceived, maxExpectedReceived)
+            << "More frames received than possible";
+
+        // All frames must be accounted for: received + dropped = NUM_FRAMES - fullyDropped
+        // (fullyDropped frames never reach the jitter buffer because all their packets were lost)
+        UINT32 accountedFrames = mTotalFramesReceived + mTotalFramesDropped;
+        UINT32 expectedAccountedFrames = numFrames - analysis.framesFullyDropped;
+        DLOGI("Frame accounting: received=%u + dropped=%u = %u, expected=%u (NUM_FRAMES=%u - fullyDropped=%u)",
+              mTotalFramesReceived, mTotalFramesDropped, accountedFrames, expectedAccountedFrames,
+              numFrames, analysis.framesFullyDropped);
+        EXPECT_EQ(expectedAccountedFrames, accountedFrames)
+            << "Frame accounting mismatch: some frames are unaccounted for";
+    }
+};
+
+// Test: Perfect delivery - all packets in order, no loss
+TEST_F(H264JitterBufferIntegrationTest, perfectDeliveryAllFramesReceived)
+{
+    runPacketLossTest("../samples/girH264", 50, randomLoss(0.0));
+    runPacketLossTest("../samples/h264SampleFrames", 50, randomLoss(0.0));
+}
+
+// Test: Packet reordering - packets arrive out of order but most are delivered
+TEST_F(H264JitterBufferIntegrationTest, packetReorderingAllFramesRecovered)
+{
+    runPacketLossTest("../samples/girH264", 1000, randomLoss(0.0), 5);
+    runPacketLossTest("../samples/h264SampleFrames", 1000, randomLoss(0.0), 5);
+}
+
+// Test: 1% packet loss
+TEST_F(H264JitterBufferIntegrationTest, packetLoss1Percent)
+{
+    runPacketLossTest("../samples/girH264", 1000, randomLoss(0.01));
+    runPacketLossTest("../samples/h264SampleFrames", 1000, randomLoss(0.01));
+}
+
+// Test: 5% packet loss
+TEST_F(H264JitterBufferIntegrationTest, packetLoss5Percent)
+{
+    runPacketLossTest("../samples/girH264", 1000, randomLoss(0.05));
+    runPacketLossTest("../samples/h264SampleFrames", 1000, randomLoss(0.05));
+}
+
+// Test: Combined packet loss and reordering
+TEST_F(H264JitterBufferIntegrationTest, combinedLossAndReordering)
+{
+    runPacketLossTest("../samples/girH264", 1000, randomLoss(0.02), 3);
+    runPacketLossTest("../samples/h264SampleFrames", 1000, randomLoss(0.02), 3);
+}
+
+// Test: Burst packet loss (consecutive packets dropped)
+TEST_F(H264JitterBufferIntegrationTest, burstPacketLoss)
+{
+    runPacketLossTest("../samples/girH264", 1000, burstLoss(5, 3));
+    runPacketLossTest("../samples/h264SampleFrames", 1000, burstLoss(5, 3));
+}
+
+// Test: Periodic packet loss (every Nth packet dropped)
+TEST_F(H264JitterBufferIntegrationTest, periodicPacketLoss)
+{
+    runPacketLossTest("../samples/girH264", 1000, periodicLoss(10));
+    runPacketLossTest("../samples/h264SampleFrames", 1000, periodicLoss(10));
+}
+
+// Test: Gilbert-Elliott bursty packet loss (simulates network congestion bursts)
+// p=0.05 means 5% chance to enter bad state, r=0.3 means 30% chance to recover
+TEST_F(H264JitterBufferIntegrationTest, gilbertElliottPacketLoss)
+{
+    runPacketLossTest("../samples/girH264", 1000, gilbertElliottLoss(0.05, 0.3));
+    runPacketLossTest("../samples/h264SampleFrames", 1000, gilbertElliottLoss(0.05, 0.3));
+}
+
+// Benchmark test: Records jitter buffer deficiency metrics
+// Run this test to capture baseline performance before/after fix
+TEST_F(H264JitterBufferIntegrationTest, DISABLED_jitterBufferDeficiencyBenchmark)
+{
+    const char* RESULTS_FILE = "../jitter_buffer_benchmark.txt";
+
+    // Clear the results file
+    FILE* fp = fopen(RESULTS_FILE, "w");
+    if (fp != NULL) {
+        fprintf(fp, "===========================================\n");
+        fprintf(fp, "JITTER BUFFER DEFICIENCY BENCHMARK RESULTS\n");
+        fprintf(fp, "===========================================\n\n");
+        fclose(fp);
+    }
+
+    // Test 1: 1% packet loss with 1000 frames
+    {
+        const UINT32 NUM_FRAMES = 1000;
+        const DOUBLE PACKET_LOSS_RATE = 0.01;
+
+        cleanupTest();
+        initializeH264JitterBuffer();
+        loadFramesFromSamples("../samples/h264SampleFrames", NUM_FRAMES);
+        packetizeAllFrames();
+
+        auto dropIndices = generateDropIndices((UINT32) mAllPackets.size(), PACKET_LOSS_RATE, 12345);
+        auto analysis = analyzeFrameLoss(dropIndices);
+
+        std::vector<UINT32> sendIndices;
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            if (dropIndices.find(i) == dropIndices.end()) {
+                sendIndices.push_back(i);
+            }
+        }
+        pushPacketsWithIndices(sendIndices);
+        freeJitterBuffer(&mJitterBuffer);
+        mJitterBuffer = NULL;
+
+        UINT32 intactDropped = countIntactFramesDropped(dropIndices);
+        saveBenchmarkResults(RESULTS_FILE, "1% Packet Loss (1000 frames)", analysis, intactDropped);
+
+        DLOGI("1%% loss: intact=%u, intactDropped=%u", analysis.framesIntact, intactDropped);
+    }
+
+    // Test 2: 5% packet loss with 100 frames
+    {
+        const UINT32 NUM_FRAMES = 100;
+        const DOUBLE PACKET_LOSS_RATE = 0.05;
+
+        cleanupTest();
+        initializeH264JitterBuffer();
+        loadFramesFromSamples("../samples/h264SampleFrames", NUM_FRAMES);
+        packetizeAllFrames();
+
+        auto dropIndices = generateDropIndices((UINT32) mAllPackets.size(), PACKET_LOSS_RATE, 54321);
+        auto analysis = analyzeFrameLoss(dropIndices);
+
+        std::vector<UINT32> sendIndices;
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            if (dropIndices.find(i) == dropIndices.end()) {
+                sendIndices.push_back(i);
+            }
+        }
+        pushPacketsWithIndices(sendIndices);
+        freeJitterBuffer(&mJitterBuffer);
+        mJitterBuffer = NULL;
+
+        UINT32 intactDropped = countIntactFramesDropped(dropIndices);
+        saveBenchmarkResults(RESULTS_FILE, "5% Packet Loss (100 frames)", analysis, intactDropped);
+
+        DLOGI("5%% loss: intact=%u, intactDropped=%u", analysis.framesIntact, intactDropped);
+    }
+
+    // Test 3: Burst packet loss
+    {
+        const UINT32 NUM_FRAMES = 100;
+        const UINT32 BURST_SIZE = 5;
+        const UINT32 NUM_BURSTS = 3;
+
+        cleanupTest();
+        initializeH264JitterBuffer();
+        loadFramesFromSamples("../samples/h264SampleFrames", NUM_FRAMES);
+        packetizeAllFrames();
+
+        std::set<UINT32> dropIndices;
+        UINT32 totalPackets = (UINT32) mAllPackets.size();
+        UINT32 burstInterval = totalPackets / (NUM_BURSTS + 1);
+        for (UINT32 b = 0; b < NUM_BURSTS; b++) {
+            UINT32 burstStart = burstInterval * (b + 1);
+            for (UINT32 i = 0; i < BURST_SIZE && (burstStart + i) < totalPackets; i++) {
+                dropIndices.insert(burstStart + i);
+            }
+        }
+
+        auto analysis = analyzeFrameLoss(dropIndices);
+
+        std::vector<UINT32> sendIndices;
+        for (UINT32 i = 0; i < mAllPackets.size(); i++) {
+            if (dropIndices.find(i) == dropIndices.end()) {
+                sendIndices.push_back(i);
+            }
+        }
+        pushPacketsWithIndices(sendIndices);
+        freeJitterBuffer(&mJitterBuffer);
+        mJitterBuffer = NULL;
+
+        UINT32 intactDropped = countIntactFramesDropped(dropIndices);
+        saveBenchmarkResults(RESULTS_FILE, "Burst Loss (3 bursts of 5 packets)", analysis, intactDropped);
+
+        DLOGI("Burst loss: intact=%u, intactDropped=%u", analysis.framesIntact, intactDropped);
+    }
+
+    DLOGI("Benchmark results saved to %s", RESULTS_FILE);
+}
+
+} // namespace webrtcclient
+} // namespace video
+} // namespace kinesis
+} // namespace amazonaws
+} // namespace com

--- a/tst/JitterBufferFunctionalityTest.cpp
+++ b/tst/JitterBufferFunctionalityTest.cpp
@@ -1851,6 +1851,157 @@ TEST_F(JitterBufferFunctionalityTest, LongRunningWithDroppedPacketsTest)
 }
 #endif
 
+TEST_F(JitterBufferFunctionalityTest, markerBitTriggersImmediateDelivery)
+{
+    UINT32 i;
+    UINT32 pktCount = 4;
+    UINT32 startingSequenceNumber = 0;
+
+    srand(time(0));
+    startingSequenceNumber = rand() % UINT16_MAX;
+
+    initializeJitterBuffer(2, 0, pktCount);
+
+    // First frame: 3 packets with marker on last one, timestamp 100
+    // Packet 0: start packet
+    mPRtpPackets[0]->payloadLength = 1;
+    mPRtpPackets[0]->payload = (PBYTE) MEMALLOC(mPRtpPackets[0]->payloadLength + 1);
+    mPRtpPackets[0]->payload[0] = 1;
+    mPRtpPackets[0]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[0]->header.timestamp = 100;
+    mPRtpPackets[0]->header.sequenceNumber = startingSequenceNumber++;
+    mPRtpPackets[0]->header.marker = FALSE;
+
+    // Packet 1: middle packet
+    mPRtpPackets[1]->payloadLength = 1;
+    mPRtpPackets[1]->payload = (PBYTE) MEMALLOC(mPRtpPackets[1]->payloadLength + 1);
+    mPRtpPackets[1]->payload[0] = 2;
+    mPRtpPackets[1]->payload[1] = 0; // Following packet
+    mPRtpPackets[1]->header.timestamp = 100;
+    mPRtpPackets[1]->header.sequenceNumber = startingSequenceNumber++;
+    mPRtpPackets[1]->header.marker = FALSE;
+
+    // Packet 2: last packet with MARKER BIT SET
+    mPRtpPackets[2]->payloadLength = 1;
+    mPRtpPackets[2]->payload = (PBYTE) MEMALLOC(mPRtpPackets[2]->payloadLength + 1);
+    mPRtpPackets[2]->payload[0] = 3;
+    mPRtpPackets[2]->payload[1] = 0; // Following packet
+    mPRtpPackets[2]->header.timestamp = 100;
+    mPRtpPackets[2]->header.sequenceNumber = startingSequenceNumber++;
+    mPRtpPackets[2]->header.marker = TRUE; // MARKER BIT!
+
+    // Expected to get frame "123" IMMEDIATELY after packet 2 (not waiting for packet 3)
+    mPExpectedFrameArr[0] = (PBYTE) MEMALLOC(3);
+    mPExpectedFrameArr[0][0] = 1;
+    mPExpectedFrameArr[0][1] = 2;
+    mPExpectedFrameArr[0][2] = 3;
+    mExpectedFrameSizeArr[0] = 3;
+
+    // Second frame: single packet with marker, timestamp 200
+    mPRtpPackets[3]->payloadLength = 1;
+    mPRtpPackets[3]->payload = (PBYTE) MEMALLOC(mPRtpPackets[3]->payloadLength + 1);
+    mPRtpPackets[3]->payload[0] = 4;
+    mPRtpPackets[3]->payload[1] = 1; // First packet of a frame
+    mPRtpPackets[3]->header.timestamp = 200;
+    mPRtpPackets[3]->header.sequenceNumber = startingSequenceNumber++;
+    mPRtpPackets[3]->header.marker = TRUE; // Single packet frame, marker set
+
+    // Expected to get frame "4"
+    mPExpectedFrameArr[1] = (PBYTE) MEMALLOC(1);
+    mPExpectedFrameArr[1][0] = 4;
+    mExpectedFrameSizeArr[1] = 1;
+
+    setPayloadToFree();
+
+    for (i = 0; i < pktCount; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mPRtpPackets[i], nullptr));
+        switch (i) {
+            case 0:
+            case 1:
+                EXPECT_EQ(0, mReadyFrameIndex); // Frame not complete yet
+                break;
+            case 2:
+                EXPECT_EQ(1, mReadyFrameIndex); // Frame delivered on marker!
+                break;
+            case 3:
+                EXPECT_EQ(2, mReadyFrameIndex); // Second frame delivered on marker
+                break;
+            default:
+                ASSERT_TRUE(FALSE);
+        }
+        EXPECT_EQ(0, mDroppedFrameIndex);
+    }
+
+    clearJitterBufferForTest();
+}
+
+TEST_F(JitterBufferFunctionalityTest, markerBitOutOfOrderWaitsForCompletion)
+{
+    UINT32 i;
+    UINT32 pktCount = 3;
+
+    initializeJitterBuffer(1, 0, pktCount);
+
+    // Frame with 3 packets, but marker arrives before middle packet
+    // Push order: packet 0 (seq 0), packet 1 (seq 2, marker), packet 2 (seq 1)
+    // Frame should NOT be delivered until all packets arrive, even though marker arrived early
+
+    // Packet 0: start packet, seq 0
+    mPRtpPackets[0]->payloadLength = 1;
+    mPRtpPackets[0]->payload = (PBYTE) MEMALLOC(mPRtpPackets[0]->payloadLength + 1);
+    mPRtpPackets[0]->payload[0] = 1;
+    mPRtpPackets[0]->payload[1] = 1;
+    mPRtpPackets[0]->header.timestamp = 100;
+    mPRtpPackets[0]->header.sequenceNumber = 0;
+    mPRtpPackets[0]->header.marker = FALSE;
+
+    // Packet 1: marker packet, seq 2 (arrives second, before seq 1)
+    mPRtpPackets[1]->payloadLength = 1;
+    mPRtpPackets[1]->payload = (PBYTE) MEMALLOC(mPRtpPackets[1]->payloadLength + 1);
+    mPRtpPackets[1]->payload[0] = 3;
+    mPRtpPackets[1]->payload[1] = 0;
+    mPRtpPackets[1]->header.timestamp = 100;
+    mPRtpPackets[1]->header.sequenceNumber = 2;
+    mPRtpPackets[1]->header.marker = TRUE;
+
+    // Packet 2: middle packet, seq 1 (arrives third, filling the gap)
+    mPRtpPackets[2]->payloadLength = 1;
+    mPRtpPackets[2]->payload = (PBYTE) MEMALLOC(mPRtpPackets[2]->payloadLength + 1);
+    mPRtpPackets[2]->payload[0] = 2;
+    mPRtpPackets[2]->payload[1] = 0;
+    mPRtpPackets[2]->header.timestamp = 100;
+    mPRtpPackets[2]->header.sequenceNumber = 1;
+    mPRtpPackets[2]->header.marker = FALSE;
+
+    // Expected frame "123"
+    mPExpectedFrameArr[0] = (PBYTE) MEMALLOC(3);
+    mPExpectedFrameArr[0][0] = 1;
+    mPExpectedFrameArr[0][1] = 2;
+    mPExpectedFrameArr[0][2] = 3;
+    mExpectedFrameSizeArr[0] = 3;
+
+    setPayloadToFree();
+
+    for (i = 0; i < pktCount; i++) {
+        EXPECT_EQ(STATUS_SUCCESS, jitterBufferPush(mJitterBuffer, mPRtpPackets[i], nullptr));
+        switch (i) {
+            case 0:
+                EXPECT_EQ(0, mReadyFrameIndex); // Only start, not complete
+                break;
+            case 1:
+                EXPECT_EQ(0, mReadyFrameIndex); // Marker but missing seq 1
+                break;
+            case 2:
+                EXPECT_EQ(1, mReadyFrameIndex); // Now complete with marker!
+                break;
+            default:
+                ASSERT_TRUE(FALSE);
+        }
+    }
+
+    clearJitterBufferForTest();
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtpFunctionalityTest.cpp
+++ b/tst/RtpFunctionalityTest.cpp
@@ -774,7 +774,7 @@ TEST_F(RtpFunctionalityTest, stapADepayloadRoundTrip)
     // Depayload and verify we get back the original NALs
     PBYTE depayload = (PBYTE) MEMALLOC(frameLen + 100);
     UINT32 depayloadLen = frameLen + 100;
-    BOOL isStart = FALSE;
+    BOOL isStart = TRUE;
 
     EXPECT_EQ(STATUS_SUCCESS, depayH264FromRtpPayload(payloadArray.payloadBuffer, payloadArray.payloadSubLength[0],
                                                       depayload, &depayloadLen, &isStart));


### PR DESCRIPTION
TLDR: the old code's delivery trigger was curTimestamp != headTimestamp — it only fired when the parser encountered the first packet of the next frame. The new code adds an early-exit path directly on the marker bit packet, so the frame ships without ever needing to see new frame.


BEFORE:
```
 Frame A sits buffered, complete, waiting...
  A1    A2    A3[M]  . . . . . . . . .  B1
 ----------------------------------------^---------
                                         |
                                         +-- Frame A delivered
                                             only when B1 arrives
```

AFTER:
```
  A1    A2    A3[M]  . . . . . . . . .  B1
 --------------^--------------------------------------------
               |
               +-- Frame A delivered here, no need to wait for B1
 ```


*Issue #, if available:*
- N/A

*What was changed?*
- Improved JitterBuffer with immediate frame delivery when marker bit is received and frame is complete
- Added `transceiverOnPartialFrame` callback to deliver partial frames to the transceiver
- Fixed H.264 RTP payloader to use 3-byte start codes for all NALs within a single frame
- Enhanced frame continuity tracking to correctly distinguish gaps in head frame vs subsequent frames
- Updated `freeJitterBuffer` to loop until all frames are parsed for complete cleanup
- Added `H264JitterBufferIntegrationTest` covering packet loss, reordering, and burst loss scenarios
- Added unit tests for marker bit delivery and out-of-order packet handling

*Why was it changed?*
- Immediate delivery on marker bit reduces end-to-end latency for complete frames
- Partial frame callback enables upstream code to handle incomplete frames (e.g. for error concealment)
- Correct 3-byte start codes fix H.264 Annex B framing for multi-NAL frames

*How was it changed?*
- Modified `JitterBuffer.c` to trigger frame delivery immediately upon receiving the marker bit when the frame is contiguous
- Added `onPartialFrameReadyFunc` callback type in `Include.h` and wired it through `PeerConnection.c` and `Rtp.h/Rtp.c`
- Updated `RtpH264Payloader.c` to emit 3-byte start codes (0x000001) for all NALs belonging to the same access unit

*What testing was done for the changes?*
- Added `H264JitterBufferIntegrationTest.cpp` with 1070 lines of integration tests simulating packet loss, reordering, and burst loss
- Extended `JitterBufferFunctionalityTest.cpp` with 151 lines of unit tests for marker-bit delivery and out-of-order scenarios
- Existing RTP functionality tests updated and passing

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.