### PR TITLE
Enable TWCC in offer SDP and fix spurious Sender Reports

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -878,6 +878,7 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
 
     // check if ice agent is connected, reschedule in 200msec if not
     ready = pKvsPeerConnection->pSrtpSession != NULL &&
+        pKvsRtpTransceiver->sender.firstFrameWallClockTime != 0 &&
         currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime >= 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     if (!ready) {
         DLOGV("sender report no frames sent %u", ssrc);
@@ -1267,6 +1268,10 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
         CHK(pKvsPeerConnection->pTwccManager != NULL, STATUS_NOT_ENOUGH_MEMORY);
         CHK_STATUS(hashTableCreateWithParams(TWCC_HASH_TABLE_BUCKET_COUNT, TWCC_HASH_TABLE_BUCKET_LENGTH,
                                              &pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable));
+        // Set default TWCC extension ID so the offer SDP includes the extmap.
+        // If the remote peer offers a different ID, it will be overwritten
+        // during setRemoteDescription.
+        pKvsPeerConnection->twccExtId = TWCC_DEFAULT_EXT_ID;
     }
 
     // TWCC feedback generation (receiver side)

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -877,8 +877,7 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
     DLOGS("rtcpReportsCallback %" PRIu64 " ssrc: %u rtxssrc: %u", currentTime, ssrc, pKvsRtpTransceiver->sender.rtxSsrc);
 
     // check if ice agent is connected, reschedule in 200msec if not
-    ready = pKvsPeerConnection->pSrtpSession != NULL &&
-        pKvsRtpTransceiver->sender.firstFrameWallClockTime != 0 &&
+    ready = pKvsPeerConnection->pSrtpSession != NULL && pKvsRtpTransceiver->sender.firstFrameWallClockTime != 0 &&
         currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime >= 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
     if (!ready) {
         DLOGV("sender report no frames sent %u", ssrc);

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -33,6 +33,7 @@ extern "C" {
 #define RTX_HASH_TABLE_BUCKET_LENGTH   2
 #define TWCC_HASH_TABLE_BUCKET_COUNT   100
 #define TWCC_HASH_TABLE_BUCKET_LENGTH  2
+#define TWCC_DEFAULT_EXT_ID            5 // Default RTP header extension ID for transport-wide-cc
 
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_COUNT  200
 #define DATA_CHANNEL_HASH_TABLE_BUCKET_LENGTH 2

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -851,7 +851,8 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     EXPECT_EQ(246790, stats.sent.bytesSent);
 #endif
     EXPECT_EQ(2, stats.framesSent);
-    EXPECT_EQ(2472, stats.headerBytesSent);
+    // Each RTP packet header: 12 bytes base + 8 bytes TWCC extension = 20 bytes
+    EXPECT_EQ(4120, stats.headerBytesSent);
     EXPECT_LT(0, stats.lastPacketSentTimestamp);
 
     RtcInboundRtpStreamStats answerStats{};


### PR DESCRIPTION
*What was changed?*
- Set default TWCC RTP header extension ID (5) during peer connection creation when sender-side bandwidth estimation is enabled.
- Added a guard to skip RTCP Sender Reports for transceivers that have never sent any media frames.
- Updated `headerBytesSent` test expectation to account for TWCC extension headers.

*Why was it changed?*
- `twccExtId` was 0 at offer creation time, so the offer SDP never included the `extmap` for `transport-wide-cc`. TWCC was only negotiated if the remote peer (e.g., a browser) offered it first. SDK-to-SDK sessions never got TWCC.
- Transceivers that never called `writeFrame` had `firstFrameWallClockTime == 0`, which made the `currentTime - 0` guard always pass, causing bogus Sender Reports with garbage RTP timestamps.

*How was it changed?*
- In `createPeerConnection`, set `pKvsPeerConnection->twccExtId = TWCC_DEFAULT_EXT_ID` (5) inside the BWE-enabled block. This value is overwritten by `setRemoteDescription` if the remote peer offers a different ID.
- In `rtcpReportsCallback`, added `pKvsRtpTransceiver->sender.firstFrameWallClockTime != 0` to the SR readiness check.
- Updated the `exchangeMedia` test to expect 4120 header bytes (20 bytes/packet with TWCC extension) instead of 2472 (12 bytes/packet without).

*What testing was done for the changes?*
All 649 tests pass with `--gtest_break_on_failure` on macOS ARM64 (MbedTLS static build). Verified via pcap dump that TWCC feedback packets are now exchanged in loopback tests, and that spurious Sender Reports from non-sending transceivers are eliminated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.