### PR TITLE
Add file-based logging for Android app tests

### DIFF
--- a/android-test-app/app/src/androidTest/java/com/kvs/webrtctest/WebRtcNativeTest.java
+++ b/android-test-app/app/src/androidTest/java/com/kvs/webrtctest/WebRtcNativeTest.java
@@ -40,6 +40,7 @@ public class WebRtcNativeTest {
 
     private String workDir;
     private String filter;
+    private String logDir;
 
     @Before
     public void setUp() throws IOException {
@@ -64,8 +65,18 @@ public class WebRtcNativeTest {
         Bundle args = InstrumentationRegistry.getArguments();
         filter = args.getString("gtest_filter", "*");
 
+        // External files dir is accessible via adb pull without root
+        File extDir = ctx.getExternalFilesDir(null);
+        if (extDir != null) {
+            extDir.mkdirs();
+            logDir = extDir.getAbsolutePath();
+        } else {
+            logDir = tstDir.getAbsolutePath();
+        }
+
         Log.i(TAG, "Work dir: " + workDir);
         Log.i(TAG, "Samples dir: " + samplesDir.getAbsolutePath());
+        Log.i(TAG, "Log dir: " + logDir);
         Log.i(TAG, "Filter: " + filter);
     }
 
@@ -74,7 +85,7 @@ public class WebRtcNativeTest {
     @Test
     public void runNativeTests() throws Exception {
         ExecutorService executor = Executors.newSingleThreadExecutor();
-        Future<Integer> future = executor.submit(() -> NativeTestLib.runTests(workDir, filter));
+        Future<Integer> future = executor.submit(() -> NativeTestLib.runTests(workDir, filter, logDir));
         try {
             int rc = future.get(TIMEOUT_MINUTES, TimeUnit.MINUTES);
             assertEquals("Native gtest tests failed (see logcat tag 'webrtc_test_jni' for details)", 0, rc);

--- a/android-test-app/app/src/main/java/com/kvs/webrtctest/NativeTestLib.java
+++ b/android-test-app/app/src/main/java/com/kvs/webrtctest/NativeTestLib.java
@@ -10,7 +10,8 @@ public class NativeTestLib {
      *
      * @param workDir working directory (tests expect ../samples/ relative to this)
      * @param filter  gtest filter expression (e.g. "StunApiTest.*"), "*" for all
+     * @param logDir  directory to write test.log into (for reliable log retrieval)
      * @return 0 on success, nonzero on failure
      */
-    public static native int runTests(String workDir, String filter);
+    public static native int runTests(String workDir, String filter, String logDir);
 }

--- a/android-test-app/jni_bridge.cpp
+++ b/android-test-app/jni_bridge.cpp
@@ -1,6 +1,7 @@
 #include <jni.h>
 #include <unistd.h>
 #include <string>
+#include <cstdio>
 #include <android/log.h>
 
 #include "gtest/gtest.h"
@@ -9,6 +10,9 @@
 
 #define LOG_TAG "webrtc_test_jni"
 
+// File for persistent logging (survives logcat truncation on low-end devices)
+static FILE* g_logFile = nullptr;
+
 // Custom gtest listener that routes output to Android logcat.
 class LogcatPrinter : public ::testing::EmptyTestEventListener {
   public:
@@ -16,16 +20,29 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
     {
         __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[==========] Running %d tests from %d test suites.",
                             unit_test.test_to_run_count(), unit_test.test_suite_to_run_count());
+        if (g_logFile) {
+            fprintf(g_logFile, "[==========] Running %d tests from %d test suites.\n",
+                    unit_test.test_to_run_count(), unit_test.test_suite_to_run_count());
+            fflush(g_logFile);
+        }
     }
 
     void OnTestSuiteStart(const ::testing::TestSuite& suite) override
     {
         __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[----------] %d tests from %s", suite.test_to_run_count(), suite.name());
+        if (g_logFile) {
+            fprintf(g_logFile, "[----------] %d tests from %s\n", suite.test_to_run_count(), suite.name());
+            fflush(g_logFile);
+        }
     }
 
     void OnTestStart(const ::testing::TestInfo& info) override
     {
         __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[ RUN      ] %s.%s", info.test_suite_name(), info.name());
+        if (g_logFile) {
+            fprintf(g_logFile, "[ RUN      ] %s.%s\n", info.test_suite_name(), info.name());
+            fflush(g_logFile);
+        }
     }
 
     void OnTestPartResult(const ::testing::TestPartResult& result) override
@@ -34,6 +51,12 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
             __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "%s:%d: Failure\n%s",
                                 result.file_name() ? result.file_name() : "unknown", result.line_number(),
                                 result.message() ? result.message() : "");
+            if (g_logFile) {
+                fprintf(g_logFile, "%s:%d: Failure\n%s\n",
+                        result.file_name() ? result.file_name() : "unknown", result.line_number(),
+                        result.message() ? result.message() : "");
+                fflush(g_logFile);
+            }
         }
     }
 
@@ -42,9 +65,19 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
         if (info.result()->Passed()) {
             __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[       OK ] %s.%s (%lld ms)", info.test_suite_name(), info.name(),
                                 (long long) info.result()->elapsed_time());
+            if (g_logFile) {
+                fprintf(g_logFile, "[       OK ] %s.%s (%lld ms)\n", info.test_suite_name(), info.name(),
+                        (long long) info.result()->elapsed_time());
+                fflush(g_logFile);
+            }
         } else {
             __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "[  FAILED  ] %s.%s (%lld ms)", info.test_suite_name(), info.name(),
                                 (long long) info.result()->elapsed_time());
+            if (g_logFile) {
+                fprintf(g_logFile, "[  FAILED  ] %s.%s (%lld ms)\n", info.test_suite_name(), info.name(),
+                        (long long) info.result()->elapsed_time());
+                fflush(g_logFile);
+            }
         }
     }
 
@@ -52,6 +85,11 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
     {
         __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[----------] %d tests from %s (%lld ms total)", suite.test_to_run_count(),
                             suite.name(), (long long) suite.elapsed_time());
+        if (g_logFile) {
+            fprintf(g_logFile, "[----------] %d tests from %s (%lld ms total)\n", suite.test_to_run_count(),
+                    suite.name(), (long long) suite.elapsed_time());
+            fflush(g_logFile);
+        }
     }
 
     void OnTestProgramEnd(const ::testing::UnitTest& unit_test) override
@@ -62,6 +100,16 @@ class LogcatPrinter : public ::testing::EmptyTestEventListener {
         __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "[  PASSED  ] %d tests.", unit_test.successful_test_count());
         if (unit_test.failed_test_count() > 0) {
             __android_log_print(ANDROID_LOG_ERROR, LOG_TAG, "[  FAILED  ] %d tests.", unit_test.failed_test_count());
+        }
+        if (g_logFile) {
+            fprintf(g_logFile, "[==========] %d tests from %d test suites ran. (%lld ms total)\n",
+                    unit_test.test_to_run_count(), unit_test.test_suite_to_run_count(),
+                    (long long) unit_test.elapsed_time());
+            fprintf(g_logFile, "[  PASSED  ] %d tests.\n", unit_test.successful_test_count());
+            if (unit_test.failed_test_count() > 0) {
+                fprintf(g_logFile, "[  FAILED  ] %d tests.\n", unit_test.failed_test_count());
+            }
+            fflush(g_logFile);
         }
     }
 };
@@ -101,20 +149,44 @@ static VOID logcatLogPrint(UINT32 level, const PCHAR tag, const PCHAR fmt, ...)
         char taggedFmt[1024];
         snprintf(taggedFmt, sizeof(taggedFmt), "[%s] %s", tag, fmt);
         __android_log_vprint(androidLevel, LOG_TAG, taggedFmt, args);
+        if (g_logFile) {
+            va_end(args);
+            va_start(args, fmt);
+            vfprintf(g_logFile, taggedFmt, args);
+            fprintf(g_logFile, "\n");
+            fflush(g_logFile);
+        }
     } else {
         __android_log_vprint(androidLevel, LOG_TAG, fmt, args);
+        if (g_logFile) {
+            va_end(args);
+            va_start(args, fmt);
+            vfprintf(g_logFile, fmt, args);
+            fprintf(g_logFile, "\n");
+            fflush(g_logFile);
+        }
     }
     va_end(args);
 }
 
 extern "C" JNIEXPORT jint JNICALL Java_com_kvs_webrtctest_NativeTestLib_runTests(JNIEnv* env, jclass /* clazz */, jstring workDir,
-                                                                                  jstring filter)
+                                                                                  jstring filter, jstring logDir)
 {
     // Route KVS SDK logs to logcat
     globalCustomLogPrintFn = logcatLogPrint;
 
     const char* workDirStr = env->GetStringUTFChars(workDir, nullptr);
     const char* filterStr = env->GetStringUTFChars(filter, nullptr);
+    const char* logDirStr = env->GetStringUTFChars(logDir, nullptr);
+
+    // Open log file for persistent logging (survives logcat truncation)
+    std::string logPath = std::string(logDirStr) + "/test.log";
+    g_logFile = fopen(logPath.c_str(), "w");
+    if (g_logFile) {
+        __android_log_print(ANDROID_LOG_INFO, LOG_TAG, "Logging to %s", logPath.c_str());
+    } else {
+        __android_log_print(ANDROID_LOG_WARN, LOG_TAG, "Failed to open log file %s", logPath.c_str());
+    }
 
     // Change to working directory so tests find sample data at ../samples/
     chdir(workDirStr);
@@ -134,6 +206,12 @@ extern "C" JNIEXPORT jint JNICALL Java_com_kvs_webrtctest_NativeTestLib_runTests
 
     int rc = RUN_ALL_TESTS();
 
+    if (g_logFile) {
+        fclose(g_logFile);
+        g_logFile = nullptr;
+    }
+
+    env->ReleaseStringUTFChars(logDir, logDirStr);
     env->ReleaseStringUTFChars(filter, filterStr);
     env->ReleaseStringUTFChars(workDir, workDirStr);
 

--- a/scripts/run-android-app-test.sh
+++ b/scripts/run-android-app-test.sh
@@ -34,6 +34,9 @@ STATUS_CODE=$(grep '^INSTRUMENTATION_STATUS_CODE:' "$OUTPUT_LOG" | tail -1 | awk
 
 if [[ "$STATUS_CODE" != "0" ]]; then
   echo "::error::Tests failed (INSTRUMENTATION_STATUS_CODE: ${STATUS_CODE})"
+  LOG_FILE="/sdcard/Android/data/com.kvs.webrtctest/files/test.log"
+  echo "=== test.log ==="
+  "${ADB}" -s "${SERIAL}" pull "${LOG_FILE}" test.log 2>/dev/null && cat test.log || echo "(test.log not available)"
   echo "=== logcat ==="
   "${ADB}" -s "${SERIAL}" logcat -d -s "webrtc_test_jni:*" "WebRtcNativeTest:*" "TestRunner:*"
   echo "=== crash log ==="


### PR DESCRIPTION
## Summary
- Add file-based logging alongside logcat for Android test runs to survive logcat truncation on low-end devices

*What was changed?*
Added a `logDir` parameter to the JNI `runTests` method and a global `FILE*` in `jni_bridge.cpp` that mirrors all test output (gtest events and KVS SDK logs) to `<externalFilesDir>/test.log`. The CI script now pulls this file on failure.

*Why was it changed?*
On low-end Android devices, logcat gets truncated and test output is lost, making CI failures hard to diagnose. A persistent log file guarantees the full output is available.

*How was it changed?*
- `NativeTestLib.java`: Added `logDir` parameter to `runTests` JNI signature.
- `WebRtcNativeTest.java`: Passes `ctx.getExternalFilesDir(null)` as `logDir`.
- `jni_bridge.cpp`: Opens `<logDir>/test.log`, writes all `LogcatPrinter` events and `logcatLogPrint` output to it via `fprintf`/`vfprintf` with `fflush`, closes after `RUN_ALL_TESTS()`.
- `scripts/run-android-app-test.sh`: On failure, pulls `/sdcard/Android/data/com.kvs.webrtctest/files/test.log` via adb and cats it.

*What testing was done for the changes?*
Code review for correctness. The log file path uses the standard Android external files directory which is accessible via adb without root. Will be validated on next CI run with a connected device.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.