### PR TITLE
Add configurable jitter buffer max latency

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1281,6 +1281,12 @@ typedef struct {
     BOOL disableSenderSideBandwidthEstimation; //!< Disable TWCC feedback based sender bandwidth estimation, enabled by default.
                                                //!< You want to set this to TRUE if you are on a very stable connection and want to save 1.2MB of
                                                //!< memory
+
+    UINT32 jitterBufferMaxLatency; //!< Maximum time in 100ns units that a frame can remain in the jitter buffer before being dropped.
+                                   //!< An incomplete frame at the head of the jitter buffer blocks delivery of all subsequent complete frames
+                                   //!< until this timeout expires. Lower values reduce head-of-line blocking latency but increase frame drops
+                                   //!< under packet loss. If 0, DEFAULT_JITTER_BUFFER_MAX_LATENCY (2000ms) is used.
+
 #ifdef ENABLE_STATS_CALCULATION_CONTROL
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined
                          //!< to use this member, else stats are enabled by default.

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1171,6 +1171,9 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     pKvsPeerConnection->MTU = pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit == 0
         ? DEFAULT_MTU_SIZE_BYTES
         : pConfiguration->kvsRtcConfiguration.maximumTransmissionUnit;
+    pKvsPeerConnection->jitterBufferMaxLatency = pConfiguration->kvsRtcConfiguration.jitterBufferMaxLatency == 0
+        ? DEFAULT_JITTER_BUFFER_MAX_LATENCY
+        : pConfiguration->kvsRtcConfiguration.jitterBufferMaxLatency;
     ATOMIC_STORE_BOOL(&pKvsPeerConnection->sctpIsEnabled, FALSE);
     ATOMIC_STORE_BOOL(&pKvsPeerConnection->receiveEnabled, TRUE);
 
@@ -2001,7 +2004,7 @@ STATUS addTransceiver(PRtcPeerConnection pPeerConnection, PRtcMediaStreamTrack p
     // Audio codecs (Opus per RFC 7587, G.711) never fragment frames across RTP packets
     BOOL alwaysSinglePacketFrames = (pRtcMediaStreamTrack->codec == RTC_CODEC_OPUS || pRtcMediaStreamTrack->codec == RTC_CODEC_MULAW ||
                                      pRtcMediaStreamTrack->codec == RTC_CODEC_ALAW);
-    CHK_STATUS(createJitterBuffer(onFrameReadyFunc, onFrameDroppedFunc, depayFunc, DEFAULT_JITTER_BUFFER_MAX_LATENCY, clockRate,
+    CHK_STATUS(createJitterBuffer(onFrameReadyFunc, onFrameDroppedFunc, depayFunc, pKvsPeerConnection->jitterBufferMaxLatency, clockRate,
                                   (UINT64) pKvsRtpTransceiver, alwaysSinglePacketFrames, &pJitterBuffer));
     CHK_STATUS(kvsRtpTransceiverSetJitterBuffer(pKvsRtpTransceiver, pJitterBuffer));
 

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -177,6 +177,8 @@ typedef struct {
 
     UINT64 iceConnectingStartTime;
     KvsPeerConnectionDiagnostics peerConnectionDiagnostics;
+
+    UINT32 jitterBufferMaxLatency; //!< Max latency for jitter buffer, from KvsRtcConfiguration
 } KvsPeerConnection, *PKvsPeerConnection;
 
 typedef struct {

--- a/tst/H264JitterBufferIntegrationTest.cpp
+++ b/tst/H264JitterBufferIntegrationTest.cpp
@@ -65,6 +65,7 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
     std::vector<std::vector<BYTE>> mReceivedFrames;
     std::vector<UINT32> mReceivedFrameTimestamps;
     std::vector<UINT32> mDroppedFrameTimestamps;
+    std::vector<DOUBLE> mFrameDelayMs; // delay in ms for each delivered/dropped frame
 
     // Storage for RTP packets (for simulation)
     struct RtpPacketInfo {
@@ -123,6 +124,7 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
         mReceivedFrames.clear();
         mReceivedFrameTimestamps.clear();
         mDroppedFrameTimestamps.clear();
+        mFrameDelayMs.clear();
 
         if (mJitterBuffer != NULL) {
             freeJitterBuffer(&mJitterBuffer);
@@ -303,7 +305,21 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
         H264JitterBufferIntegrationTest* pTest = (H264JitterBufferIntegrationTest*) customData;
         UINT32 filledSize = 0;
 
-        DLOGS("Frame ready callback: startIndex=%u, endIndex=%u, frameSize=%u", startIndex, endIndex, frameSize);
+        UINT32 frameTsReady = 0;
+        UINT32 tailTsReady = 0;
+        if (pTest->mJitterBuffer != NULL) {
+            tailTsReady = pTest->mJitterBuffer->tailTimestamp;
+            // Look up the frame timestamp from the start packet
+            UINT64 hashValue = 0;
+            if (STATUS_SUCCEEDED(hashTableGet(pTest->mJitterBuffer->pPkgBufferHashTable, startIndex, &hashValue))) {
+                frameTsReady = ((PRtpPacket) hashValue)->header.timestamp;
+            }
+        }
+        INT32 delayTs = (INT32)(tailTsReady - frameTsReady);
+        DOUBLE delayMs = (pTest->mClockRate > 0) ? (DOUBLE) delayTs * 1000.0 / pTest->mClockRate : 0.0;
+        pTest->mFrameDelayMs.push_back(delayMs);
+        DLOGI("Frame READY: startIndex=%u, endIndex=%u, frameSize=%u, frameTs=%u, tailTs=%u, delay=%d (%.1fms)",
+              startIndex, endIndex, frameSize, frameTsReady, tailTsReady, delayTs, delayMs);
 
         if (frameSize == 0) {
             DLOGW("Frame size is 0, skipping");
@@ -339,11 +355,16 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
 
     static STATUS h264FrameDroppedCallback(UINT64 customData, UINT16 startIndex, UINT16 endIndex, UINT32 timestamp)
     {
-        UNUSED_PARAM(startIndex);
-        UNUSED_PARAM(endIndex);
-        DLOGS("Frame dropped callback: startIndex=%u, endIndex=%u, timestamp=%u", startIndex, endIndex, timestamp);
-
         H264JitterBufferIntegrationTest* pTest = (H264JitterBufferIntegrationTest*) customData;
+        UINT32 tailTsDropped = 0;
+        if (pTest->mJitterBuffer != NULL) {
+            tailTsDropped = pTest->mJitterBuffer->tailTimestamp;
+        }
+        INT32 delayTs = (INT32)(tailTsDropped - timestamp);
+        DOUBLE delayMs = (pTest->mClockRate > 0) ? (DOUBLE) delayTs * 1000.0 / pTest->mClockRate : 0.0;
+        pTest->mFrameDelayMs.push_back(delayMs);
+        DLOGI("Frame DROPPED: startIndex=%u, endIndex=%u, frameTs=%u, tailTs=%u, delay=%d (%.1fms)",
+              startIndex, endIndex, timestamp, tailTsDropped, delayTs, delayMs);
         pTest->mTotalFramesDropped++;
         pTest->mDroppedFrameTimestamps.push_back(timestamp);
         return STATUS_SUCCESS;
@@ -826,8 +847,13 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
         freeJitterBuffer(&mJitterBuffer);
         mJitterBuffer = NULL;
 
-        DLOGI("reorder=%u: received=%u (flush added %u), dropped=%u (flush added %u), packets dropped=%zu", maxReorderDistance, mTotalFramesReceived,
-              mTotalFramesReceived - receivedBeforeFlush, mTotalFramesDropped, mTotalFramesDropped - droppedBeforeFlush, dropIndices.size());
+        DOUBLE avgDelayMs = 0.0;
+        if (!mFrameDelayMs.empty()) {
+            avgDelayMs = std::accumulate(mFrameDelayMs.begin(), mFrameDelayMs.end(), 0.0) / mFrameDelayMs.size();
+        }
+        DLOGI("reorder=%u: received=%u (flush added %u), dropped=%u (flush added %u), packets dropped=%zu, avgDelayMs=%.1f",
+              maxReorderDistance, mTotalFramesReceived, mTotalFramesReceived - receivedBeforeFlush, mTotalFramesDropped,
+              mTotalFramesDropped - droppedBeforeFlush, dropIndices.size(), avgDelayMs);
 
         // Count intact frames that were incorrectly dropped
         mIntactFramesDropped = countIntactFramesDropped(dropIndices);
@@ -853,6 +879,10 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
         DLOGI("Frame accounting: received=%u + dropped=%u = %u, expected=%u (NUM_FRAMES=%u - fullyDropped=%u)", mTotalFramesReceived,
               mTotalFramesDropped, accountedFrames, expectedAccountedFrames, numFrames, analysis.framesFullyDropped);
         EXPECT_EQ(expectedAccountedFrames, accountedFrames) << "Frame accounting mismatch: some frames are unaccounted for";
+
+        // Average delay must not exceed max latency
+        DOUBLE maxLatencyMs = (DOUBLE) H264_INTEGRATION_TEST_MAX_LATENCY / (DOUBLE) HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        EXPECT_LE(avgDelayMs, maxLatencyMs) << "Average frame delay " << avgDelayMs << "ms exceeds max latency " << maxLatencyMs << "ms";
     }
 };
 
@@ -962,6 +992,18 @@ TEST_F(H264JitterBufferIntegrationTest, markerPacketFirstAtTimestampZeroNoDouble
     // Verify frame 0 was received with correct timestamp
     ASSERT_GE(mReceivedFrameTimestamps.size(), 1u);
     EXPECT_EQ(0u, mReceivedFrameTimestamps[0]) << "Frame 0 should have timestamp 0";
+}
+
+// Test: Single dropped packet in first frame delays all subsequent frames
+TEST_F(H264JitterBufferIntegrationTest, singleDropInFirstFrameDelaysAll)
+{
+    // Drop only packet index 1 (second packet of first frame)
+    auto dropSecondPacket = [](UINT32 totalPackets) {
+        std::set<UINT32> drops;
+        drops.insert(1);
+        return drops;
+    };
+    runPacketLossTest("../samples/girH264", 1000, dropSecondPacket);
 }
 
 // Benchmark test: Records jitter buffer deficiency metrics


### PR DESCRIPTION
*What was changed?*
Added `jitterBufferMaxLatency` field to `KvsRtcConfiguration` allowing applications to configure the maximum time an incomplete frame can block the jitter buffer. Added frame delivery delay instrumentation and assertions to H264 integration tests.

*Why was it changed?*
An incomplete frame at the head of the jitter buffer blocks delivery of all subsequent complete frames until the max latency timeout fires. With the default 2000ms max latency, a single lost packet can delay 60+ complete frames by up to 2 seconds. With 5000ms, the delay is even worse. Applications need the ability to tune this tradeoff between head-of-line blocking latency and frame drop rate under packet loss.

*How was it changed?*
- Added `jitterBufferMaxLatency` (UINT32, 100ns units) to `KvsRtcConfiguration` in Include.h
- Store the value in `KvsPeerConnection` during `createPeerConnection`, defaulting to `DEFAULT_JITTER_BUFFER_MAX_LATENCY` (2000ms) when 0
- Pass the configured value to `createJitterBuffer` in `addTransceiver` instead of the hardcoded default
- Added delay tracking (delayMs) to H264 integration test callbacks for both delivered and dropped frames
- Added avgDelayMs summary and assertion that average delay does not exceed max latency
- Added `singleDropInFirstFrameDelaysAll` test demonstrating head-of-line blocking from a single lost packet

*What testing was done for the changes?*
All 10 H264JitterBufferIntegrationTest tests pass. The new singleDropInFirstFrameDelaysAll test confirms that one lost packet in the first frame delays ~150 subsequent complete frames by up to 5 seconds (with 5s max latency). The delay instrumentation shows avgDelayMs=0.7ms for perfect delivery vs avgDelayMs=4243ms with 1% packet loss.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.