### PR TITLE
RTCP Receiver Reports and packetsLost stats (RFC 3550)

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -410,10 +410,10 @@ typedef struct {
 
 typedef struct {
     RTCRtpStreamStats rtpStream;
-    UINT64 packetsReceived; //!< Total number of RTP packets received for this SSRC.
-    INT64 packetsLost; //!< Total number of RTP packets lost for this SSRC. Calculated as defined in [RFC3550] section 6.4.1. Note that because
-                       //!< of how this is estimated, it can be negative if more packets are received than sent.
-    DOUBLE jitter;     //!< Packet Jitter measured in seconds for this SSRC. Calculated as defined in section 6.4.1. of [RFC3550].
+    UINT64 packetsReceived;  //!< Total number of RTP packets received for this SSRC.
+    INT64 packetsLost;       //!< Total number of RTP packets lost for this SSRC. Calculated as defined in [RFC3550] section 6.4.1. Note that because
+                             //!< of how this is estimated, it can be negative if more packets are received than sent.
+    DOUBLE jitter;           //!< Packet Jitter measured in seconds for this SSRC. Calculated as defined in section 6.4.1. of [RFC3550].
     UINT64 packetsDiscarded; //!< The cumulative number of RTP packets discarded by the jitter buffer due to late or early-arrival, i.e., these
                              //!< packets are not played out. RTP packets discarded due to packet duplication are not reported in this metric
                              //!< [XRBLOCK-STATS]. Calculated as defined in [RFC7002] section 3.2 and Appendix A.a.
@@ -448,13 +448,13 @@ typedef struct {
  * Reference: https://www.w3.org/TR/webrtc-stats/#remoteinboundrtpstats-dict*
  */
 typedef struct {
-    RtcReceivedRtpStreamStats received;  //!< Inherited from RTCReceivedRtpStreamStats (packetsReceived, packetsLost, jitter)
-    DOMString localId;                //!< Used to look up RTCOutboundRtpStreamStats for the SSRC
-    UINT64 roundTripTime;             //!< Estimated round trip time (milliseconds) for this SSRC based on the RTCP timestamps
-    UINT64 totalRoundTripTime;        //!< The cumulative sum of all round trip time measurements in seconds since the beginning of the session
-    DOUBLE fractionLost;              //!< The fraction packet loss reported for this SSRC
-    UINT64 reportsReceived;           //!< Total number of RTCP RR blocks received for this SSRC
-    UINT64 roundTripTimeMeasurements; //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
+    RtcReceivedRtpStreamStats received; //!< Inherited from RTCReceivedRtpStreamStats (packetsReceived, packetsLost, jitter)
+    DOMString localId;                  //!< Used to look up RTCOutboundRtpStreamStats for the SSRC
+    UINT64 roundTripTime;               //!< Estimated round trip time (milliseconds) for this SSRC based on the RTCP timestamps
+    UINT64 totalRoundTripTime;          //!< The cumulative sum of all round trip time measurements in seconds since the beginning of the session
+    DOUBLE fractionLost;                //!< The fraction packet loss reported for this SSRC
+    UINT64 reportsReceived;             //!< Total number of RTCP RR blocks received for this SSRC
+    UINT64 roundTripTimeMeasurements;   //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
 } RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
 
 /**

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -408,24 +408,10 @@ typedef struct {
     RTC_QUALITY_LIMITATION_REASON qualityLimitationReason;       //!< Only valid for video.
 } RtcOutboundRtpStreamStats, *PRtcOutboundRtpStreamStats;
 
-/**
- * @brief RTCRemoteInboundRtpStreamStats Represents the remote endpoint's measurement metrics for a particular incoming RTP stream
- *
- * Reference: https://www.w3.org/TR/webrtc-stats/#remoteinboundrtpstats-dict*
- */
-typedef struct {
-    DOMString localId;                //!< Used to look up RTCOutboundRtpStreamStats for the SSRC
-    UINT64 roundTripTime;             //!< Estimated round trip time (milliseconds) for this SSRC based on the RTCP timestamps
-    UINT64 totalRoundTripTime;        //!< The cumulative sum of all round trip time measurements in seconds since the beginning of the session
-    DOUBLE fractionLost;              //!< The fraction packet loss reported for this SSRC
-    UINT64 reportsReceived;           //!< Total number of RTCP RR blocks received for this SSRC
-    UINT64 roundTripTimeMeasurements; //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
-} RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
-
 typedef struct {
     RTCRtpStreamStats rtpStream;
     UINT64 packetsReceived; //!< Total number of RTP packets received for this SSRC.
-    INT64 packetsLost; //!< TODO Total number of RTP packets lost for this SSRC. Calculated as defined in [RFC3550] section 6.4.1. Note that because
+    INT64 packetsLost; //!< Total number of RTP packets lost for this SSRC. Calculated as defined in [RFC3550] section 6.4.1. Note that because
                        //!< of how this is estimated, it can be negative if more packets are received than sent.
     DOUBLE jitter;     //!< Packet Jitter measured in seconds for this SSRC. Calculated as defined in section 6.4.1. of [RFC3550].
     UINT64 packetsDiscarded; //!< The cumulative number of RTP packets discarded by the jitter buffer due to late or early-arrival, i.e., these
@@ -455,6 +441,21 @@ typedef struct {
     UINT32 fullFramesLost; //!< Only valid for video. The cumulative number of full frames lost. The measurement begins when the receiver is created
                            //!< and is a cumulative metric as defined in Appendix A (i) of [RFC7004].
 } RtcReceivedRtpStreamStats, *PRtcReceivedRtpStreamStats;
+
+/**
+ * @brief RTCRemoteInboundRtpStreamStats Represents the remote endpoint's measurement metrics for a particular incoming RTP stream
+ *
+ * Reference: https://www.w3.org/TR/webrtc-stats/#remoteinboundrtpstats-dict*
+ */
+typedef struct {
+    RtcReceivedRtpStreamStats received;  //!< Inherited from RTCReceivedRtpStreamStats (packetsReceived, packetsLost, jitter)
+    DOMString localId;                //!< Used to look up RTCOutboundRtpStreamStats for the SSRC
+    UINT64 roundTripTime;             //!< Estimated round trip time (milliseconds) for this SSRC based on the RTCP timestamps
+    UINT64 totalRoundTripTime;        //!< The cumulative sum of all round trip time measurements in seconds since the beginning of the session
+    DOUBLE fractionLost;              //!< The fraction packet loss reported for this SSRC
+    UINT64 reportsReceived;           //!< Total number of RTCP RR blocks received for this SSRC
+    UINT64 roundTripTimeMeasurements; //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time
+} RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
 
 /**
  * @brief The RTCInboundRtpStreamStats dictionary represents the measurement metrics for the incoming RTP media stream. The timestamp reported in the

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -254,6 +254,41 @@ CleanUp:
     LEAVES();
 }
 
+static VOID rrInitSeq(PKvsRtpTransceiver pTransceiver, UINT16 seq)
+{
+    pTransceiver->rrBaseSeq = seq;
+    pTransceiver->rrMaxSeq = seq;
+    pTransceiver->rrBadSeq = RTP_SEQ_MOD + 1;
+    pTransceiver->rrCycles = 0;
+    pTransceiver->rrExpectedPrior = 0;
+    pTransceiver->rrReceivedPrior = 0;
+    pTransceiver->rrSeqInitialized = TRUE;
+}
+
+static VOID rrUpdateSeq(PKvsRtpTransceiver pTransceiver, UINT16 seq)
+{
+    // RFC 3550 Appendix A.1
+    UINT16 udelta = seq - pTransceiver->rrMaxSeq;
+
+    if (udelta < MAX_DROPOUT) {
+        // in order, with permissible gap
+        if (seq < pTransceiver->rrMaxSeq) {
+            // sequence number wrapped
+            pTransceiver->rrCycles += RTP_SEQ_MOD;
+        }
+        pTransceiver->rrMaxSeq = seq;
+    } else if (udelta <= RTP_SEQ_MOD - MAX_MISORDER) {
+        // the sequence number made a very large jump
+        if ((UINT32) seq == pTransceiver->rrBadSeq) {
+            // two sequential packets -- assume that the other side restarted
+            rrInitSeq(pTransceiver, seq);
+        } else {
+            pTransceiver->rrBadSeq = ((UINT32) seq + 1) & (RTP_SEQ_MOD - 1);
+        }
+    }
+    // else duplicate or reordered packet — ignore for max tracking
+}
+
 STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuffer, UINT32 bufferLen)
 {
     ENTERS();
@@ -319,6 +354,11 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
         if (pTransceiver->jitterBufferSsrc == ssrc) {
             packetsReceived++;
 
+            if (!pTransceiver->rrSeqInitialized) {
+                rrInitSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
+            }
+            rrUpdateSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
+
             // https://tools.ietf.org/html/rfc3550#section-6.4.1
             // https://tools.ietf.org/html/rfc3550#appendix-A.8
             // interarrival jitter
@@ -357,6 +397,12 @@ CleanUp:
         pTransceiver->inboundStats.bytesReceived += bytesReceived;
         pTransceiver->inboundStats.received.jitter = pTransceiver->pJitterBuffer->jitter / pTransceiver->pJitterBuffer->clockRate;
         pTransceiver->inboundStats.received.packetsDiscarded += packetsDiscarded;
+        if (pTransceiver->rrSeqInitialized) {
+            UINT32 extMax = pTransceiver->rrCycles + pTransceiver->rrMaxSeq;
+            UINT32 expected = extMax - pTransceiver->rrBaseSeq + 1;
+            pTransceiver->inboundStats.received.packetsLost =
+                (INT64) expected - (INT64) pTransceiver->inboundStats.received.packetsReceived;
+        }
         MUTEX_UNLOCK(pTransceiver->statsLock);
     }
     if (!ownedByJitterBuffer) {
@@ -862,6 +908,82 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         putUnalignedInt32BigEndian(rawPacket + 24, octetCount);
         CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
         CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen));
+    }
+
+    // Send RTCP Receiver Report if we are receiving media on this transceiver
+    if (pKvsPeerConnection->pSrtpSession != NULL && pKvsRtpTransceiver->jitterBufferSsrc != 0 && pKvsRtpTransceiver->rrSeqInitialized) {
+        UINT32 rrExtMax, rrExpected, rrReceived, rrLost, rrExpectedInterval, rrReceivedInterval, rrLostInterval;
+        UINT8 rrFraction;
+        INT32 rrCumulativeLost;
+        UINT32 rrPacketLen;
+        BYTE rrPacket[RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN]; // header + sender SSRC + 1 report block
+
+        MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+        rrExtMax = pKvsRtpTransceiver->rrCycles + pKvsRtpTransceiver->rrMaxSeq;
+        rrExpected = rrExtMax - pKvsRtpTransceiver->rrBaseSeq + 1;
+        rrReceived = (UINT32) pKvsRtpTransceiver->inboundStats.received.packetsReceived;
+
+        rrLost = rrExpected - rrReceived;
+
+        rrExpectedInterval = rrExpected - pKvsRtpTransceiver->rrExpectedPrior;
+        pKvsRtpTransceiver->rrExpectedPrior = rrExpected;
+        rrReceivedInterval = rrReceived - pKvsRtpTransceiver->rrReceivedPrior;
+        pKvsRtpTransceiver->rrReceivedPrior = rrReceived;
+        rrLostInterval = rrExpectedInterval - rrReceivedInterval;
+
+        if (rrExpectedInterval == 0 || rrLostInterval == 0) {
+            rrFraction = 0;
+        } else {
+            rrFraction = (UINT8) ((rrLostInterval << 8) / rrExpectedInterval);
+        }
+
+        // Clamp cumulative lost to 24-bit signed range [-0x800000, 0x7FFFFF]
+        if ((INT32) rrLost > 0x7FFFFF) {
+            rrCumulativeLost = 0x7FFFFF;
+        } else if ((INT32) rrLost < -0x800000) {
+            rrCumulativeLost = -0x800000;
+        } else {
+            rrCumulativeLost = (INT32) rrLost;
+        }
+        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+
+        rrPacketLen = sizeof(rrPacket);
+        MEMSET(rrPacket, 0, rrPacketLen);
+        rrPacket[0] = (RTCP_PACKET_VERSION_VAL << 6) | 1; // V=2, RC=1
+        rrPacket[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_RECEIVER_REPORT;
+        putUnalignedInt16BigEndian(rrPacket + RTCP_PACKET_LEN_OFFSET, (rrPacketLen / RTCP_PACKET_LEN_WORD_SIZE) - 1);
+        putUnalignedInt32BigEndian(rrPacket + 4, ssrc); // sender SSRC (our SSRC)
+        // Report block
+        putUnalignedInt32BigEndian(rrPacket + 8, pKvsRtpTransceiver->jitterBufferSsrc); // SSRC_1 (source)
+        rrPacket[12] = rrFraction;
+        rrPacket[13] = (rrCumulativeLost >> 16) & 0xFF;
+        rrPacket[14] = (rrCumulativeLost >> 8) & 0xFF;
+        rrPacket[15] = rrCumulativeLost & 0xFF;
+        putUnalignedInt32BigEndian(rrPacket + 16, rrExtMax); // extended highest sequence number
+        putUnalignedInt32BigEndian(rrPacket + 20, (UINT32) (pKvsRtpTransceiver->pJitterBuffer->jitter)); // interarrival jitter
+        putUnalignedInt32BigEndian(rrPacket + 24, pKvsRtpTransceiver->lastSRNtpMid); // LSR
+
+        // DLSR: delay since last SR in 1/65536 sec units
+        if (pKvsRtpTransceiver->lastSRReceivedTime != 0) {
+            UINT64 dlsrTime = currentTime - pKvsRtpTransceiver->lastSRReceivedTime;
+            UINT32 dlsr = (UINT32) KVS_CONVERT_TIMESCALE(dlsrTime, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
+            putUnalignedInt32BigEndian(rrPacket + 28, dlsr);
+        }
+
+        DLOGV("receiver report ssrc: %u src: %u frac: %u lost: %d seq: %u", ssrc, pKvsRtpTransceiver->jitterBufferSsrc, rrFraction, rrCumulativeLost,
+              rrExtMax);
+        {
+            UINT32 rrAllocSize = rrPacketLen + SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
+            PBYTE rrRawPacket = (PBYTE) MEMALLOC(rrAllocSize);
+            CHK(rrRawPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
+            MEMCPY(rrRawPacket, rrPacket, rrPacketLen);
+            retStatus = encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rrRawPacket, (PINT32) &rrPacketLen);
+            if (STATUS_SUCCEEDED(retStatus)) {
+                retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rrRawPacket, rrPacketLen);
+            }
+            SAFE_MEMFREE(rrRawPacket);
+            CHK_STATUS(retStatus);
+        }
     }
 
     delay = 100 + (RAND() % 200);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -400,8 +400,7 @@ CleanUp:
         if (pTransceiver->rrSeqInitialized) {
             UINT32 extMax = pTransceiver->rrCycles + pTransceiver->rrMaxSeq;
             UINT32 expected = extMax - pTransceiver->rrBaseSeq + 1;
-            pTransceiver->inboundStats.received.packetsLost =
-                (INT64) expected - (INT64) pTransceiver->inboundStats.received.packetsReceived;
+            pTransceiver->inboundStats.received.packetsLost = (INT64) expected - (INT64) pTransceiver->inboundStats.received.packetsReceived;
         }
         MUTEX_UNLOCK(pTransceiver->statsLock);
     }
@@ -959,9 +958,9 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         rrPacket[13] = (rrCumulativeLost >> 16) & 0xFF;
         rrPacket[14] = (rrCumulativeLost >> 8) & 0xFF;
         rrPacket[15] = rrCumulativeLost & 0xFF;
-        putUnalignedInt32BigEndian(rrPacket + 16, rrExtMax); // extended highest sequence number
+        putUnalignedInt32BigEndian(rrPacket + 16, rrExtMax);                                             // extended highest sequence number
         putUnalignedInt32BigEndian(rrPacket + 20, (UINT32) (pKvsRtpTransceiver->pJitterBuffer->jitter)); // interarrival jitter
-        putUnalignedInt32BigEndian(rrPacket + 24, pKvsRtpTransceiver->lastSRNtpMid); // LSR
+        putUnalignedInt32BigEndian(rrPacket + 24, pKvsRtpTransceiver->lastSRNtpMid);                     // LSR
 
         // DLSR: delay since last SR in 1/65536 sec units
         if (pKvsRtpTransceiver->lastSRReceivedTime != 0) {

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -70,6 +70,9 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
         UINT32 packetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 16);
         UINT32 octetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 20);
         DLOGV("RTCP_PACKET_TYPE_SENDER_REPORT %d %" PRIu64 " rtpTs: %u %u pkts %u bytes", senderSSRC, ntpTime, rtpTs, packetCnt, octetCnt);
+        // Store for LSR/DLSR in outgoing RR
+        pTransceiver->lastSRNtpMid = (UINT32) ((ntpTime >> 16U) & 0xffffffffULL);
+        pTransceiver->lastSRReceivedTime = GETTIME();
     } else {
         DLOGW("Received sender report for non existing ssrc: %u", senderSSRC);
     }
@@ -91,9 +94,6 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     UNUSED_PARAM(rttPropDelay);
     UNUSED_PARAM(delaySinceLastSR);
     UNUSED_PARAM(lastSR);
-    UNUSED_PARAM(interarrivalJitter);
-    UNUSED_PARAM(extHiSeqNumReceived);
-    UNUSED_PARAM(cumulativeLost);
     UNUSED_PARAM(senderSSRC);
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
@@ -139,6 +139,10 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     pTransceiver->remoteInboundStats.roundTripTimeMeasurements++;
     pTransceiver->remoteInboundStats.totalRoundTripTime += rttPropDelayMsec;
     pTransceiver->remoteInboundStats.roundTripTime = rttPropDelayMsec;
+    // Sign-extend 24-bit cumulativeLost to INT64
+    pTransceiver->remoteInboundStats.received.packetsLost = (cumulativeLost & 0x800000u) ? (INT64) (cumulativeLost | 0xFF000000u) : (INT64) cumulativeLost;
+    pTransceiver->remoteInboundStats.received.jitter =
+        (DOUBLE) interarrivalJitter / (DOUBLE) pTransceiver->pJitterBuffer->clockRate;
     MUTEX_UNLOCK(pTransceiver->statsLock);
 
 CleanUp:

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -140,9 +140,9 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     pTransceiver->remoteInboundStats.totalRoundTripTime += rttPropDelayMsec;
     pTransceiver->remoteInboundStats.roundTripTime = rttPropDelayMsec;
     // Sign-extend 24-bit cumulativeLost to INT64
-    pTransceiver->remoteInboundStats.received.packetsLost = (cumulativeLost & 0x800000u) ? (INT64) (cumulativeLost | 0xFF000000u) : (INT64) cumulativeLost;
-    pTransceiver->remoteInboundStats.received.jitter =
-        (DOUBLE) interarrivalJitter / (DOUBLE) pTransceiver->pJitterBuffer->clockRate;
+    pTransceiver->remoteInboundStats.received.packetsLost =
+        (cumulativeLost & 0x800000u) ? (INT64) (cumulativeLost | 0xFF000000u) : (INT64) cumulativeLost;
+    pTransceiver->remoteInboundStats.received.jitter = (DOUBLE) interarrivalJitter / (DOUBLE) pTransceiver->pJitterBuffer->clockRate;
     MUTEX_UNLOCK(pTransceiver->statsLock);
 
 CleanUp:

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -27,9 +27,9 @@ extern "C" {
 #define HUGE_FRAME_MULTIPLIER 2.5
 
 // RFC 3550 Appendix A.1 constants
-#define RTP_SEQ_MOD   (1 << 16)
-#define MAX_DROPOUT   3000
-#define MAX_MISORDER  100
+#define RTP_SEQ_MOD  (1 << 16)
+#define MAX_DROPOUT  3000
+#define MAX_MISORDER 100
 
 typedef struct {
     UINT8 payloadType;

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -26,6 +26,11 @@ extern "C" {
 // Huge frames, by definition, are frames that have an encoded size at least 2.5 times the average size of the frames.
 #define HUGE_FRAME_MULTIPLIER 2.5
 
+// RFC 3550 Appendix A.1 constants
+#define RTP_SEQ_MOD   (1 << 16)
+#define MAX_DROPOUT   3000
+#define MAX_MISORDER  100
+
 typedef struct {
     UINT8 payloadType;
     UINT8 rtxPayloadType;
@@ -85,6 +90,19 @@ typedef struct {
     RtcOutboundRtpStreamStats outboundStats;
     RtcRemoteInboundRtpStreamStats remoteInboundStats;
     RtcInboundRtpStreamStats inboundStats;
+
+    // RFC 3550 A.1/A.3 — receiver sequence number state for RR and packetsLost
+    UINT16 rrMaxSeq;        // highest seq number seen
+    UINT32 rrCycles;        // shifted count of seq number cycles (wraps)
+    UINT32 rrBaseSeq;       // first seq number received
+    UINT32 rrBadSeq;        // last 'bad' seq number + 1
+    UINT32 rrExpectedPrior; // expected at last RR interval
+    UINT32 rrReceivedPrior; // received at last RR interval
+    BOOL rrSeqInitialized;  // whether first packet has been seen
+
+    // For LSR/DLSR in outgoing RR
+    UINT32 lastSRNtpMid;       // middle 32 bits of last received SR NTP timestamp
+    UINT64 lastSRReceivedTime; // wallclock (100ns) when last SR was received
 
     UINT8 firSequenceNumber;
 } KvsRtpTransceiver, *PKvsRtpTransceiver;

--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -94,7 +94,7 @@ UINT64 convertTimestampToNTP(UINT64 time100ns);
 // In some fields where a more compact representation is
 //   appropriate, only the middle 32 bits are used; that is, the low 16
 //   bits of the integer part and the high 16 bits of the fractional part.
-#define MID_NTP(ntp_time) (UINT32)((currentTimeNTP >> 16U) & 0xffffffffULL)
+#define MID_NTP(ntp_time) (UINT32)(((ntp_time) >> 16U) & 0xffffffffULL)
 
 #ifdef __cplusplus
 }

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -204,6 +204,9 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundSenderReport)
     EXPECT_EQ(4.0 / 255.0, stats.fractionLost);
     EXPECT_LT(0, stats.totalRoundTripTime);
     EXPECT_LT(0, stats.roundTripTime);
+    // Verify incoming RR fields stored in received stats
+    EXPECT_EQ(0, stats.received.packetsLost); // cumulative lost = 0 in the packet
+    EXPECT_DOUBLE_EQ(0.0, stats.received.jitter); // interarrival jitter = 0 in the packet
     freePeerConnection(&pRtcPeerConnection);
 }
 
@@ -727,6 +730,214 @@ TEST_F(RtcpFunctionalityTest, twccReceiverDuplicatePacketHandling)
     EXPECT_EQ(1, itemCount);
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportSequentialPackets)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // Simulate rrInitSeq + rrUpdateSeq for seq 0..99 by setting state directly
+    pT->rrBaseSeq = 0;
+    pT->rrMaxSeq = 99;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+
+    MUTEX_LOCK(pT->statsLock);
+    pT->inboundStats.received.packetsReceived = 100;
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq;
+    UINT32 expected = extMax - pT->rrBaseSeq + 1;
+    pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
+    MUTEX_UNLOCK(pT->statsLock);
+
+    EXPECT_EQ(99, pT->rrMaxSeq);
+    EXPECT_EQ(0u, pT->rrCycles);
+    EXPECT_EQ(0, pT->inboundStats.received.packetsLost);
+
+    // Verify RR packet fields
+    UINT32 rrExpected = extMax - pT->rrBaseSeq + 1;
+    UINT32 rrReceived = (UINT32) pT->inboundStats.received.packetsReceived;
+    UINT32 rrLost = rrExpected - rrReceived;
+    UINT32 rrExpectedInterval = rrExpected - pT->rrExpectedPrior;
+    UINT32 rrReceivedInterval = rrReceived - pT->rrReceivedPrior;
+    UINT32 rrLostInterval = rrExpectedInterval - rrReceivedInterval;
+    EXPECT_EQ(0u, rrLost);
+    EXPECT_EQ(0u, rrLostInterval);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportWithPacketLoss)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // 100 expected (seq 0..99), 97 received (skipped 10, 20, 30)
+    pT->rrBaseSeq = 0;
+    pT->rrMaxSeq = 99;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+
+    MUTEX_LOCK(pT->statsLock);
+    pT->inboundStats.received.packetsReceived = 97;
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq;
+    UINT32 expected = extMax - pT->rrBaseSeq + 1;
+    pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
+    MUTEX_UNLOCK(pT->statsLock);
+
+    EXPECT_EQ(3, pT->inboundStats.received.packetsLost);
+
+    // Verify fraction lost calculation
+    UINT32 rrReceived = (UINT32) pT->inboundStats.received.packetsReceived;
+    UINT32 rrLostInterval = expected - rrReceived;
+    UINT8 fraction = (UINT8) ((rrLostInterval << 8) / expected);
+    EXPECT_EQ((3 << 8) / 100, fraction); // = 7
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportSeqOverflow)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // Simulate: rrInitSeq(65534), then packets 65534, 65535, 0, 1, 2
+    pT->rrBaseSeq = 65534;
+    pT->rrMaxSeq = 2;
+    pT->rrCycles = RTP_SEQ_MOD; // one wrap
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+
+    MUTEX_LOCK(pT->statsLock);
+    pT->inboundStats.received.packetsReceived = 5;
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq; // 65536 + 2 = 65538
+    UINT32 expected = extMax - pT->rrBaseSeq + 1;  // 65538 - 65534 + 1 = 5
+    pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
+    MUTEX_UNLOCK(pT->statsLock);
+
+    EXPECT_EQ(65538u, extMax);
+    EXPECT_EQ(5u, expected);
+    EXPECT_EQ(0, pT->inboundStats.received.packetsLost);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportSeqOverflowWithLoss)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // rrInitSeq(65533), feed: 65533, 65534, skip 65535, 0, 1, skip 2, 3
+    pT->rrBaseSeq = 65533;
+    pT->rrMaxSeq = 3;
+    pT->rrCycles = RTP_SEQ_MOD; // one wrap
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+
+    MUTEX_LOCK(pT->statsLock);
+    pT->inboundStats.received.packetsReceived = 5; // 65533, 65534, 0, 1, 3
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq; // 65536 + 3 = 65539
+    UINT32 expected = extMax - pT->rrBaseSeq + 1;  // 65539 - 65533 + 1 = 7
+    pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
+    MUTEX_UNLOCK(pT->statsLock);
+
+    EXPECT_EQ(7u, expected);
+    EXPECT_EQ(2, pT->inboundStats.received.packetsLost);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportFractionLostPerInterval)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // First interval: seq 0..49, 50 packets
+    pT->rrBaseSeq = 0;
+    pT->rrMaxSeq = 49;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+    pT->inboundStats.received.packetsReceived = 50;
+
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq;
+    UINT32 expected = extMax - pT->rrBaseSeq + 1;
+    UINT32 received = (UINT32) pT->inboundStats.received.packetsReceived;
+    UINT32 expectedInterval = expected - pT->rrExpectedPrior;
+    UINT32 receivedInterval = received - pT->rrReceivedPrior;
+    UINT32 lostInterval = expectedInterval - receivedInterval;
+    UINT8 fraction1 = (expectedInterval == 0 || lostInterval == 0) ? 0 : (UINT8) ((lostInterval << 8) / expectedInterval);
+    pT->rrExpectedPrior = expected;
+    pT->rrReceivedPrior = received;
+    EXPECT_EQ(0, fraction1);
+
+    // Second interval: seq 50..99, but skip 60, 70, 80 -> 47 received
+    pT->rrMaxSeq = 99;
+    pT->inboundStats.received.packetsReceived = 97; // 50 + 47
+
+    extMax = pT->rrCycles + pT->rrMaxSeq;
+    expected = extMax - pT->rrBaseSeq + 1; // 100
+    received = (UINT32) pT->inboundStats.received.packetsReceived; // 97
+    expectedInterval = expected - pT->rrExpectedPrior; // 100 - 50 = 50
+    receivedInterval = received - pT->rrReceivedPrior; // 97 - 50 = 47
+    lostInterval = expectedInterval - receivedInterval; // 3
+    UINT8 fraction2 = (expectedInterval == 0 || lostInterval == 0) ? 0 : (UINT8) ((lostInterval << 8) / expectedInterval);
+    EXPECT_EQ((3 << 8) / 50, fraction2); // = 15
+
+    // Verify prior values were updated
+    EXPECT_EQ(50u, pT->rrExpectedPrior);
+    EXPECT_EQ(50u, pT->rrReceivedPrior);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportLargeJump)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // rrInitSeq(100), sequential 100..110
+    pT->rrBaseSeq = 100;
+    pT->rrMaxSeq = 110;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrSeqInitialized = TRUE;
+
+    // Now a large jump to 5000 — per RFC 3550, badSeq should be set
+    // udelta = 5000 - 110 = 4890, which is > MAX_DROPOUT (3000)
+    // and 4890 < RTP_SEQ_MOD - MAX_MISORDER = 65436
+    // So badSeq = (5000 + 1) & 0xFFFF = 5001
+    // maxSeq should NOT change
+    constexpr UINT16 jumpSeq = 5000;
+    UINT16 udelta = jumpSeq - pT->rrMaxSeq; // 4890
+    EXPECT_GT(udelta, 3000); // > MAX_DROPOUT
+    EXPECT_LT(udelta, RTP_SEQ_MOD - 100); // < RTP_SEQ_MOD - MAX_MISORDER
+
+    // After this, maxSeq should remain 110, badSeq = 5001
+    pT->rrBadSeq = ((UINT32) jumpSeq + 1) & (RTP_SEQ_MOD - 1);
+    EXPECT_EQ(110, pT->rrMaxSeq);
+    EXPECT_EQ(5001u, pT->rrBadSeq);
+
+    // Second sequential packet at 5001 would re-init
+    pT->rrBaseSeq = 5001;
+    pT->rrMaxSeq = 5001;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    EXPECT_EQ(5001, pT->rrMaxSeq);
+
+    freePeerConnection(&pRtcPeerConnection);
 }
 
 TEST_F(RtcpFunctionalityTest, twccMakeRunlenMacro)


### PR DESCRIPTION
*What was changed?*
- Send RTCP Receiver Report (RR) packets per RFC 3550 with fraction lost, cumulative lost, extended highest sequence number, interarrival jitter, LSR, and DLSR
- Populate `inboundStats.received.packetsLost` from RFC 3550 sequence number tracking
- Store incoming RR fields (`cumulativeLost`, `interarrivalJitter`) into `remoteInboundStats.received.*`
- Align `RtcRemoteInboundRtpStreamStats` with W3C spec by adding `RtcReceivedRtpStreamStats received` base struct
- Fix `MID_NTP` macro bug (used hardcoded `currentTimeNTP` instead of the `ntp_time` parameter)

*Why was it changed?*
The SDK did not send RTCP Receiver Reports and did not populate `packetsLost`. Per RFC 3550 section 6.4.2, a receiver SHOULD periodically send RR packets. Incoming RR fields were parsed in `onRtcpReceiverReport` but discarded via `UNUSED_PARAM`. The `RtcRemoteInboundRtpStreamStats` struct didn't match the W3C RTCRemoteInboundRtpStreamStats hierarchy which inherits from RTCReceivedRtpStreamStats.

*How was it changed?*
- **Stats.h**: Moved `RtcReceivedRtpStreamStats` before `RtcRemoteInboundRtpStreamStats`; added `received` field to `RtcRemoteInboundRtpStreamStats`; removed TODO from packetsLost comment
- **Rtp.h**: Added RFC 3550 A.1/A.3 sequence tracking state (`rrMaxSeq`, `rrCycles`, `rrBaseSeq`, etc.) and LSR/DLSR fields to `KvsRtpTransceiver`; added `RTP_SEQ_MOD`, `MAX_DROPOUT`, `MAX_MISORDER` constants
- **PeerConnection.c**: Implemented `rrInitSeq`/`rrUpdateSeq` (RFC 3550 Appendix A.1); calls sequence tracking in `sendPacketToRtpReceiver`; populates `packetsLost`; sends RR in `rtcpReportsCallback`
- **Rtcp.c**: Stores SR NTP timestamp for LSR/DLSR; stores incoming RR cumulativeLost and jitter in `remoteInboundStats.received.*`
- **RtcpPacket.h**: Fixed `MID_NTP` macro parameter bug

*What testing was done for the changes?*
- Added 6 new unit tests: `receiverReportSequentialPackets`, `receiverReportWithPacketLoss`, `receiverReportSeqOverflow`, `receiverReportSeqOverflowWithLoss`, `receiverReportFractionLostPerInterval`, `receiverReportLargeJump`
- Updated existing `onRtcpPacketCompoundSenderReport` test to verify `received.packetsLost` and `received.jitter`
- All 30 RTCP tests pass, all Metrics/exchangeMedia tests pass
- Built and tested with mbedTLS static preset

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.