### PR TITLE
Fix DTLS and SDP fingerprint parsing

### DIFF
--- a/src/source/Crypto/Dtls_openssl.c
+++ b/src/source/Crypto/Dtls_openssl.c
@@ -903,7 +903,7 @@ STATUS dtlsSessionVerifyRemoteCertificateFingerprint(PDtlsSession pDtlsSession, 
     CHK((pRemoteCertificate = SSL_get_peer_certificate(pDtlsSession->pSsl)) != NULL, STATUS_INTERNAL_ERROR);
     CHK_STATUS(dtlsCertificateFingerprint(pRemoteCertificate, actualFingerprint));
 
-    CHK(STRCMP(pExpectedFingerprint, actualFingerprint) == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
+    CHK(STRCMPI(pExpectedFingerprint, actualFingerprint) == 0, STATUS_SSL_REMOTE_CERTIFICATE_VERIFICATION_FAILED);
 
 CleanUp:
     if (pRemoteCertificate != NULL) {

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1806,8 +1806,14 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
 
     for (i = 0; i < pSessionDescription->sessionAttributesCount; i++) {
         if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "fingerprint") == 0) {
-            STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, pSessionDescription->sdpAttributes[i].attributeValue + 8,
-                    CERTIFICATE_FINGERPRINT_LENGTH);
+            PCHAR attrValue = pSessionDescription->sdpAttributes[i].attributeValue;
+            PCHAR space = STRCHR(attrValue, ' ');
+            if (space != NULL && (space - attrValue) == 7 && STRNCMP(attrValue, "sha-256", 7) == 0) {
+                STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, space + 1, CERTIFICATE_FINGERPRINT_LENGTH);
+            } else {
+                DLOGW("Skipping session-level fingerprint with unsupported hash algorithm: %.*s",
+                       space != NULL ? (INT32)(space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
+            }
         } else if (pKvsPeerConnection->isOffer && STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "setup") == 0) {
             // possible values are actpass, passive and active. If the incoming SDP has active, it indicates it is taking up a client role
             // In case of actpass and passive, the other peer is taking up a server role and is waiting for incoming connection
@@ -1837,8 +1843,14 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 // Ignore the return value, we have candidates we don't support yet like TURN
                 iceAgentAddRemoteCandidate(pKvsPeerConnection->pIceAgent, pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue);
             } else if (STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "fingerprint") == 0) {
-                STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint,
-                        pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue + 8, CERTIFICATE_FINGERPRINT_LENGTH);
+                PCHAR attrValue = pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue;
+                PCHAR space = STRCHR(attrValue, ' ');
+                if (space != NULL && (space - attrValue) == 7 && STRNCMP(attrValue, "sha-256", 7) == 0) {
+                    STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, space + 1, CERTIFICATE_FINGERPRINT_LENGTH);
+                } else {
+                    DLOGW("Skipping media-level fingerprint with unsupported hash algorithm: %.*s",
+                           space != NULL ? (INT32)(space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
+                }
             } else if (pKvsPeerConnection->isOffer &&
                        STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "setup") == 0) {
                 pKvsPeerConnection->dtlsIsServer = STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeValue, "active") == 0;
@@ -1855,6 +1867,9 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     }
 
     CHK(remoteIceUfrag != NULL && remoteIcePwd != NULL, STATUS_SESSION_DESCRIPTION_MISSING_ICE_VALUES);
+    if (pKvsPeerConnection->remoteCertificateFingerprint[0] == '\0') {
+        DLOGE("No sha-256 fingerprint found in remote SDP. Only sha-256 is supported.");
+    }
     CHK(pKvsPeerConnection->remoteCertificateFingerprint[0] != '\0', STATUS_SESSION_DESCRIPTION_MISSING_CERTIFICATE_FINGERPRINT);
 
     if (!IS_EMPTY_STRING(pKvsPeerConnection->remoteIceUfrag) && !IS_EMPTY_STRING(pKvsPeerConnection->remoteIcePwd) &&

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1812,7 +1812,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                 STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, space + 1, CERTIFICATE_FINGERPRINT_LENGTH);
             } else {
                 DLOGW("Skipping session-level fingerprint with unsupported hash algorithm: %.*s",
-                       space != NULL ? (INT32)(space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
+                      space != NULL ? (INT32) (space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
             }
         } else if (pKvsPeerConnection->isOffer && STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "setup") == 0) {
             // possible values are actpass, passive and active. If the incoming SDP has active, it indicates it is taking up a client role
@@ -1849,7 +1849,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
                     STRNCPY(pKvsPeerConnection->remoteCertificateFingerprint, space + 1, CERTIFICATE_FINGERPRINT_LENGTH);
                 } else {
                     DLOGW("Skipping media-level fingerprint with unsupported hash algorithm: %.*s",
-                           space != NULL ? (INT32)(space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
+                          space != NULL ? (INT32) (space - attrValue) : (INT32) STRLEN(attrValue), attrValue);
                 }
             } else if (pKvsPeerConnection->isOffer &&
                        STRCMP(pSessionDescription->mediaDescriptions[i].sdpAttributes[j].attributeName, "setup") == 0) {


### PR DESCRIPTION
*What was changed?*
Fixed DTLS certificate fingerprint comparison to use case-insensitive matching (STRCMPI) and improved SDP fingerprint attribute parsing to use space-delimiter detection instead of hardcoded offset.

*Why was it changed?*
The DTLS fingerprint comparison used case-sensitive STRCMP, which fails when the remote peer sends hex digits in different casing (e.g. "A3:B2" vs "a3:b2"). The SDP fingerprint parser used a hardcoded +8 offset to skip "sha-256 ", which is fragile and doesn't validate the hash algorithm prefix.

*How was it changed?*
- Changed STRCMP to STRCMPI in dtlsSessionVerifyRemoteCertificateFingerprint for case-insensitive hex comparison
- In setRemoteDescription, parse fingerprint by finding the space delimiter and validating "sha-256" prefix explicitly (both session-level and media-level attributes)
- Added clear error logging when no sha-256 fingerprint is found in the remote SDP

*What testing was done for the changes?*
- Verified the changes compile correctly
- Reviewed against RFC 4572 fingerprint format requirements
- Tested with SDP containing both uppercase and lowercase fingerprint hex values

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.