### PR TITLE
Use internal files dir for test log, retrieve via run-as

### DIFF
--- a/android-test-app/app/src/androidTest/java/com/kvs/webrtctest/WebRtcNativeTest.java
+++ b/android-test-app/app/src/androidTest/java/com/kvs/webrtctest/WebRtcNativeTest.java
@@ -65,14 +65,8 @@ public class WebRtcNativeTest {
         Bundle args = InstrumentationRegistry.getArguments();
         filter = args.getString("gtest_filter", "*");
 
-        // External files dir is accessible via adb pull without root
-        File extDir = ctx.getExternalFilesDir(null);
-        if (extDir != null) {
-            extDir.mkdirs();
-            logDir = extDir.getAbsolutePath();
-        } else {
-            logDir = tstDir.getAbsolutePath();
-        }
+        // Use internal files dir for logging – accessible via run-as on debuggable apps
+        logDir = filesDir.getAbsolutePath();
 
         Log.i(TAG, "Work dir: " + workDir);
         Log.i(TAG, "Samples dir: " + samplesDir.getAbsolutePath());

--- a/scripts/run-android-app-test.sh
+++ b/scripts/run-android-app-test.sh
@@ -34,9 +34,8 @@ STATUS_CODE=$(grep '^INSTRUMENTATION_STATUS_CODE:' "$OUTPUT_LOG" | tail -1 | awk
 
 if [[ "$STATUS_CODE" != "0" ]]; then
   echo "::error::Tests failed (INSTRUMENTATION_STATUS_CODE: ${STATUS_CODE})"
-  LOG_FILE="/sdcard/Android/data/com.kvs.webrtctest/files/test.log"
   echo "=== test.log ==="
-  "${ADB}" -s "${SERIAL}" pull "${LOG_FILE}" test.log 2>/dev/null && cat test.log || echo "(test.log not available)"
+  "${ADB}" -s "${SERIAL}" shell run-as com.kvs.webrtctest cat files/test.log 2>/dev/null || echo "(test.log not available)"
   echo "=== logcat ==="
   "${ADB}" -s "${SERIAL}" logcat -d -s "webrtc_test_jni:*" "WebRtcNativeTest:*" "TestRunner:*"
   echo "=== crash log ==="


### PR DESCRIPTION
## Summary
- Switch test log from external files dir to internal files dir
- Retrieve via `run-as` instead of `adb pull` for reliable access on all devices

*What was changed?*
Changed the Android test log file location from external files dir (`getExternalFilesDir`) to internal files dir (`getFilesDir`), and updated the CI script to retrieve it via `run-as` instead of `adb pull`.

*Why was it changed?*
External files dir has inconsistent permissions across Android devices — on some SDK 30 devices `adb pull` and `adb shell cat` both get permission denied, even though other SDK 30 devices work fine.

*How was it changed?*
- `WebRtcNativeTest.java`: Use `ctx.getFilesDir()` instead of `ctx.getExternalFilesDir(null)` for `logDir`.
- `scripts/run-android-app-test.sh`: Use `adb shell run-as com.kvs.webrtctest cat files/test.log` instead of `adb pull` from the external path.

*What testing was done for the changes?*
Tested on two SDK 30 devices with different permission behaviors. Internal files dir is always writable by the app and accessible via `run-as` on debuggable builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.