### PR TITLE
Add configurable socket receive buffer size

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1270,6 +1270,8 @@ typedef struct {
 
     UINT32 sendBufSize; //!< Socket send buffer length. Item larger then this size will get dropped. Use system default if 0.
 
+    UINT32 recvBufSize; //!< Socket receive buffer length. Use system default if 0.
+
     UINT64 filterCustomData; //!< Custom Data that can be populated by the developer while developing filter function
 
     IceSetInterfaceFilterFunc iceSetInterfaceFilterFunc; //!< Filter function callback to be set when the developer

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -526,7 +526,8 @@ STATUS iceAgentInitHostCandidate(PIceAgent pIceAgent)
 
         if (pDuplicatedIceCandidate == NULL &&
             STATUS_SUCCEEDED(createSocketConnection(pIpAddress->family, KVS_SOCKET_PROTOCOL_UDP, pIpAddress, NULL, (UINT64) pIceAgent,
-                                                    incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize, &pSocketConnection))) {
+                                                    incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize,
+                                                    pIceAgent->kvsRtcConfiguration.recvBufSize, &pSocketConnection))) {
             pTmpIceCandidate = MEMCALLOC(1, SIZEOF(IceCandidate));
             generateJSONSafeString(pTmpIceCandidate->id, ARRAY_SIZE(pTmpIceCandidate->id));
             pTmpIceCandidate->isRemote = FALSE;
@@ -1828,7 +1829,8 @@ STATUS iceAgentInitSrflxCandidate(PIceAgent pIceAgent)
         // The new port will be stored in pNewCandidate->ipAddress.port. And the IP address will later be updated
         // with the correct IP address once the STUN response is received.
         CHK_STATUS(createSocketConnection(pCandidate->ipAddress.family, KVS_SOCKET_PROTOCOL_UDP, &pCandidate->ipAddress, NULL, (UINT64) pIceAgent,
-                                          incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize, &pCandidate->pSocketConnection));
+                                          incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize,
+                                          pIceAgent->kvsRtcConfiguration.recvBufSize, &pCandidate->pSocketConnection));
         ATOMIC_STORE_BOOL(&pCandidate->pSocketConnection->receiveData, TRUE);
         // connectionListener will free the pSocketConnection at the end.
         CHK_STATUS(connectionListenerAddConnection(pIceAgent->pConnectionListener, pCandidate->pSocketConnection));
@@ -1983,7 +1985,8 @@ STATUS iceAgentInitRelayCandidate(PIceAgent pIceAgent, UINT32 iceServerIndex, KV
     // with the correct relay IP address once the Allocation success response is received. Relay candidate's socket is managed
     // by TurnConnection struct.
     CHK_STATUS(createSocketConnection(turnServerIpFamily, protocol, NULL, pTurnServerAddress, (UINT64) pNewCandidate, incomingRelayedDataHandler,
-                                      pIceAgent->kvsRtcConfiguration.sendBufSize, &pNewCandidate->pSocketConnection));
+                                      pIceAgent->kvsRtcConfiguration.sendBufSize, pIceAgent->kvsRtcConfiguration.recvBufSize,
+                                      &pNewCandidate->pSocketConnection));
     // connectionListener will free the pSocketConnection at the end.
     CHK_STATUS(connectionListenerAddConnection(pIceAgent->pConnectionListener, pNewCandidate->pSocketConnection));
 

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -1829,8 +1829,8 @@ STATUS iceAgentInitSrflxCandidate(PIceAgent pIceAgent)
         // The new port will be stored in pNewCandidate->ipAddress.port. And the IP address will later be updated
         // with the correct IP address once the STUN response is received.
         CHK_STATUS(createSocketConnection(pCandidate->ipAddress.family, KVS_SOCKET_PROTOCOL_UDP, &pCandidate->ipAddress, NULL, (UINT64) pIceAgent,
-                                          incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize,
-                                          pIceAgent->kvsRtcConfiguration.recvBufSize, &pCandidate->pSocketConnection));
+                                          incomingDataHandler, pIceAgent->kvsRtcConfiguration.sendBufSize, pIceAgent->kvsRtcConfiguration.recvBufSize,
+                                          &pCandidate->pSocketConnection));
         ATOMIC_STORE_BOOL(&pCandidate->pSocketConnection->receiveData, TRUE);
         // connectionListener will free the pSocketConnection at the end.
         CHK_STATUS(connectionListenerAddConnection(pIceAgent->pConnectionListener, pCandidate->pSocketConnection));

--- a/src/source/Ice/NatBehaviorDiscovery.c
+++ b/src/source/Ice/NatBehaviorDiscovery.c
@@ -300,7 +300,7 @@ STATUS discoverNatBehavior(PCHAR stunServer, NAT_BEHAVIOR* pNatMappingBehavior, 
     CHK_WARN(pSelectedLocalInterface != NULL, retStatus, "No usable local interface");
 
     CHK_STATUS(createSocketConnection(iceServerStun.ipAddresses.ipv4Address.family, KVS_SOCKET_PROTOCOL_UDP, pSelectedLocalInterface, NULL,
-                                      (UINT64) &customData, natTestIncomingDataHandler, 0, &pSocketConnection));
+                                      (UINT64) &customData, natTestIncomingDataHandler, 0, 0, &pSocketConnection));
     ATOMIC_STORE_BOOL(&pSocketConnection->receiveData, TRUE);
 
     CHK_STATUS(createConnectionListener(&pConnectionListener));
@@ -324,7 +324,7 @@ STATUS discoverNatBehavior(PCHAR stunServer, NAT_BEHAVIOR* pNatMappingBehavior, 
     CHK_STATUS(connectionListenerRemoveAllConnection(pConnectionListener));
     freeSocketConnection(&pSocketConnection);
     CHK_STATUS(createSocketConnection(iceServerStun.ipAddresses.ipv4Address.family, KVS_SOCKET_PROTOCOL_UDP, pSelectedLocalInterface, NULL,
-                                      (UINT64) &customData, natTestIncomingDataHandler, 0, &pSocketConnection));
+                                      (UINT64) &customData, natTestIncomingDataHandler, 0, 0, &pSocketConnection));
     ATOMIC_STORE_BOOL(&pSocketConnection->receiveData, TRUE);
     CHK_STATUS(connectionListenerAddConnection(pConnectionListener, pSocketConnection));
 

--- a/src/source/Ice/Network.c
+++ b/src/source/Ice/Network.c
@@ -164,7 +164,7 @@ CleanUp:
 }
 #endif
 
-STATUS createSocket(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL protocol, UINT32 sendBufSize, PINT32 pOutSockFd)
+STATUS createSocket(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL protocol, UINT32 sendBufSize, UINT32 recvBufSize, PINT32 pOutSockFd)
 {
     STATUS retStatus = STATUS_SUCCESS;
 
@@ -192,13 +192,8 @@ STATUS createSocket(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL protocol,
         CHK(FALSE, STATUS_SOCKET_SET_SEND_BUFFER_SIZE_FAILED);
     }
 
-    // Increase UDP receive buffer to handle burst traffic (e.g. a full video
-    // frame worth of RTP packets arriving before the reader thread drains them).
-    if (protocol == KVS_SOCKET_PROTOCOL_UDP) {
-        INT32 rcvBufSize = 512 * 1024;
-        if (setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &rcvBufSize, SIZEOF(rcvBufSize)) < 0) {
-            DLOGD("setsockopt() SO_RCVBUF failed with errno %s", getErrorString(getErrorCode()));
-        }
+    if (recvBufSize > 0 && setsockopt(sockfd, SOL_SOCKET, SO_RCVBUF, &recvBufSize, SIZEOF(recvBufSize)) < 0) {
+        DLOGW("setsockopt() SO_RCVBUF failed with errno %s", getErrorString(getErrorCode()));
     }
 
     *pOutSockFd = (INT32) sockfd;

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -73,11 +73,12 @@ STATUS createSocketPair(INT32 (*)[2]);
  * @param - KVS_IP_FAMILY_TYPE - IN - Family for the socket. Must be one of KVS_IP_FAMILY_TYPE
  * @param - KVS_SOCKET_PROTOCOL - IN - either tcp or udp
  * @param - UINT32 - IN - send buffer size in bytes
+ * @param - UINT32 - IN - receive buffer size in bytes
  * @param - PINT32 - OUT - PINT32 for the socketfd
  *
  * @return - STATUS status of execution
  */
-STATUS createSocket(KVS_IP_FAMILY_TYPE, KVS_SOCKET_PROTOCOL, UINT32, PINT32);
+STATUS createSocket(KVS_IP_FAMILY_TYPE, KVS_SOCKET_PROTOCOL, UINT32, UINT32, PINT32);
 
 /**
  * @param - INT32 - IN - INT32 for the socketfd

--- a/src/source/Ice/SocketConnection.c
+++ b/src/source/Ice/SocketConnection.c
@@ -5,7 +5,7 @@
 #include "../Include_i.h"
 
 STATUS createSocketConnection(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL protocol, PKvsIpAddress pBindAddr, PKvsIpAddress pPeerIpAddr,
-                              UINT64 customData, ConnectionDataAvailableFunc dataAvailableFn, UINT32 sendBufSize,
+                              UINT64 customData, ConnectionDataAvailableFunc dataAvailableFn, UINT32 sendBufSize, UINT32 recvBufSize,
                               PSocketConnection* ppSocketConnection)
 {
     ENTERS();
@@ -22,7 +22,7 @@ STATUS createSocketConnection(KVS_IP_FAMILY_TYPE familyType, KVS_SOCKET_PROTOCOL
     pSocketConnection->lock = MUTEX_CREATE(FALSE);
     CHK(pSocketConnection->lock != INVALID_MUTEX_VALUE, STATUS_INVALID_OPERATION);
 
-    CHK_STATUS(createSocket(familyType, protocol, sendBufSize, &pSocketConnection->localSocket));
+    CHK_STATUS(createSocket(familyType, protocol, sendBufSize, recvBufSize, &pSocketConnection->localSocket));
     if (pBindAddr) {
         CHK_STATUS(socketBind(pBindAddr, pSocketConnection->localSocket));
         pSocketConnection->hostIpAddr = *pBindAddr;

--- a/src/source/Ice/SocketConnection.h
+++ b/src/source/Ice/SocketConnection.h
@@ -68,12 +68,13 @@ typedef struct __SocketConnection* PSocketConnection;
  * @param - UINT64 - IN - data available callback custom data
  * @param - ConnectionDataAvailableFunc - IN - data available callback (OPTIONAL)
  * @param - UINT32 - IN - send buffer size in bytes
+ * @param - UINT32 - IN - receive buffer size in bytes
  * @param - PSocketConnection* - OUT - the resulting SocketConnection struct
  *
  * @return - STATUS - status of execution
  */
 STATUS createSocketConnection(KVS_IP_FAMILY_TYPE, KVS_SOCKET_PROTOCOL, PKvsIpAddress, PKvsIpAddress, UINT64, ConnectionDataAvailableFunc, UINT32,
-                              PSocketConnection*);
+                              UINT32, PSocketConnection*);
 
 /**
  * Free the SocketConnection struct

--- a/tst/IceApiTest.cpp
+++ b/tst/IceApiTest.cpp
@@ -26,7 +26,7 @@ TEST_F(IceApiTest, ConnectionListenerApiTest)
     localhost.port = 0;
 
     EXPECT_EQ(STATUS_SUCCESS,
-              createSocketConnection(KVS_IP_FAMILY_TYPE_IPV4, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0, &pDummySocketConnection));
+              createSocketConnection(KVS_IP_FAMILY_TYPE_IPV4, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0, 0, &pDummySocketConnection));
 
     EXPECT_NE(STATUS_SUCCESS, createConnectionListener(NULL));
     EXPECT_NE(STATUS_SUCCESS, freeConnectionListener(NULL));

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -138,7 +138,7 @@ PVOID connectionListenAddConnectionRoutine(PVOID arg)
     for (i = 0; i < pCustomData->connectionToAdd; ++i) {
         randomDelay = (UINT64) (RAND() % 300) * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
         THREAD_SLEEP(randomDelay);
-        CHECK(STATUS_SUCCEEDED(createSocketConnection((KVS_IP_FAMILY_TYPE) localhost.family, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0,
+        CHECK(STATUS_SUCCEEDED(createSocketConnection((KVS_IP_FAMILY_TYPE) localhost.family, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0, 0,
                                                       &pSocketConnection)));
         pCustomData->socketConnectionList[i] = pSocketConnection;
         CHECK(STATUS_SUCCEEDED(connectionListenerAddConnection(pCustomData->pConnectionListener, pSocketConnection)));
@@ -190,7 +190,7 @@ TEST_F(IceFunctionalityTest, connectionListenerFunctionalityTest)
     EXPECT_EQ(connectionCount, routine1CustomData.connectionToAdd + routine2CustomData.connectionToAdd);
 
     CHECK(STATUS_SUCCEEDED(
-        createSocketConnection((KVS_IP_FAMILY_TYPE) localhost.family, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0, &pSocketConnection)));
+        createSocketConnection((KVS_IP_FAMILY_TYPE) localhost.family, KVS_SOCKET_PROTOCOL_UDP, &localhost, NULL, 0, NULL, 0, 0, &pSocketConnection)));
     EXPECT_EQ(STATUS_SUCCESS, connectionListenerAddConnection(pConnectionListener, pSocketConnection));
 
     newConnectionCount = pConnectionListener->socketCount;

--- a/tst/TurnConnectionFunctionalityTest.cpp
+++ b/tst/TurnConnectionFunctionalityTest.cpp
@@ -71,7 +71,7 @@ class TurnConnectionFunctionalityTest : public WebRtcClientTestBase {
         };
         EXPECT_EQ(STATUS_SUCCESS,
                   createSocketConnection((KVS_IP_FAMILY_TYPE) pTurnServer->ipAddresses.ipv4Address.family, KVS_ICE_DEFAULT_TURN_PROTOCOL, NULL,
-                                         &pTurnServer->ipAddresses.ipv4Address, (UINT64) this, onDataHandler, 0, &pTurnSocket));
+                                         &pTurnServer->ipAddresses.ipv4Address, (UINT64) this, onDataHandler, 0, 0, &pTurnSocket));
         EXPECT_EQ(STATUS_SUCCESS, connectionListenerAddConnection(pConnectionListener, pTurnSocket));
         ASSERT_EQ(STATUS_SUCCESS,
                   createTurnConnection(pTurnServer, timerQueueHandle, TURN_CONNECTION_DATA_TRANSFER_MODE_DATA_CHANNEL, KVS_ICE_DEFAULT_TURN_PROTOCOL,

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -320,6 +320,11 @@ void WebRtcClientTestBase::initRtcConfiguration(PRtcConfiguration pRtcConfigurat
     pRtcConfiguration->kvsRtcConfiguration.iceLocalCandidateGatheringTimeout = KVS_CONVERT_TIMESCALE(1000, 1000, HUNDREDS_OF_NANOS_IN_A_SECOND);
     pRtcConfiguration->kvsRtcConfiguration.iceConnectionCheckTimeout = KVS_CONVERT_TIMESCALE(1000, 1000, HUNDREDS_OF_NANOS_IN_A_SECOND);
     pRtcConfiguration->kvsRtcConfiguration.iceCandidateNominationTimeout = KVS_CONVERT_TIMESCALE(2000, 1000, HUNDREDS_OF_NANOS_IN_A_SECOND);
+    // Low-end Android devices we run tests on have small default socket
+    // receive buffers, causing packet drops under burst traffic.
+#ifdef __ANDROID__
+    pRtcConfiguration->kvsRtcConfiguration.recvBufSize = 512 * 1024;
+#endif
 }
 
 PCHAR WebRtcClientTestBase::GetTestName()


### PR DESCRIPTION
## Summary
- Add `recvBufSize` field to `KvsRtcConfiguration`, mirroring the existing `sendBufSize` pattern
- Pass `recvBufSize` through `createSocketConnection` and `createSocket` to apply `SO_RCVBUF` via `setsockopt`
- Set 512KB default on Android in test fixture to prevent packet drops on low-end devices

*What was changed?*
Added a new `recvBufSize` field to `KvsRtcConfiguration` and plumbed it through the socket creation APIs (`createSocket`, `createSocketConnection`) to allow configuring `SO_RCVBUF` on ICE sockets. Previously the receive buffer was hardcoded to 512KB for UDP sockets. Now it is configurable, with 0 meaning system default. Android test fixture sets 512KB explicitly.

*Why was it changed?*
The receive buffer size was hardcoded and not configurable by the application. Low-end Android devices have small default socket receive buffers that cause packet drops under burst traffic (e.g. a full video frame worth of RTP packets). Making it configurable allows applications to tune buffer sizes per platform.

*How was it changed?*
- Added `UINT32 recvBufSize` to `KvsRtcConfiguration` in `Include.h`
- Added `recvBufSize` parameter to `createSocket()` in `Network.h/.c`
- Added `recvBufSize` parameter to `createSocketConnection()` in `SocketConnection.h/.c`
- Updated all call sites in `IceAgent.c` (3), `NatBehaviorDiscovery.c` (2), and test files (4)
- Added `#ifdef __ANDROID__` block in `initRtcConfiguration` test fixture to set 512KB default

*What testing was done for the changes?*
Updated all test call sites to pass the new parameter. Verified compilation of the library target succeeds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.