### PR TITLE
Guard ThreadpoolContext.h include behind ENABLE_KVS_THREADPOOL

### DIFF
--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -143,7 +143,9 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 ////////////////////////////////////////////////////
 // Project internal includes
 ////////////////////////////////////////////////////
+#ifdef ENABLE_KVS_THREADPOOL
 #include "Threadpool/ThreadpoolContext.h"
+#endif
 #include "Crypto/IOBuffer.h"
 #include "Crypto/Crypto.h"
 #include "Crypto/Dtls.h"


### PR DESCRIPTION
*What was changed?*
`ThreadpoolContext.h` is now included in `Include_i.h` only when `ENABLE_KVS_THREADPOOL` is defined, matching the CMake option that controls threadpool compilation.

*Why was it changed?*
The header was included unconditionally, pulling in threadpool type declarations (`PThreadpool`, `MUTEX`, threadpool function prototypes) into every translation unit regardless of whether the threadpool feature was enabled. This creates unnecessary symbol dependencies and can cause build failures when the threadpool library is not compiled.

*How was it changed?*
Wrapped the `#include "Threadpool/ThreadpoolContext.h"` in `Include_i.h` with `#ifdef ENABLE_KVS_THREADPOOL` / `#endif`, consistent with how all other threadpool usage in the codebase (`PeerConnection.c`, `LwsApiCalls.c`) is already guarded.

*What testing was done for the changes?*
Existing CI builds cover both `ENABLE_KVS_THREADPOOL=OFF` (default) and `ON` paths. The change is a one-line guard matching the established pattern used throughout the codebase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.