### PR TITLE
Pluggable jitter buffer interface with vtable dispatch

### DIFF
--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -5,132 +5,197 @@
 // Applies only to the case where the very first frame has its first packets out of order
 #define MAX_OUT_OF_ORDER_PACKET_DIFFERENCE 512
 
-// forward declaration
-STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed);
+#define JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT  3000
+#define JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH 2
+
+// Internal struct for the default jitter buffer implementation.
+// The base JitterBuffer must be the first member so that a PJitterBuffer
+// pointer can be safely cast to PJitterBufferInternal.
+typedef struct {
+    JitterBuffer base;
+    FrameReadyFunc onFrameReadyFn;
+    FrameDroppedFunc onFrameDroppedFn;
+    DepayRtpPayloadFunc depayPayloadFn;
+    UINT16 headSequenceNumber;
+    UINT16 tailSequenceNumber;
+    UINT32 headTimestamp;
+    UINT64 maxLatency;
+    UINT64 customData;
+    BOOL started;
+    BOOL firstFrameProcessed;
+    BOOL sequenceNumberOverflowState;
+    BOOL timestampOverFlowState;
+    BOOL alwaysSinglePacketFrames;
+    PHashTable pPkgBufferHashTable;
+} JitterBufferInternal, *PJitterBufferInternal;
+
+// forward declarations of default implementations
+static STATUS defaultPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded);
+static STATUS defaultDestroy(PJitterBuffer* ppJitterBuffer);
+static STATUS defaultFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex, UINT16 endIndex);
+static STATUS defaultFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
+                                           UINT16 endIndex);
+static STATUS defaultGetPacket(PJitterBuffer pJitterBuffer, UINT16 seqNum, PRtpPacket* ppPacket);
+static STATUS defaultDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex, UINT16 endIndex, UINT32 nextTimestamp);
+static STATUS jitterBufferInternalParse(PJitterBufferInternal pInternal, BOOL bufferClosed);
+
+//
+// Public dispatcher functions — these call through the vtable
+//
+
+STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded)
+{
+    if (pJitterBuffer == NULL || pJitterBuffer->pushFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return pJitterBuffer->pushFn(pJitterBuffer, pRtpPacket, pPacketDiscarded);
+}
+
+STATUS freeJitterBuffer(PJitterBuffer* ppJitterBuffer)
+{
+    if (ppJitterBuffer == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    if (*ppJitterBuffer == NULL) {
+        return STATUS_SUCCESS;
+    }
+    if ((*ppJitterBuffer)->destroyFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return (*ppJitterBuffer)->destroyFn(ppJitterBuffer);
+}
+
+STATUS jitterBufferFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex, UINT16 endIndex)
+{
+    if (pJitterBuffer == NULL || pJitterBuffer->fillFrameDataFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return pJitterBuffer->fillFrameDataFn(pJitterBuffer, pFrame, frameSize, pFilledSize, startIndex, endIndex);
+}
+
+STATUS jitterBufferFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
+                                         UINT16 endIndex)
+{
+    if (pJitterBuffer == NULL || pJitterBuffer->fillPartialFrameDataFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return pJitterBuffer->fillPartialFrameDataFn(pJitterBuffer, pFrame, frameSize, pFilledSize, startIndex, endIndex);
+}
+
+STATUS jitterBufferGetPacket(PJitterBuffer pJitterBuffer, UINT16 seqNum, PRtpPacket* ppPacket)
+{
+    if (pJitterBuffer == NULL || pJitterBuffer->getPacketFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return pJitterBuffer->getPacketFn(pJitterBuffer, seqNum, ppPacket);
+}
+
+STATUS jitterBufferDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex, UINT16 endIndex, UINT32 nextTimestamp)
+{
+    if (pJitterBuffer == NULL || pJitterBuffer->dropBufferDataFn == NULL) {
+        return STATUS_NULL_ARG;
+    }
+    return pJitterBuffer->dropBufferDataFn(pJitterBuffer, startIndex, endIndex, nextTimestamp);
+}
+
+//
+// Constructor — allocates JitterBufferInternal and wires vtable
+//
 
 STATUS createJitterBuffer(FrameReadyFunc onFrameReadyFunc, FrameDroppedFunc onFrameDroppedFunc, DepayRtpPayloadFunc depayRtpPayloadFunc,
                           UINT32 maxLatency, UINT32 clockRate, UINT64 customData, BOOL alwaysSinglePacketFrames, PJitterBuffer* ppJitterBuffer)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    PJitterBuffer pJitterBuffer = NULL;
+    PJitterBufferInternal pInternal = NULL;
 
     CHK(ppJitterBuffer != NULL && onFrameReadyFunc != NULL && onFrameDroppedFunc != NULL && depayRtpPayloadFunc != NULL, STATUS_NULL_ARG);
     CHK(clockRate != 0, STATUS_INVALID_ARG);
 
-    pJitterBuffer = (PJitterBuffer) MEMALLOC(SIZEOF(JitterBuffer));
-    CHK(pJitterBuffer != NULL, STATUS_NOT_ENOUGH_MEMORY);
+    pInternal = (PJitterBufferInternal) MEMALLOC(SIZEOF(JitterBufferInternal));
+    CHK(pInternal != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
-    pJitterBuffer->onFrameReadyFn = onFrameReadyFunc;
-    pJitterBuffer->onFrameDroppedFn = onFrameDroppedFunc;
-    pJitterBuffer->depayPayloadFn = depayRtpPayloadFunc;
-    pJitterBuffer->clockRate = clockRate;
+    // Wire vtable
+    pInternal->base.pushFn = defaultPush;
+    pInternal->base.destroyFn = defaultDestroy;
+    pInternal->base.fillFrameDataFn = defaultFillFrameData;
+    pInternal->base.fillPartialFrameDataFn = defaultFillPartialFrameData;
+    pInternal->base.getPacketFn = defaultGetPacket;
+    pInternal->base.dropBufferDataFn = defaultDropBufferData;
 
-    pJitterBuffer->maxLatency = maxLatency;
-    if (pJitterBuffer->maxLatency == 0) {
-        pJitterBuffer->maxLatency = DEFAULT_JITTER_BUFFER_MAX_LATENCY;
+    // Public fields
+    pInternal->base.clockRate = clockRate;
+    pInternal->base.transit = 0;
+    pInternal->base.jitter = 0;
+    pInternal->base.tailTimestamp = 0;
+
+    // Private fields
+    pInternal->onFrameReadyFn = onFrameReadyFunc;
+    pInternal->onFrameDroppedFn = onFrameDroppedFunc;
+    pInternal->depayPayloadFn = depayRtpPayloadFunc;
+
+    pInternal->maxLatency = maxLatency;
+    if (pInternal->maxLatency == 0) {
+        pInternal->maxLatency = DEFAULT_JITTER_BUFFER_MAX_LATENCY;
     }
-    pJitterBuffer->maxLatency = pJitterBuffer->maxLatency * pJitterBuffer->clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pInternal->maxLatency = pInternal->maxLatency * pInternal->base.clockRate / HUNDREDS_OF_NANOS_IN_A_SECOND;
 
-    CHK(pJitterBuffer->maxLatency < MAX_RTP_TIMESTAMP, STATUS_INVALID_ARG);
+    CHK(pInternal->maxLatency < MAX_RTP_TIMESTAMP, STATUS_INVALID_ARG);
 
-    pJitterBuffer->tailTimestamp = 0;
-    pJitterBuffer->headTimestamp = MAX_UINT32;
-    pJitterBuffer->headSequenceNumber = MAX_RTP_SEQUENCE_NUM;
-    pJitterBuffer->tailSequenceNumber = MAX_RTP_SEQUENCE_NUM;
-    pJitterBuffer->started = FALSE;
-    pJitterBuffer->firstFrameProcessed = FALSE;
-    pJitterBuffer->timestampOverFlowState = FALSE;
-    pJitterBuffer->sequenceNumberOverflowState = FALSE;
-    pJitterBuffer->alwaysSinglePacketFrames = alwaysSinglePacketFrames;
+    pInternal->headTimestamp = MAX_UINT32;
+    pInternal->headSequenceNumber = MAX_RTP_SEQUENCE_NUM;
+    pInternal->tailSequenceNumber = MAX_RTP_SEQUENCE_NUM;
+    pInternal->started = FALSE;
+    pInternal->firstFrameProcessed = FALSE;
+    pInternal->timestampOverFlowState = FALSE;
+    pInternal->sequenceNumberOverflowState = FALSE;
+    pInternal->alwaysSinglePacketFrames = alwaysSinglePacketFrames;
 
-    pJitterBuffer->customData = customData;
+    pInternal->customData = customData;
     CHK_STATUS(hashTableCreateWithParams(JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT, JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH,
-                                         &pJitterBuffer->pPkgBufferHashTable));
+                                         &pInternal->pPkgBufferHashTable));
 
 CleanUp:
-    if (STATUS_FAILED(retStatus) && pJitterBuffer != NULL) {
-        freeJitterBuffer(&pJitterBuffer);
-        pJitterBuffer = NULL;
+    if (STATUS_FAILED(retStatus) && pInternal != NULL) {
+        PJitterBuffer pTemp = (PJitterBuffer) pInternal;
+        freeJitterBuffer(&pTemp);
+        pInternal = NULL;
     }
 
     if (ppJitterBuffer != NULL) {
-        *ppJitterBuffer = pJitterBuffer;
+        *ppJitterBuffer = (PJitterBuffer) pInternal;
     }
 
     LEAVES();
     return retStatus;
 }
 
-STATUS freeJitterBuffer(PJitterBuffer* ppJitterBuffer)
-{
-    ENTERS();
+//
+// Default implementation — internal helpers
+//
 
-    STATUS retStatus = STATUS_SUCCESS;
-    PJitterBuffer pJitterBuffer = NULL;
-
-    CHK(ppJitterBuffer != NULL, STATUS_NULL_ARG);
-    // freeJitterBuffer is idempotent
-    CHK(*ppJitterBuffer != NULL, retStatus);
-
-    pJitterBuffer = *ppJitterBuffer;
-
-    // Parse repeatedly until all frames are processed.
-    // After marker bit delivery, the parse breaks early, so we need to loop
-    // to ensure all remaining frames are delivered/dropped.
-    if (pJitterBuffer->started) {
-        UINT16 prevHead = pJitterBuffer->headSequenceNumber;
-        UINT32 maxIterations = 65536; // Safety limit to prevent infinite loops
-        while (maxIterations-- > 0) {
-            jitterBufferInternalParse(pJitterBuffer, TRUE);
-            // If head didn't advance, we're done or stuck
-            if (pJitterBuffer->headSequenceNumber == prevHead) {
-                break;
-            }
-            // If we've processed everything, we're done
-            // Use signed comparison to handle wraparound
-            INT32 remaining = (INT32) ((UINT16) (pJitterBuffer->tailSequenceNumber - pJitterBuffer->headSequenceNumber + 1));
-            if (remaining <= 0) {
-                break;
-            }
-            prevHead = pJitterBuffer->headSequenceNumber;
-        }
-        // Clean up any remaining packets that weren't delivered/dropped
-        jitterBufferDropBufferData(pJitterBuffer, pJitterBuffer->headSequenceNumber, pJitterBuffer->tailSequenceNumber, 0);
-    }
-    hashTableFree(pJitterBuffer->pPkgBufferHashTable);
-
-    SAFE_MEMFREE(*ppJitterBuffer);
-
-CleanUp:
-    CHK_LOG_ERR(retStatus);
-
-    LEAVES();
-    return retStatus;
-}
-
-BOOL underflowPossible(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL underflowPossible(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
     UINT32 seqNoDifference = 0;
     UINT64 timestampDifference = 0;
     UINT64 maxTimePassed = 0;
-    if (pJitterBuffer->headTimestamp == pRtpPacket->header.timestamp) {
+    if (pInternal->headTimestamp == pRtpPacket->header.timestamp) {
         retVal = TRUE;
     } else {
-        seqNoDifference = (MAX_RTP_SEQUENCE_NUM - pRtpPacket->header.sequenceNumber) + pJitterBuffer->headSequenceNumber;
-        if (pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp) {
-            timestampDifference = pJitterBuffer->headTimestamp - pRtpPacket->header.timestamp;
+        seqNoDifference = (MAX_RTP_SEQUENCE_NUM - pRtpPacket->header.sequenceNumber) + pInternal->headSequenceNumber;
+        if (pInternal->headTimestamp > pRtpPacket->header.timestamp) {
+            timestampDifference = pInternal->headTimestamp - pRtpPacket->header.timestamp;
         } else {
-            timestampDifference = (MAX_RTP_TIMESTAMP - pRtpPacket->header.timestamp) + pJitterBuffer->headTimestamp;
+            timestampDifference = (MAX_RTP_TIMESTAMP - pRtpPacket->header.timestamp) + pInternal->headTimestamp;
         }
 
         // 1 frame per second, and 1 packet per frame, the most charitable case we can consider
         // TODO track most recent FPS to improve this metric
-        if ((MAX_RTP_TIMESTAMP / pJitterBuffer->clockRate) <= seqNoDifference) {
+        if ((MAX_RTP_TIMESTAMP / pInternal->base.clockRate) <= seqNoDifference) {
             maxTimePassed = MAX_RTP_TIMESTAMP;
         } else {
-            maxTimePassed = pJitterBuffer->clockRate * seqNoDifference;
+            maxTimePassed = pInternal->base.clockRate * seqNoDifference;
         }
 
         if (maxTimePassed >= timestampDifference) {
@@ -140,59 +205,37 @@ BOOL underflowPossible(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
     return retVal;
 }
 
-BOOL headCheckingAllowed(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL headCheckingAllowed(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
-    /*If we haven't yet processed a frame yet, then we don't have a definitive way of knowing if
-     *the first packet we receive is actually the earliest packet we'll ever receive. Since sequence numbers
-     *can start anywhere from 0 - 65535, we need to incorporate some checks to determine if a newly received packet
-     *should be considered the new head. Part of how we determine this is by setting a limit to how many packets off we allow
-     *this out of order case to be. Without setting a limit, then we could run into an odd scenario.
-     * Example:
-     * Push->Packet->SeqNumber == 0. //FIRST PACKET! new head of buffer!
-     * Push->Packet->SeqNumber == 3. //... new head of 65532 packet sized frame? maybe? was 0 the tail?
-     *
-     * To resolve that insanity we set a MAX, and will use that MAX for the range.
-     * This logic is present in headSequenceNumberCheck()
-     *
-     *After the first frame has been processed we don't need or want to make this consideration, since if our parser has
-     *dropped a frame for a good reason then we want to ignore any packets from that dropped frame that may come later.
-     *
-     *However if the packet's timestamp is the same as the head timestamp, then it's possible this is simply an earlier
-     *sequence number of the same packet.
-     */
-    if (!(pJitterBuffer->firstFrameProcessed) || pJitterBuffer->headTimestamp == pRtpPacket->header.timestamp) {
+    if (!(pInternal->firstFrameProcessed) || pInternal->headTimestamp == pRtpPacket->header.timestamp) {
         retVal = TRUE;
     }
     return retVal;
 }
 
 // return true if pRtpPacket contains the head sequence number
-BOOL headSequenceNumberCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL headSequenceNumberCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
     UINT16 minimumHead = 0;
-    if (pJitterBuffer->headSequenceNumber >= MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
-        minimumHead = pJitterBuffer->headSequenceNumber - MAX_OUT_OF_ORDER_PACKET_DIFFERENCE;
+    if (pInternal->headSequenceNumber >= MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
+        minimumHead = pInternal->headSequenceNumber - MAX_OUT_OF_ORDER_PACKET_DIFFERENCE;
     }
 
-    // If we've already done this check and it was true
-    if (pJitterBuffer->headSequenceNumber == pRtpPacket->header.sequenceNumber) {
+    if (pInternal->headSequenceNumber == pRtpPacket->header.sequenceNumber) {
         retVal = TRUE;
-    } else if (headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
-        if (pJitterBuffer->sequenceNumberOverflowState) {
-            if (pJitterBuffer->tailSequenceNumber < pRtpPacket->header.sequenceNumber &&
-                pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber && pRtpPacket->header.sequenceNumber >= minimumHead) {
-                // This purposefully misses the usecase where the buffer has >65000 entries.
-                // Our buffer is not designed for that use case, and it becomes far too ambiguous
-                // as to which packets are new tails or new heads without adding epoch checks.
-                pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+    } else if (headCheckingAllowed(pInternal, pRtpPacket)) {
+        if (pInternal->sequenceNumberOverflowState) {
+            if (pInternal->tailSequenceNumber < pRtpPacket->header.sequenceNumber &&
+                pInternal->headSequenceNumber > pRtpPacket->header.sequenceNumber && pRtpPacket->header.sequenceNumber >= minimumHead) {
+                pInternal->headSequenceNumber = pRtpPacket->header.sequenceNumber;
                 retVal = TRUE;
             }
         } else {
-            if (pRtpPacket->header.sequenceNumber < pJitterBuffer->headSequenceNumber) {
+            if (pRtpPacket->header.sequenceNumber < pInternal->headSequenceNumber) {
                 if (pRtpPacket->header.sequenceNumber >= minimumHead) {
-                    pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+                    pInternal->headSequenceNumber = pRtpPacket->header.sequenceNumber;
                     retVal = TRUE;
                 }
             }
@@ -202,44 +245,39 @@ BOOL headSequenceNumberCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
 }
 
 // return true if pRtpPacket contains a new tail sequence number
-BOOL tailSequenceNumberCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL tailSequenceNumberCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
-    // If we've already done this check and it was true
-    if (pJitterBuffer->tailSequenceNumber == pRtpPacket->header.sequenceNumber) {
+    if (pInternal->tailSequenceNumber == pRtpPacket->header.sequenceNumber) {
         retVal = TRUE;
-    } else if (pRtpPacket->header.sequenceNumber > pJitterBuffer->tailSequenceNumber &&
-               (!pJitterBuffer->sequenceNumberOverflowState || pJitterBuffer->headSequenceNumber > pRtpPacket->header.sequenceNumber)) {
+    } else if (pRtpPacket->header.sequenceNumber > pInternal->tailSequenceNumber &&
+               (!pInternal->sequenceNumberOverflowState || pInternal->headSequenceNumber > pRtpPacket->header.sequenceNumber)) {
         retVal = TRUE;
-        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pInternal->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
     }
     return retVal;
 }
 
 // return true if sequence numbers are now overflowing
-BOOL enterSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL enterSequenceNumberOverflowCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL overflow = FALSE;
     BOOL underflow = FALSE;
-    UINT16 packetsUntilOverflow = MAX_RTP_SEQUENCE_NUM - pJitterBuffer->tailSequenceNumber;
+    UINT16 packetsUntilOverflow = MAX_RTP_SEQUENCE_NUM - pInternal->tailSequenceNumber;
 
-    if (!pJitterBuffer->sequenceNumberOverflowState) {
+    if (!pInternal->sequenceNumberOverflowState) {
         // overflow case
         if (MAX_OUT_OF_ORDER_PACKET_DIFFERENCE >= packetsUntilOverflow) {
-            // It's possible sequence numbers and timestamps are both overflowing.
-            if (pRtpPacket->header.sequenceNumber < pJitterBuffer->tailSequenceNumber &&
+            if (pRtpPacket->header.sequenceNumber < pInternal->tailSequenceNumber &&
                 pRtpPacket->header.sequenceNumber <= MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - packetsUntilOverflow) {
-                // Sequence number overflow detected
                 overflow = TRUE;
             }
         }
         // underflow case
-        else if (headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
-            if (pJitterBuffer->headSequenceNumber < MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
-                if (pRtpPacket->header.sequenceNumber >= (MAX_UINT16 - (MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - pJitterBuffer->headSequenceNumber))) {
-                    // Possible sequence number underflow detected, now lets check the timestamps to be certain
-                    // this is an earlier value, and not a much later.
-                    if (underflowPossible(pJitterBuffer, pRtpPacket)) {
+        else if (headCheckingAllowed(pInternal, pRtpPacket)) {
+            if (pInternal->headSequenceNumber < MAX_OUT_OF_ORDER_PACKET_DIFFERENCE) {
+                if (pRtpPacket->header.sequenceNumber >= (MAX_UINT16 - (MAX_OUT_OF_ORDER_PACKET_DIFFERENCE - pInternal->headSequenceNumber))) {
+                    if (underflowPossible(pInternal, pRtpPacket)) {
                         underflow = TRUE;
                     }
                 }
@@ -247,113 +285,94 @@ BOOL enterSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pR
         }
     }
     if (overflow && underflow) {
-        // This shouldn't be possible.
         DLOGE("Critical underflow/overflow error in jitterbuffer");
     }
     if (overflow) {
-        pJitterBuffer->sequenceNumberOverflowState = TRUE;
-        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
-        pJitterBuffer->tailTimestamp = pRtpPacket->header.timestamp;
+        pInternal->sequenceNumberOverflowState = TRUE;
+        pInternal->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pInternal->base.tailTimestamp = pRtpPacket->header.timestamp;
     }
     if (underflow) {
-        pJitterBuffer->sequenceNumberOverflowState = TRUE;
-        pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
-        pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+        pInternal->sequenceNumberOverflowState = TRUE;
+        pInternal->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pInternal->headTimestamp = pRtpPacket->header.timestamp;
     }
     return (overflow || underflow);
 }
 
-BOOL enterTimestampOverflowCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL enterTimestampOverflowCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL underflow = FALSE;
     BOOL overflow = FALSE;
-    if (!pJitterBuffer->timestampOverFlowState) {
+    if (!pInternal->timestampOverFlowState) {
         // overflow check
-        if (pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp && pJitterBuffer->tailTimestamp > pRtpPacket->header.timestamp) {
-            // Check to see if this could be a timestamp overflow case
-            // We always check sequence number first, so the 'or equal to' checks if we just set the tail.
-            // That would be a corner case of sequence number and timestamp both overflowing
-            // in this one packet.
-            if (tailSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
-                // RTP timestamp overflow detected!
+        if (pInternal->headTimestamp > pRtpPacket->header.timestamp && pInternal->base.tailTimestamp > pRtpPacket->header.timestamp) {
+            if (tailSequenceNumberCheck(pInternal, pRtpPacket)) {
                 overflow = TRUE;
             }
         }
         // underflow check
-        else if (pJitterBuffer->headTimestamp < pRtpPacket->header.timestamp && pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
-            // Only detect underflow if headSequenceNumberCheck actually updates the head (meaning packet is EARLIER than expected).
-            // Don't trigger underflow if packet is exactly at headSequenceNumber (that's the expected next packet, not underflow).
-            UINT16 prevHead = pJitterBuffer->headSequenceNumber;
-            if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket) && pJitterBuffer->headSequenceNumber != prevHead) {
+        else if (pInternal->headTimestamp < pRtpPacket->header.timestamp && pInternal->base.tailTimestamp < pRtpPacket->header.timestamp) {
+            UINT16 prevHead = pInternal->headSequenceNumber;
+            if (headSequenceNumberCheck(pInternal, pRtpPacket) && pInternal->headSequenceNumber != prevHead) {
                 underflow = TRUE;
             }
         }
     }
     if (overflow && underflow) {
-        // This shouldn't be possible.
         DLOGE("Critical underflow/overflow error in jitterbuffer");
     }
     if (overflow) {
-        pJitterBuffer->timestampOverFlowState = TRUE;
-        pJitterBuffer->tailTimestamp = pRtpPacket->header.timestamp;
+        pInternal->timestampOverFlowState = TRUE;
+        pInternal->base.tailTimestamp = pRtpPacket->header.timestamp;
     } else if (underflow) {
-        pJitterBuffer->timestampOverFlowState = TRUE;
-        pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+        pInternal->timestampOverFlowState = TRUE;
+        pInternal->headTimestamp = pRtpPacket->header.timestamp;
     }
     return (underflow || overflow);
 }
 
-BOOL exitSequenceNumberOverflowCheck(PJitterBuffer pJitterBuffer)
+static BOOL exitSequenceNumberOverflowCheck(PJitterBufferInternal pInternal)
 {
     BOOL retVal = FALSE;
-
-    // can't exit if you're not in it
-    if (pJitterBuffer->sequenceNumberOverflowState) {
-        if (pJitterBuffer->headSequenceNumber <= pJitterBuffer->tailSequenceNumber) {
-            pJitterBuffer->sequenceNumberOverflowState = FALSE;
+    if (pInternal->sequenceNumberOverflowState) {
+        if (pInternal->headSequenceNumber <= pInternal->tailSequenceNumber) {
+            pInternal->sequenceNumberOverflowState = FALSE;
             retVal = TRUE;
         }
     }
-
     return retVal;
 }
 
-BOOL exitTimestampOverflowCheck(PJitterBuffer pJitterBuffer)
+static BOOL exitTimestampOverflowCheck(PJitterBufferInternal pInternal)
 {
     BOOL retVal = FALSE;
-
-    // can't exit if you're not in it
-    if (pJitterBuffer->timestampOverFlowState) {
-        if (pJitterBuffer->headTimestamp <= pJitterBuffer->tailTimestamp) {
-            pJitterBuffer->timestampOverFlowState = FALSE;
+    if (pInternal->timestampOverFlowState) {
+        if (pInternal->headTimestamp <= pInternal->base.tailTimestamp) {
+            pInternal->timestampOverFlowState = FALSE;
             retVal = TRUE;
         }
     }
-
     return retVal;
 }
 
 // return true if pRtpPacket contains a new head timestamp
-BOOL headTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL headTimestampCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
 
-    if (headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
-        if (pJitterBuffer->timestampOverFlowState) {
-            if (pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp && pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
-                // in the correct range to be a new head or new tail.
-                // if it's also the head sequence number then it's the new headtimestamp
-                if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
-                    pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+    if (headCheckingAllowed(pInternal, pRtpPacket)) {
+        if (pInternal->timestampOverFlowState) {
+            if (pInternal->headTimestamp > pRtpPacket->header.timestamp && pInternal->base.tailTimestamp < pRtpPacket->header.timestamp) {
+                if (headSequenceNumberCheck(pInternal, pRtpPacket)) {
+                    pInternal->headTimestamp = pRtpPacket->header.timestamp;
                     retVal = TRUE;
                 }
             }
         } else {
-            if (pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp || pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
-                // in the correct range to be a new head or new tail.
-                // if it's also the head sequence number then it's the new headtimestamp
-                if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
-                    pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+            if (pInternal->headTimestamp > pRtpPacket->header.timestamp || pInternal->base.tailTimestamp < pRtpPacket->header.timestamp) {
+                if (headSequenceNumberCheck(pInternal, pRtpPacket)) {
+                    pInternal->headTimestamp = pRtpPacket->header.timestamp;
                     retVal = TRUE;
                 }
             }
@@ -363,16 +382,14 @@ BOOL headTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
 }
 
 // return true if pRtpPacket contains a new tail timestamp
-BOOL tailTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+static BOOL tailTimestampCheck(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
 
-    if (pJitterBuffer->tailTimestamp < pRtpPacket->header.timestamp) {
-        if (!pJitterBuffer->timestampOverFlowState || pJitterBuffer->headTimestamp > pRtpPacket->header.timestamp) {
-            // in the correct range to be a new head or new tail.
-            // if it's also the tail sequence number then it's the new tail timestamp
-            if (tailSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
-                pJitterBuffer->tailTimestamp = pRtpPacket->header.timestamp;
+    if (pInternal->base.tailTimestamp < pRtpPacket->header.timestamp) {
+        if (!pInternal->timestampOverFlowState || pInternal->headTimestamp > pRtpPacket->header.timestamp) {
+            if (tailSequenceNumberCheck(pInternal, pRtpPacket)) {
+                pInternal->base.tailTimestamp = pRtpPacket->header.timestamp;
                 retVal = TRUE;
             }
         }
@@ -380,35 +397,27 @@ BOOL tailTimestampCheck(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
     return retVal;
 }
 
-// return true if pRtpPacket is within the latency tolerance (not much earlier than current head)
-BOOL withinLatencyTolerance(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
+// return true if pRtpPacket is within the latency tolerance
+static BOOL withinLatencyTolerance(PJitterBufferInternal pInternal, PRtpPacket pRtpPacket)
 {
     BOOL retVal = FALSE;
     UINT32 minimumTimestamp = 0;
 
-    // Simple check, if we're at or past the tail timestamp then we're always within latency tolerance.
-    // overflow is checked earlier
-    if (tailTimestampCheck(pJitterBuffer, pRtpPacket) || pJitterBuffer->tailTimestamp == pRtpPacket->header.timestamp) {
+    if (tailTimestampCheck(pInternal, pRtpPacket) || pInternal->base.tailTimestamp == pRtpPacket->header.timestamp) {
         retVal = TRUE;
     } else {
-        // Is our tail current less than our head due to timestamp overflow?
-        if (pJitterBuffer->timestampOverFlowState) {
-            // calculate max-latency across the overflow boundry without triggering underflow
-            if (pJitterBuffer->tailTimestamp < pJitterBuffer->maxLatency) {
-                minimumTimestamp = MAX_RTP_TIMESTAMP - (pJitterBuffer->maxLatency - pJitterBuffer->tailTimestamp);
+        if (pInternal->timestampOverFlowState) {
+            if (pInternal->base.tailTimestamp < pInternal->maxLatency) {
+                minimumTimestamp = MAX_RTP_TIMESTAMP - (pInternal->maxLatency - pInternal->base.tailTimestamp);
             }
-            // Is the packet within the current range or is it a new head/tail
-            if (pRtpPacket->header.timestamp < pJitterBuffer->tailTimestamp || pRtpPacket->header.timestamp > pJitterBuffer->headTimestamp) {
-                // The packet is within the current range
+            if (pRtpPacket->header.timestamp < pInternal->base.tailTimestamp || pRtpPacket->header.timestamp > pInternal->headTimestamp) {
                 retVal = TRUE;
-            }
-            // The only remaining option is that timestamp must be before headTimestamp
-            else if (pRtpPacket->header.timestamp >= minimumTimestamp) {
+            } else if (pRtpPacket->header.timestamp >= minimumTimestamp) {
                 retVal = TRUE;
             }
         } else {
-            if ((pRtpPacket->header.timestamp < pJitterBuffer->maxLatency && pJitterBuffer->tailTimestamp <= pJitterBuffer->maxLatency) ||
-                pRtpPacket->header.timestamp >= pJitterBuffer->tailTimestamp - pJitterBuffer->maxLatency) {
+            if ((pRtpPacket->header.timestamp < pInternal->maxLatency && pInternal->base.tailTimestamp <= pInternal->maxLatency) ||
+                pRtpPacket->header.timestamp >= pInternal->base.tailTimestamp - pInternal->maxLatency) {
                 retVal = TRUE;
             }
         }
@@ -416,70 +425,137 @@ BOOL withinLatencyTolerance(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket)
     return retVal;
 }
 
-STATUS jitterBufferPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded)
+//
+// Default vtable implementations
+//
+
+static STATUS defaultGetPacket(PJitterBuffer pJitterBuffer, UINT16 seqNum, PRtpPacket* ppPacket)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 hashValue = 0;
+    PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
+
+    CHK(pInternal != NULL && ppPacket != NULL, STATUS_NULL_ARG);
+
+    retStatus = hashTableGet(pInternal->pPkgBufferHashTable, seqNum, &hashValue);
+    if (retStatus == STATUS_HASH_KEY_NOT_PRESENT) {
+        *ppPacket = NULL;
+        CHK(FALSE, retStatus);
+    }
+    CHK_STATUS(retStatus);
+    *ppPacket = (PRtpPacket) hashValue;
+
+CleanUp:
+    return retStatus;
+}
+
+static STATUS defaultFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
+                                           UINT16 endIndex)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
+    UINT16 index;
+    UINT64 hashValue = 0;
+    PRtpPacket pPacket = NULL;
+    PBYTE pCurPtrInFrame = pFrame;
+    UINT32 partialFrameSize = 0;
+    UINT32 filledSize = 0;
+    BOOL hasEntry = FALSE;
+    BOOL isFirstInFrame = TRUE;
+
+    CHK(pInternal != NULL && pFilledSize != NULL, STATUS_NULL_ARG);
+
+    for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
+        if (STATUS_FAILED(hashTableContains(pInternal->pPkgBufferHashTable, index, &hasEntry))) {
+            continue;
+        }
+        if (hasEntry) {
+            if (STATUS_FAILED(hashTableGet(pInternal->pPkgBufferHashTable, index, &hashValue))) {
+                continue;
+            }
+            pPacket = (PRtpPacket) hashValue;
+            if (pFrame != NULL) {
+                partialFrameSize = frameSize - filledSize;
+            } else {
+                partialFrameSize = 0;
+            }
+            BOOL depayIsFirst = isFirstInFrame;
+            if (STATUS_FAILED(pInternal->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &depayIsFirst))) {
+                DLOGW("depayPayloadFn failed for packet index %u, skipping", index);
+                continue;
+            }
+            if (pCurPtrInFrame != NULL) {
+                pCurPtrInFrame += partialFrameSize;
+            }
+            filledSize += partialFrameSize;
+            isFirstInFrame = FALSE;
+        }
+    }
+
+CleanUp:
+    if (pFilledSize != NULL) {
+        *pFilledSize = filledSize;
+    }
+    return retStatus;
+}
+
+static STATUS defaultPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS, status = STATUS_SUCCESS;
     UINT64 hashValue = 0;
     PRtpPacket pCurPacket = NULL;
+    PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
 
-    CHK(pJitterBuffer != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
+    CHK(pInternal != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
 
-    if (!pJitterBuffer->started) {
-        // Set to started and initialize the sequence number
-        pJitterBuffer->started = TRUE;
-        pJitterBuffer->headSequenceNumber = pRtpPacket->header.sequenceNumber;
-        pJitterBuffer->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
-        pJitterBuffer->headTimestamp = pRtpPacket->header.timestamp;
+    if (!pInternal->started) {
+        pInternal->started = TRUE;
+        pInternal->headSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pInternal->tailSequenceNumber = pRtpPacket->header.sequenceNumber;
+        pInternal->headTimestamp = pRtpPacket->header.timestamp;
     }
 
-    // We'll check sequence numbers first, with our MAX Out of Order packet count to avoid
-    // defining a timestamp window for overflow
-    // Returning true means this packet is a new tail AND we've entered overflow state.
-    if (!enterSequenceNumberOverflowCheck(pJitterBuffer, pRtpPacket)) {
-        tailSequenceNumberCheck(pJitterBuffer, pRtpPacket);
+    if (!enterSequenceNumberOverflowCheck(pInternal, pRtpPacket)) {
+        tailSequenceNumberCheck(pInternal, pRtpPacket);
     } else {
         DLOGS("Entered sequenceNumber overflow state");
     }
 
-    if (!enterTimestampOverflowCheck(pJitterBuffer, pRtpPacket)) {
-        tailTimestampCheck(pJitterBuffer, pRtpPacket);
+    if (!enterTimestampOverflowCheck(pInternal, pRtpPacket)) {
+        tailTimestampCheck(pInternal, pRtpPacket);
     } else {
         DLOGS("Entered timestamp overflow state");
     }
 
-    // is the packet within the accepted latency range, if so, add it to the hashtable
-    if (withinLatencyTolerance(pJitterBuffer, pRtpPacket)) {
-        status = hashTableGet(pJitterBuffer->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, &hashValue);
+    if (withinLatencyTolerance(pInternal, pRtpPacket)) {
+        status = hashTableGet(pInternal->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, &hashValue);
         pCurPacket = (PRtpPacket) hashValue;
         if (STATUS_SUCCEEDED(status) && pCurPacket != NULL) {
             freeRtpPacket(&pCurPacket);
-            CHK_STATUS(hashTableRemove(pJitterBuffer->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber));
+            CHK_STATUS(hashTableRemove(pInternal->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber));
         }
 
-        CHK_STATUS(hashTablePut(pJitterBuffer->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, (UINT64) pRtpPacket));
+        CHK_STATUS(hashTablePut(pInternal->pPkgBufferHashTable, pRtpPacket->header.sequenceNumber, (UINT64) pRtpPacket));
 
-        if (headCheckingAllowed(pJitterBuffer, pRtpPacket)) {
-            // if the timestamp is less, we'll accept it as a new head, since it must be an earlier frame.
-            if (headTimestampCheck(pJitterBuffer, pRtpPacket)) {
+        if (headCheckingAllowed(pInternal, pRtpPacket)) {
+            if (headTimestampCheck(pInternal, pRtpPacket)) {
                 DLOGS("New jitterbuffer head timestamp");
             }
-            if (headSequenceNumberCheck(pJitterBuffer, pRtpPacket)) {
+            if (headSequenceNumberCheck(pInternal, pRtpPacket)) {
                 DLOGS("New jitterbuffer head sequenceNumber");
             }
         }
-        // DONE with considering the head.
 
         DLOGS("jitterBufferPush get packet timestamp %lu seqNum %lu", pRtpPacket->header.timestamp, pRtpPacket->header.sequenceNumber);
     } else {
-        // Free the packet if it is out of range, jitter buffer need to own the packet and do free
         freeRtpPacket(&pRtpPacket);
         if (pPacketDiscarded != NULL) {
             *pPacketDiscarded = TRUE;
         }
     }
 
-    CHK_STATUS(jitterBufferInternalParse(pJitterBuffer, FALSE));
+    CHK_STATUS(jitterBufferInternalParse(pInternal, FALSE));
 
 CleanUp:
 
@@ -489,7 +565,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
+static STATUS jitterBufferInternalParse(PJitterBufferInternal pInternal, BOOL bufferClosed)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -497,69 +573,48 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
     UINT16 lastIndex;
     UINT32 earliestAllowedTimestamp = 0;
     BOOL isFrameDataContinuous = TRUE;
-    BOOL headFrameIsContiguous = TRUE; // Track continuity for head frame only
+    BOOL headFrameIsContiguous = TRUE;
     UINT32 curTimestamp = 0;
     UINT16 startDropIndex = 0;
     UINT32 curFrameSize = 0;
-    BOOL sizeCalcIsFirst = TRUE; // tracks first packet in frame for start code size calculation
+    BOOL sizeCalcIsFirst = TRUE;
     UINT32 partialFrameSize = 0;
     UINT64 hashValue = 0;
     BOOL isStart = FALSE, containStartForEarliestFrame = FALSE, hasEntry = FALSE;
     UINT16 lastNonNullIndex = 0;
-    UINT16 lastHeadFrameSeqNum = 0;    // Last seq number seen with head timestamp
-    BOOL seenHeadFramePacket = FALSE;  // Whether we've seen any packet from head frame
-    UINT16 firstGapIndex = 0;          // First gap sequence number since last frame boundary
-    BOOL sawGapSinceLastFrame = FALSE; // Whether we've seen any gap since last frame boundary
-    BOOL headFrameEnded = FALSE;       // Whether head frame's last packet had marker bit (complete frame)
+    UINT16 lastHeadFrameSeqNum = 0;
+    BOOL seenHeadFramePacket = FALSE;
+    UINT16 firstGapIndex = 0;
+    BOOL sawGapSinceLastFrame = FALSE;
+    BOOL headFrameEnded = FALSE;
     PRtpPacket pCurPacket = NULL;
 
-    CHK(pJitterBuffer != NULL && pJitterBuffer->onFrameDroppedFn != NULL && pJitterBuffer->onFrameReadyFn != NULL, STATUS_NULL_ARG);
-    CHK(pJitterBuffer->started, retStatus);
+    CHK(pInternal != NULL && pInternal->onFrameDroppedFn != NULL && pInternal->onFrameReadyFn != NULL, STATUS_NULL_ARG);
+    CHK(pInternal->started, retStatus);
 
-    if (pJitterBuffer->tailTimestamp > pJitterBuffer->maxLatency) {
-        earliestAllowedTimestamp = pJitterBuffer->tailTimestamp - pJitterBuffer->maxLatency;
+    if (pInternal->base.tailTimestamp > pInternal->maxLatency) {
+        earliestAllowedTimestamp = pInternal->base.tailTimestamp - pInternal->maxLatency;
     }
 
-    lastIndex = pJitterBuffer->tailSequenceNumber + 1;
-    index = pJitterBuffer->headSequenceNumber;
+    lastIndex = pInternal->tailSequenceNumber + 1;
+    index = pInternal->headSequenceNumber;
     startDropIndex = index;
-    // Loop through entire buffer to find complete frames.
-    /*A Frame is ready when these conditions are met:
-     * 1. We have a starting packet
-     * 2. There were no missing sequence numbers up to this point
-     * 3. A different timestamp in a sequential packet was found
-     * 4. There are no earlier frames still in the buffer
-     *
-     *A Frame is dropped when the above conditions are not met, and the following conditions have been:
-     * 1. the buffer is being closed
-     * 2. The time between the most recently pushed RTP packet and oldest stored packet has surpassed the
-     *    maximum allowed latency
-     *
-     *The buffer is parsed in order of sequence numbers. It is important to note that if the Frame ready
-     *conditions have been met from dropping an earlier frame, then it will be processed.
-     */
     for (; index != lastIndex; index++) {
-        CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        CHK_STATUS(hashTableContains(pInternal->pPkgBufferHashTable, index, &hasEntry));
         if (!hasEntry) {
             isFrameDataContinuous = FALSE;
-            // Track where first gap is found - we'll determine at frame boundary if it's in head frame
             if (!sawGapSinceLastFrame) {
                 firstGapIndex = index;
                 sawGapSinceLastFrame = TRUE;
             }
-            // If we've seen head frame packets but not the marker bit yet, this gap might be in the head frame.
-            // Set headFrameIsContiguous=FALSE proactively to prevent incorrect marker bit delivery.
-            // If the gap turns out to be in a later frame, headFrameIsContiguous will be reset at frame boundary.
             if (seenHeadFramePacket && !headFrameEnded) {
                 headFrameIsContiguous = FALSE;
             }
-            // if the max latency has not been reached, or the buffer is not being closed, exit parse when a missing entry is found
-            CHK(pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed, retStatus);
+            CHK(pInternal->headTimestamp < earliestAllowedTimestamp || bufferClosed, retStatus);
         } else {
             lastNonNullIndex = index;
-            retStatus = hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue);
+            retStatus = hashTableGet(pInternal->pPkgBufferHashTable, index, &hashValue);
             if (retStatus == STATUS_HASH_KEY_NOT_PRESENT) {
-                // should be unreachable, this means hashTablContains() said we had it but hashTableGet() couldn't find it.
                 continue;
             } else {
                 CHK_STATUS(retStatus);
@@ -568,128 +623,76 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
             CHK(pCurPacket != NULL, STATUS_NULL_ARG);
             curTimestamp = pCurPacket->header.timestamp;
 
-            // Track packets belonging to the head frame
-            if (curTimestamp == pJitterBuffer->headTimestamp) {
+            if (curTimestamp == pInternal->headTimestamp) {
                 lastHeadFrameSeqNum = index;
                 seenHeadFramePacket = TRUE;
-                // Track if this packet has marker bit (indicates end of frame)
                 if (pCurPacket->header.marker) {
                     headFrameEnded = TRUE;
                 }
             }
 
-            // new timestamp on an RTP packet means new frame
-            if (curTimestamp != pJitterBuffer->headTimestamp) {
-                // Determine if head frame is contiguous by checking if any gaps are within its range
-                // Key insight: If head frame's last packet had marker bit, the frame is complete.
-                // Any gap AFTER that is in the next frame, not the head frame.
+            if (curTimestamp != pInternal->headTimestamp) {
                 if (sawGapSinceLastFrame && seenHeadFramePacket) {
-                    // Only evaluate continuity if we've actually seen head frame packets.
-                    // If seenHeadFramePacket=FALSE, the head frame was already delivered via marker
-                    // and any gaps are in inter-frame space, not the head frame.
                     if (firstGapIndex <= lastHeadFrameSeqNum) {
-                        // Gap is within head frame's known packet range
                         headFrameIsContiguous = FALSE;
                     } else if (!headFrameEnded) {
-                        // Gap is after last seen head packet, but head frame didn't have marker bit
-                        // The gap might still be in the head frame (frame not complete)
                         headFrameIsContiguous = FALSE;
                     }
-                    // else: gap is AFTER head frame's marker bit, so it's in next frame
                 }
-                // was previous frame complete? Deliver it
                 if (containStartForEarliestFrame && headFrameIsContiguous) {
-                    // Decrement the index because this is an inclusive end parser, and we don't want to include the current index in the processed
-                    // frame.
-                    CHK_STATUS(pJitterBuffer->onFrameReadyFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), curFrameSize));
-                    CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));
-                    pJitterBuffer->firstFrameProcessed = TRUE;
+                    CHK_STATUS(pInternal->onFrameReadyFn(pInternal->customData, startDropIndex, UINT16_DEC(index), curFrameSize));
+                    CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, UINT16_DEC(index), curTimestamp));
+                    pInternal->firstFrameProcessed = TRUE;
                     startDropIndex = index;
                     containStartForEarliestFrame = FALSE;
-                    // Reset tracking for the new head frame
                     headFrameIsContiguous = TRUE;
                     sawGapSinceLastFrame = FALSE;
-                    // Track the current packet as the new head frame's first packet
-                    // (headTimestamp was just updated to curTimestamp by jitterBufferDropBufferData)
                     lastHeadFrameSeqNum = index;
                     seenHeadFramePacket = TRUE;
                     headFrameEnded = pCurPacket->header.marker;
-                }
-                // are we forcibly clearing out the buffer? if so drop the contents of incomplete frame
-                // Only force clear if:
-                // 1. We've seen head frame packets (seenHeadFramePacket) - otherwise there's nothing to drop
-                // 2. There are packets to drop (startDropIndex != index)
-                // If seenHeadFramePacket=FALSE, the head frame was already delivered via marker bit
-                // and we should go to the else block to reset state for the new frame.
-                else if (seenHeadFramePacket && startDropIndex != index &&
-                         (pJitterBuffer->headTimestamp < earliestAllowedTimestamp || bufferClosed)) {
-                    // do not CHK_STATUS of onFrameDropped because we need to clear the jitter buffer no matter what else happens.
-                    pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp);
-                    CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, UINT16_DEC(index), curTimestamp));
-                    pJitterBuffer->firstFrameProcessed = TRUE;
+                } else if (seenHeadFramePacket && startDropIndex != index &&
+                           (pInternal->headTimestamp < earliestAllowedTimestamp || bufferClosed)) {
+                    pInternal->onFrameDroppedFn(pInternal->customData, startDropIndex, UINT16_DEC(index), pInternal->headTimestamp);
+                    CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, UINT16_DEC(index), curTimestamp));
+                    pInternal->firstFrameProcessed = TRUE;
                     isFrameDataContinuous = TRUE;
-                    // Reset tracking for the new head frame
                     headFrameIsContiguous = TRUE;
                     sawGapSinceLastFrame = FALSE;
-                    // Track the current packet as the new head frame's first packet
-                    // (headTimestamp was just updated to curTimestamp by jitterBufferDropBufferData)
                     lastHeadFrameSeqNum = index;
                     seenHeadFramePacket = TRUE;
                     headFrameEnded = pCurPacket->header.marker;
                     startDropIndex = index;
                 } else if (seenHeadFramePacket) {
-                    // if you're here, it means we're not force clearing the buffer, and the previous frame must be missing its starting packet.
-                    // The starting packet isn't going to be found at an incremental sequence number, so we can save some time and break here.
                     break;
                 } else {
-                    // No head frame packets were seen - the head frame was likely already delivered via marker bit.
-                    // Update state for the new frame and continue processing.
-                    pJitterBuffer->headTimestamp = curTimestamp;
+                    pInternal->headTimestamp = curTimestamp;
                     startDropIndex = index;
-                    // Track the current packet as the new head frame's first packet
                     lastHeadFrameSeqNum = index;
                     seenHeadFramePacket = TRUE;
                     headFrameEnded = pCurPacket->header.marker;
                     headFrameIsContiguous = TRUE;
                     sawGapSinceLastFrame = FALSE;
                 }
-                // new timestamp means new frame, drop tracking for previous frame size
                 curFrameSize = 0;
                 sizeCalcIsFirst = TRUE;
             }
 
-            // Size-only call: pass sizeCalcIsFirst as input so start code size matches jitterBufferFillFrameData.
-            // The depayloader reads *pIsStart for start code choice, then overwrites with isStartingPacket output.
             isStart = sizeCalcIsFirst;
-            CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
+            CHK_STATUS(pInternal->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
             curFrameSize += partialFrameSize;
             sizeCalcIsFirst = FALSE;
-            if (isStart && pJitterBuffer->headTimestamp == curTimestamp) {
+            if (isStart && pInternal->headTimestamp == curTimestamp) {
                 containStartForEarliestFrame = TRUE;
             }
 
-            // Immediate marker bit delivery: if we have a complete frame (start + marker + no gaps), deliver now
-            // This reduces latency by not waiting for the next frame's first packet
-            // Use headFrameIsContiguous (per-frame tracking) instead of isFrameDataContinuous (global) for consistency
-            // with the frame boundary delivery logic
-            // Skip marker-bit delivery for the very first frame: when no frame has been processed yet, we can't
-            // distinguish a complete single-packet frame from a late-arriving last packet of a multi-packet frame
-            // (reordering). The first frame is delivered via the frame-boundary path when the next frame arrives.
-            // Exception: codecs that never fragment (alwaysSinglePacketFrames, e.g. Opus) are always safe.
-            if ((pJitterBuffer->firstFrameProcessed || pJitterBuffer->alwaysSinglePacketFrames) && curTimestamp == pJitterBuffer->headTimestamp &&
+            if ((pInternal->firstFrameProcessed || pInternal->alwaysSinglePacketFrames) && curTimestamp == pInternal->headTimestamp &&
                 pCurPacket->header.marker && containStartForEarliestFrame && headFrameIsContiguous) {
-                // Frame is complete: has start, has marker, all packets contiguous
-                CHK_STATUS(pJitterBuffer->onFrameReadyFn(pJitterBuffer->customData, startDropIndex, index, curFrameSize));
-                CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, index, curTimestamp));
-                pJitterBuffer->firstFrameProcessed = TRUE;
-                // Update startDropIndex so the bufferClosed block doesn't try to re-deliver
+                CHK_STATUS(pInternal->onFrameReadyFn(pInternal->customData, startDropIndex, index, curFrameSize));
+                CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, index, curTimestamp));
+                pInternal->firstFrameProcessed = TRUE;
                 startDropIndex = index + 1;
                 curFrameSize = 0;
                 sizeCalcIsFirst = TRUE;
-                // Note: jitterBufferDropBufferData sets headTimestamp to curTimestamp (delivered frame's timestamp)
-                // since we don't know the next frame's timestamp yet. Break here and let the next parse
-                // correctly detect the frame boundary via the else branch at lines 606-617.
-                // When buffer is being closed, freeJitterBuffer will call parse repeatedly until all frames are done.
                 break;
             }
         }
@@ -701,24 +704,23 @@ STATUS jitterBufferInternalParse(PJitterBuffer pJitterBuffer, BOOL bufferClosed)
         sizeCalcIsFirst = TRUE;
         hasEntry = TRUE;
         for (index = startDropIndex; UINT16_DEC(index) != lastNonNullIndex && hasEntry; index++) {
-            CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+            CHK_STATUS(hashTableContains(pInternal->pPkgBufferHashTable, index, &hasEntry));
             if (hasEntry) {
-                CHK_STATUS(hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+                CHK_STATUS(hashTableGet(pInternal->pPkgBufferHashTable, index, &hashValue));
                 pCurPacket = (PRtpPacket) hashValue;
                 isStart = sizeCalcIsFirst;
-                CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
+                CHK_STATUS(pInternal->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, NULL, &partialFrameSize, &isStart));
                 curFrameSize += partialFrameSize;
                 sizeCalcIsFirst = FALSE;
             }
         }
 
-        // There is no NULL between startIndex and lastNonNullIndex
         if (UINT16_DEC(index) == lastNonNullIndex) {
-            CHK_STATUS(pJitterBuffer->onFrameReadyFn(pJitterBuffer->customData, startDropIndex, lastNonNullIndex, curFrameSize));
-            CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, lastNonNullIndex, pJitterBuffer->headTimestamp));
+            CHK_STATUS(pInternal->onFrameReadyFn(pInternal->customData, startDropIndex, lastNonNullIndex, curFrameSize));
+            CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, lastNonNullIndex, pInternal->headTimestamp));
         } else {
-            CHK_STATUS(pJitterBuffer->onFrameDroppedFn(pJitterBuffer->customData, startDropIndex, UINT16_DEC(index), pJitterBuffer->headTimestamp));
-            CHK_STATUS(jitterBufferDropBufferData(pJitterBuffer, startDropIndex, lastNonNullIndex, pJitterBuffer->headTimestamp));
+            CHK_STATUS(pInternal->onFrameDroppedFn(pInternal->customData, startDropIndex, UINT16_DEC(index), pInternal->headTimestamp));
+            CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, lastNonNullIndex, pInternal->headTimestamp));
         }
     }
 
@@ -730,8 +732,7 @@ CleanUp:
 }
 
 // Remove all packets containing sequence numbers between and including the startIndex and endIndex for the JitterBuffer.
-// The nextTimestamp is assumed to be the timestamp of the next earliest Frame
-STATUS jitterBufferDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex, UINT16 endIndex, UINT32 nextTimestamp)
+static STATUS defaultDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex, UINT16 endIndex, UINT32 nextTimestamp)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -739,25 +740,26 @@ STATUS jitterBufferDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex
     UINT64 hashValue;
     PRtpPacket pCurPacket = NULL;
     BOOL hasEntry = FALSE;
+    PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
 
-    CHK(pJitterBuffer != NULL, STATUS_NULL_ARG);
+    CHK(pInternal != NULL, STATUS_NULL_ARG);
     for (; UINT16_DEC(index) != endIndex; index++) {
-        CHK_STATUS(hashTableContains(pJitterBuffer->pPkgBufferHashTable, index, &hasEntry));
+        CHK_STATUS(hashTableContains(pInternal->pPkgBufferHashTable, index, &hasEntry));
         if (hasEntry) {
-            CHK_STATUS(hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+            CHK_STATUS(hashTableGet(pInternal->pPkgBufferHashTable, index, &hashValue));
             pCurPacket = (PRtpPacket) hashValue;
             if (pCurPacket) {
                 freeRtpPacket(&pCurPacket);
             }
-            CHK_STATUS(hashTableRemove(pJitterBuffer->pPkgBufferHashTable, index));
+            CHK_STATUS(hashTableRemove(pInternal->pPkgBufferHashTable, index));
         }
     }
-    pJitterBuffer->headTimestamp = nextTimestamp;
-    pJitterBuffer->headSequenceNumber = endIndex + 1;
-    if (exitTimestampOverflowCheck(pJitterBuffer)) {
+    pInternal->headTimestamp = nextTimestamp;
+    pInternal->headSequenceNumber = endIndex + 1;
+    if (exitTimestampOverflowCheck(pInternal)) {
         DLOGS("Exited timestamp overflow state");
     }
-    if (exitSequenceNumberOverflowCheck(pJitterBuffer)) {
+    if (exitSequenceNumberOverflowCheck(pInternal)) {
         DLOGS("Exited sequenceNumber overflow state");
     }
 
@@ -769,7 +771,8 @@ CleanUp:
 }
 
 // Depay all packets containing sequence numbers between and including the startIndex and endIndex for the JitterBuffer.
-STATUS jitterBufferFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex, UINT16 endIndex)
+static STATUS defaultFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
+                                    UINT16 endIndex)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -779,16 +782,17 @@ STATUS jitterBufferFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT
     PBYTE pCurPtrInFrame = pFrame;
     UINT32 remainingFrameSize = frameSize;
     UINT32 partialFrameSize = 0;
+    PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
 
-    CHK(pJitterBuffer != NULL && pFrame != NULL && pFilledSize != NULL, STATUS_NULL_ARG);
+    CHK(pInternal != NULL && pFrame != NULL && pFilledSize != NULL, STATUS_NULL_ARG);
     BOOL isFirstInFrame = TRUE;
     for (; UINT16_DEC(index) != endIndex; index++) {
         hashValue = 0;
-        CHK_STATUS(hashTableGet(pJitterBuffer->pPkgBufferHashTable, index, &hashValue));
+        CHK_STATUS(hashTableGet(pInternal->pPkgBufferHashTable, index, &hashValue));
         pCurPacket = (PRtpPacket) hashValue;
         CHK(pCurPacket != NULL, STATUS_NULL_ARG);
         partialFrameSize = remainingFrameSize;
-        CHK_STATUS(pJitterBuffer->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &isFirstInFrame));
+        CHK_STATUS(pInternal->depayPayloadFn(pCurPacket->payload, pCurPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &isFirstInFrame));
         pCurPtrInFrame += partialFrameSize;
         remainingFrameSize -= partialFrameSize;
         isFirstInFrame = FALSE;
@@ -798,6 +802,46 @@ CleanUp:
     if (pFilledSize != NULL) {
         *pFilledSize = frameSize - remainingFrameSize;
     }
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
+static STATUS defaultDestroy(PJitterBuffer* ppJitterBuffer)
+{
+    ENTERS();
+
+    STATUS retStatus = STATUS_SUCCESS;
+    PJitterBufferInternal pInternal = NULL;
+
+    CHK(ppJitterBuffer != NULL, STATUS_NULL_ARG);
+    CHK(*ppJitterBuffer != NULL, retStatus);
+
+    pInternal = (PJitterBufferInternal) *ppJitterBuffer;
+
+    // Parse repeatedly until all frames are processed.
+    if (pInternal->started) {
+        UINT16 prevHead = pInternal->headSequenceNumber;
+        UINT32 maxIterations = 65536;
+        while (maxIterations-- > 0) {
+            jitterBufferInternalParse(pInternal, TRUE);
+            if (pInternal->headSequenceNumber == prevHead) {
+                break;
+            }
+            INT32 remaining = (INT32) ((UINT16) (pInternal->tailSequenceNumber - pInternal->headSequenceNumber + 1));
+            if (remaining <= 0) {
+                break;
+            }
+            prevHead = pInternal->headSequenceNumber;
+        }
+        defaultDropBufferData((PJitterBuffer) pInternal, pInternal->headSequenceNumber, pInternal->tailSequenceNumber, 0);
+    }
+    hashTableFree(pInternal->pPkgBufferHashTable);
+
+    SAFE_MEMFREE(*ppJitterBuffer);
+
+CleanUp:
     CHK_LOG_ERR(retStatus);
 
     LEAVES();

--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -32,9 +32,10 @@ typedef struct {
 // forward declarations of default implementations
 static STATUS defaultPush(PJitterBuffer pJitterBuffer, PRtpPacket pRtpPacket, PBOOL pPacketDiscarded);
 static STATUS defaultDestroy(PJitterBuffer* ppJitterBuffer);
-static STATUS defaultFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex, UINT16 endIndex);
+static STATUS defaultFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
+                                   UINT16 endIndex);
 static STATUS defaultFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
-                                           UINT16 endIndex);
+                                          UINT16 endIndex);
 static STATUS defaultGetPacket(PJitterBuffer pJitterBuffer, UINT16 seqNum, PRtpPacket* ppPacket);
 static STATUS defaultDropBufferData(PJitterBuffer pJitterBuffer, UINT16 startIndex, UINT16 endIndex, UINT32 nextTimestamp);
 static STATUS jitterBufferInternalParse(PJitterBufferInternal pInternal, BOOL bufferClosed);
@@ -74,7 +75,7 @@ STATUS jitterBufferFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT
 }
 
 STATUS jitterBufferFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
-                                         UINT16 endIndex)
+                                        UINT16 endIndex)
 {
     if (pJitterBuffer == NULL || pJitterBuffer->fillPartialFrameDataFn == NULL) {
         return STATUS_NULL_ARG;
@@ -152,8 +153,8 @@ STATUS createJitterBuffer(FrameReadyFunc onFrameReadyFunc, FrameDroppedFunc onFr
     pInternal->alwaysSinglePacketFrames = alwaysSinglePacketFrames;
 
     pInternal->customData = customData;
-    CHK_STATUS(hashTableCreateWithParams(JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT, JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH,
-                                         &pInternal->pPkgBufferHashTable));
+    CHK_STATUS(
+        hashTableCreateWithParams(JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT, JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH, &pInternal->pPkgBufferHashTable));
 
 CleanUp:
     if (STATUS_FAILED(retStatus) && pInternal != NULL) {
@@ -450,7 +451,7 @@ CleanUp:
 }
 
 static STATUS defaultFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
-                                           UINT16 endIndex)
+                                          UINT16 endIndex)
 {
     STATUS retStatus = STATUS_SUCCESS;
     PJitterBufferInternal pInternal = (PJitterBufferInternal) pJitterBuffer;
@@ -480,7 +481,8 @@ static STATUS defaultFillPartialFrameData(PJitterBuffer pJitterBuffer, PBYTE pFr
                 partialFrameSize = 0;
             }
             BOOL depayIsFirst = isFirstInFrame;
-            if (STATUS_FAILED(pInternal->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &depayIsFirst))) {
+            if (STATUS_FAILED(
+                    pInternal->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize, &depayIsFirst))) {
                 DLOGW("depayPayloadFn failed for packet index %u, skipping", index);
                 continue;
             }
@@ -650,8 +652,7 @@ static STATUS jitterBufferInternalParse(PJitterBufferInternal pInternal, BOOL bu
                     lastHeadFrameSeqNum = index;
                     seenHeadFramePacket = TRUE;
                     headFrameEnded = pCurPacket->header.marker;
-                } else if (seenHeadFramePacket && startDropIndex != index &&
-                           (pInternal->headTimestamp < earliestAllowedTimestamp || bufferClosed)) {
+                } else if (seenHeadFramePacket && startDropIndex != index && (pInternal->headTimestamp < earliestAllowedTimestamp || bufferClosed)) {
                     pInternal->onFrameDroppedFn(pInternal->customData, startDropIndex, UINT16_DEC(index), pInternal->headTimestamp);
                     CHK_STATUS(defaultDropBufferData((PJitterBuffer) pInternal, startDropIndex, UINT16_DEC(index), curTimestamp));
                     pInternal->firstFrameProcessed = TRUE;
@@ -772,7 +773,7 @@ CleanUp:
 
 // Depay all packets containing sequence numbers between and including the startIndex and endIndex for the JitterBuffer.
 static STATUS defaultFillFrameData(PJitterBuffer pJitterBuffer, PBYTE pFrame, UINT32 frameSize, PUINT32 pFilledSize, UINT16 startIndex,
-                                    UINT16 endIndex)
+                                   UINT16 endIndex)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;

--- a/src/source/PeerConnection/JitterBuffer.h
+++ b/src/source/PeerConnection/JitterBuffer.h
@@ -14,46 +14,34 @@ typedef STATUS (*FrameReadyFunc)(UINT64, UINT16, UINT16, UINT32);
 typedef STATUS (*FrameDroppedFunc)(UINT64, UINT16, UINT16, UINT32);
 #define UINT16_DEC(a) ((UINT16) ((a) - 1))
 
-#define JITTER_BUFFER_HASH_TABLE_BUCKET_COUNT  3000
-#define JITTER_BUFFER_HASH_TABLE_BUCKET_LENGTH 2
-
-typedef struct {
-    FrameReadyFunc onFrameReadyFn;
-    FrameDroppedFunc onFrameDroppedFn;
-    DepayRtpPayloadFunc depayPayloadFn;
-
-    // used for calculating interarrival jitter https://tools.ietf.org/html/rfc3550#section-6.4.1
-    // https://tools.ietf.org/html/rfc3550#appendix-A.8
-    // holds the relative transit time for the previous packet
+// Base jitter buffer struct with vtable for pluggable implementations.
+// Concrete implementations embed this as their first member.
+typedef struct JitterBuffer {
+    // Public fields used by callers (e.g. jitter/transit calculation, RTCP reports)
     UINT64 transit;
-    // holds estimated jitter, in clockRate units
     DOUBLE jitter;
-    UINT16 headSequenceNumber;
-    UINT16 tailSequenceNumber;
-    UINT32 headTimestamp;
-    UINT32 tailTimestamp;
-    // this is set to U64 even though rtp timestamps are U32
-    // in order to allow calculations to not cause overflow
-    UINT64 maxLatency;
-    UINT64 customData;
     UINT32 clockRate;
-    BOOL started;
-    BOOL firstFrameProcessed;
-    BOOL sequenceNumberOverflowState;
-    BOOL timestampOverFlowState;
-    // Codec never fragments frames across multiple RTP packets (e.g. Opus per RFC 7587).
-    // When TRUE, marker-bit delivery is safe even for the very first frame.
-    BOOL alwaysSinglePacketFrames;
-    PHashTable pPkgBufferHashTable;
+    UINT32 tailTimestamp; // latest RTP timestamp in buffer
+
+    // vtable — set by each implementation's create function
+    STATUS (*pushFn)(struct JitterBuffer*, PRtpPacket, PBOOL);
+    STATUS (*destroyFn)(struct JitterBuffer**);
+    STATUS (*fillFrameDataFn)(struct JitterBuffer*, PBYTE, UINT32, PUINT32, UINT16, UINT16);
+    STATUS (*fillPartialFrameDataFn)(struct JitterBuffer*, PBYTE, UINT32, PUINT32, UINT16, UINT16);
+    STATUS (*getPacketFn)(struct JitterBuffer*, UINT16, PRtpPacket*);
+    STATUS (*dropBufferDataFn)(struct JitterBuffer*, UINT16, UINT16, UINT32);
 } JitterBuffer, *PJitterBuffer;
 
 // constructor
 STATUS createJitterBuffer(FrameReadyFunc, FrameDroppedFunc, DepayRtpPayloadFunc, UINT32, UINT32, UINT64, BOOL, PJitterBuffer*);
 // destructor
 STATUS freeJitterBuffer(PJitterBuffer*);
+// dispatchers
 STATUS jitterBufferPush(PJitterBuffer, PRtpPacket, PBOOL);
 STATUS jitterBufferDropBufferData(PJitterBuffer, UINT16, UINT16, UINT32);
 STATUS jitterBufferFillFrameData(PJitterBuffer, PBYTE, UINT32, PUINT32, UINT16, UINT16);
+STATUS jitterBufferFillPartialFrameData(PJitterBuffer, PBYTE, UINT32, PUINT32, UINT16, UINT16);
+STATUS jitterBufferGetPacket(PJitterBuffer, UINT16, PRtpPacket*);
 
 #ifdef __cplusplus
 }

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -430,14 +430,12 @@ STATUS onFrameReadyFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex, U
     PKvsRtpTransceiver pTransceiver = (PKvsRtpTransceiver) customData;
     PRtpPacket pPacket = NULL;
     Frame frame;
-    UINT64 hashValue;
     UINT32 filledSize = 0, index;
 
     CHK(pTransceiver != NULL, STATUS_NULL_ARG);
 
     // TODO: handle multi-packet frames
-    retStatus = hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, startIndex, &hashValue);
-    pPacket = (PRtpPacket) hashValue;
+    retStatus = jitterBufferGetPacket(pTransceiver->pJitterBuffer, startIndex, &pPacket);
     if (retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT) {
         retStatus = STATUS_SUCCESS;
     } else {
@@ -487,24 +485,17 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT64 hashValue = 0;
-    PRtpPacket pPacket = NULL;
     PRtpPacket pFirstPacket = NULL;
     PKvsRtpTransceiver pTransceiver = (PKvsRtpTransceiver) customData;
-    UINT16 index;
-    UINT32 partialFrameSize = 0;
     UINT32 totalPartialSize = 0;
     UINT32 filledSize = 0;
-    PBYTE pCurPtrInFrame = NULL;
     Frame frame;
-    BOOL hasEntry = FALSE;
 
     DLOGW("Frame with timestamp %u is dropped!", timestamp);
     CHK(pTransceiver != NULL, STATUS_NULL_ARG);
 
     // Get first available packet for stats and timestamp
-    retStatus = hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, startIndex, &hashValue);
-    pFirstPacket = (PRtpPacket) hashValue;
+    retStatus = jitterBufferGetPacket(pTransceiver->pJitterBuffer, startIndex, &pFirstPacket);
     if (retStatus == STATUS_SUCCESS || retStatus == STATUS_HASH_KEY_NOT_PRESENT) {
         retStatus = STATUS_SUCCESS;
     } else {
@@ -523,30 +514,8 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     // If no partial frame callback registered, skip partial frame extraction
     CHK(pTransceiver->onPartialFrame != NULL, retStatus);
 
-    // Calculate total size of available packets
-    // NOTE: use local status instead of CHK_STATUS to avoid aborting the entire
-    // frame when a single packet's depay fails (e.g. truncated FU-A fragment).
-    BOOL isFirstInFrame = TRUE;
-    for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
-        if (STATUS_FAILED(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry))) {
-            continue;
-        }
-        if (hasEntry) {
-            if (STATUS_FAILED(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue))) {
-                continue;
-            }
-            pPacket = (PRtpPacket) hashValue;
-            partialFrameSize = 0;
-            BOOL depayIsFirst = isFirstInFrame;
-            if (STATUS_FAILED(
-                    pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, NULL, &partialFrameSize, &depayIsFirst))) {
-                DLOGW("depayPayloadFn size query failed for packet index %u, skipping", index);
-                continue;
-            }
-            totalPartialSize += partialFrameSize;
-            isFirstInFrame = FALSE;
-        }
-    }
+    // Calculate total size of available packets (size-query pass with NULL buffer)
+    jitterBufferFillPartialFrameData(pTransceiver->pJitterBuffer, NULL, 0, &totalPartialSize, startIndex, endIndex);
 
     // If no data available, skip callback
     CHK(totalPartialSize > 0, retStatus);
@@ -560,30 +529,7 @@ STATUS onFrameDroppedFunc(UINT64 customData, UINT16 startIndex, UINT16 endIndex,
     }
 
     // Fill partial frame data (skipping missing packets)
-    // NOTE: continue on failure — same rationale as the size calculation loop.
-    isFirstInFrame = TRUE;
-    pCurPtrInFrame = pTransceiver->peerFrameBuffer;
-    for (index = startIndex; UINT16_DEC(index) != endIndex; index++) {
-        if (STATUS_FAILED(hashTableContains(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hasEntry))) {
-            continue;
-        }
-        if (hasEntry) {
-            if (STATUS_FAILED(hashTableGet(pTransceiver->pJitterBuffer->pPkgBufferHashTable, index, &hashValue))) {
-                continue;
-            }
-            pPacket = (PRtpPacket) hashValue;
-            partialFrameSize = totalPartialSize - filledSize;
-            BOOL depayIsFirst = isFirstInFrame;
-            if (STATUS_FAILED(pTransceiver->pJitterBuffer->depayPayloadFn(pPacket->payload, pPacket->payloadLength, pCurPtrInFrame, &partialFrameSize,
-                                                                          &depayIsFirst))) {
-                DLOGW("depayPayloadFn fill failed for packet index %u, skipping", index);
-                continue;
-            }
-            pCurPtrInFrame += partialFrameSize;
-            filledSize += partialFrameSize;
-            isFirstInFrame = FALSE;
-        }
-    }
+    jitterBufferFillPartialFrameData(pTransceiver->pJitterBuffer, pTransceiver->peerFrameBuffer, totalPartialSize, &filledSize, startIndex, endIndex);
 
     // Build frame struct and invoke callback
     frame.version = FRAME_CURRENT_VERSION;

--- a/tst/H264JitterBufferIntegrationTest.cpp
+++ b/tst/H264JitterBufferIntegrationTest.cpp
@@ -310,9 +310,9 @@ class H264JitterBufferIntegrationTest : public WebRtcClientTestBase {
         if (pTest->mJitterBuffer != NULL) {
             tailTsReady = pTest->mJitterBuffer->tailTimestamp;
             // Look up the frame timestamp from the start packet
-            UINT64 hashValue = 0;
-            if (STATUS_SUCCEEDED(hashTableGet(pTest->mJitterBuffer->pPkgBufferHashTable, startIndex, &hashValue))) {
-                frameTsReady = ((PRtpPacket) hashValue)->header.timestamp;
+            PRtpPacket pStartPacket = NULL;
+            if (STATUS_SUCCEEDED(jitterBufferGetPacket(pTest->mJitterBuffer, startIndex, &pStartPacket)) && pStartPacket != NULL) {
+                frameTsReady = pStartPacket->header.timestamp;
             }
         }
         INT32 delayTs = (INT32)(tailTsReady - frameTsReady);


### PR DESCRIPTION
*What was changed?*
JitterBuffer struct refactored into a base struct with vtable function pointers and a private JitterBufferInternal implementation. Added jitterBufferGetPacket() and jitterBufferFillPartialFrameData() public API functions.

*Why was it changed?*
PeerConnection.c was reaching into JitterBuffer internals (pPkgBufferHashTable, depayPayloadFn), coupling it to the single implementation. Making the struct opaque with a vtable enables swapping in experimental jitter buffer implementations behind a common interface.

*How was it changed?*
- JitterBuffer base struct now contains only public fields (transit, jitter, clockRate, tailTimestamp) and vtable function pointers
- Private fields (hash table, callbacks, sequence tracking) moved into JitterBufferInternal in JitterBuffer.c
- Public API functions become thin vtable dispatchers
- PeerConnection.c updated to use jitterBufferGetPacket() and jitterBufferFillPartialFrameData() instead of direct internal access
- Test updated to use jitterBufferGetPacket()

*What testing was done for the changes?*
All 35 jitter buffer tests pass (25 JitterBufferFunctionalityTest + 10 H264JitterBufferIntegrationTest)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.