### PR TITLE
Fix SCTP COOKIE-ECHO to send exact cookie length

### DIFF
--- a/src/source/Sctp/SctpAssoc.c
+++ b/src/source/Sctp/SctpAssoc.c
@@ -191,6 +191,7 @@ static STATUS sctpHandleInitAck(PSctpAssociation pAssoc, PBYTE pValue, UINT32 va
             UINT32 cookieDataLen = paramLen - 4;
             if (cookieDataLen <= SCTP_COOKIE_SIZE && paramOffset + paramLen <= valueLen) {
                 MEMCPY(pAssoc->cookieEchoData, pValue + paramOffset + 4, cookieDataLen);
+                pAssoc->cookieEchoLen = cookieDataLen;
                 pAssoc->cookieEchoValid = TRUE;
                 cookieFound = TRUE;
             }
@@ -207,7 +208,7 @@ static STATUS sctpHandleInitAck(PSctpAssociation pAssoc, PBYTE pValue, UINT32 va
 
     // Send COOKIE-ECHO
     offset = sctpWriteCommonHeader(pAssoc->outPacket, pAssoc->localPort, pAssoc->remotePort, pAssoc->peerVerificationTag);
-    offset += sctpWriteCookieEchoChunk(pAssoc->outPacket + offset, pAssoc->cookieEchoData, SCTP_COOKIE_SIZE);
+    offset += sctpWriteCookieEchoChunk(pAssoc->outPacket + offset, pAssoc->cookieEchoData, pAssoc->cookieEchoLen);
 
     sctpSendPacket(pAssoc, offset, outboundFn, outboundCustomData);
 
@@ -1022,7 +1023,7 @@ STATUS sctpAssocCheckTimers(PSctpAssociation pAssoc, UINT64 nowMs, SctpAssocOutb
         } else if (pAssoc->state == SCTP_ASSOC_COOKIE_ECHOED && pAssoc->cookieEchoValid) {
             // Retransmit COOKIE-ECHO
             offset = sctpWriteCommonHeader(pAssoc->outPacket, pAssoc->localPort, pAssoc->remotePort, pAssoc->peerVerificationTag);
-            offset += sctpWriteCookieEchoChunk(pAssoc->outPacket + offset, pAssoc->cookieEchoData, SCTP_COOKIE_SIZE);
+            offset += sctpWriteCookieEchoChunk(pAssoc->outPacket + offset, pAssoc->cookieEchoData, pAssoc->cookieEchoLen);
             sctpSendPacket(pAssoc, offset, outboundFn, outboundCustomData);
             DLOGD("SCTP: Retransmitting COOKIE-ECHO (%u)", pAssoc->initRetransmitCount);
         }

--- a/src/source/Sctp/SctpInt.h
+++ b/src/source/Sctp/SctpInt.h
@@ -209,6 +209,7 @@ typedef struct {
     // Cookie state (for handshake)
     SctpCookie cookie;
     BYTE cookieEchoData[SCTP_COOKIE_SIZE]; // raw cookie bytes for retransmit
+    UINT32 cookieEchoLen;                  // actual cookie length from INIT-ACK
     BOOL cookieEchoValid;
 
     // Tie tag for simultaneous open


### PR DESCRIPTION
*What was changed?*
Track the actual cookie length received in INIT-ACK and use it when sending COOKIE-ECHO, instead of always sending SCTP_COOKIE_SIZE bytes.

*Why was it changed?*
The previous code always sent SCTP_COOKIE_SIZE (256) bytes in COOKIE-ECHO regardless of the actual cookie size from the INIT-ACK. This zero-pads the cookie data, violating RFC 4960 §5.1 which requires the COOKIE-ECHO to contain the exact cookie bytes. Servers that validate cookie length reject the handshake.

*How was it changed?*
- Added cookieEchoLen field to SctpAssociation struct to track actual cookie length
- Set cookieEchoLen when parsing the State Cookie parameter from INIT-ACK
- Use cookieEchoLen instead of SCTP_COOKIE_SIZE in both initial COOKIE-ECHO send and retransmit paths

*What testing was done for the changes?*
- Verified the changes compile correctly
- Reviewed against RFC 4960 §5.1 COOKIE-ECHO requirements
- Confirmed both send and retransmit paths use the correct length

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.