### PR TITLE
Add PCAP dump for unencrypted RTP/RTCP/SCTP packets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -472,7 +472,8 @@ file(
   "src/source/Sdp/*.c"
   "src/source/Srtp/*.c"
   "src/source/Stun/*.c"
-  "src/source/Metrics/*.c")
+  "src/source/Metrics/*.c"
+  "src/source/PcapDump/*.c")
 
 if (USE_OPENSSL)
   list(FILTER WEBRTC_CLIENT_SOURCE_FILES EXCLUDE REGEX ".*_mbedtls\\.c")

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1297,6 +1297,11 @@ typedef struct {
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined
                          //!< to use this member, else stats are enabled by default.
 #endif
+
+    CHAR pcapFilePath[1024]; //!< Path to a PCAP dump file. When set (non-empty), all unencrypted RTP/RTCP packets
+                             //!< (both sent and received) are written to this file in standard pcap format with
+                             //!< fake Ethernet/IPv4/UDP headers so the file opens directly in Wireshark.
+                             //!< Leave empty (default) to disable.
 } KvsRtcConfiguration, *PKvsRtcConfiguration;
 
 /**

--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -174,6 +174,7 @@ STATUS generateJSONSafeString(PCHAR, UINT32);
 #include "Rtcp/RtcpPacket.h"
 #include "Rtcp/RollingBuffer.h"
 #include "Rtcp/RtpRollingBuffer.h"
+#include "PcapDump/PcapDump.h"
 #include "PeerConnection/JitterBuffer.h"
 #include "PeerConnection/Pacer.h"
 #include "PeerConnection/PeerConnection.h"

--- a/src/source/PcapDump/PcapDump.c
+++ b/src/source/PcapDump/PcapDump.c
@@ -144,19 +144,88 @@ static VOID buildEthIpUdpHeader(BYTE* pHeader, UINT32 payloadLen, UINT16 srcPort
     udp[7] = 0x00;
 }
 
-STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, BOOL isRtcp, PCAP_PACKET_DIRECTION direction)
+static VOID buildEthIpHeader(BYTE* pHeader, UINT32 payloadLen, UINT8 protocol, UINT32 srcIp, UINT32 dstIp)
+{
+    UINT16 ipTotalLen = (UINT16) (PCAP_IPV4_HEADER_SIZE + payloadLen);
+    UINT16 cksum;
+    BYTE* ip;
+
+    // Ethernet header (14 bytes)
+    MEMCPY(pHeader, PCAP_DST_MAC, 6);
+    MEMCPY(pHeader + 6, PCAP_SRC_MAC, 6);
+    pHeader[12] = 0x08;
+    pHeader[13] = 0x00;
+
+    // IPv4 header (20 bytes)
+    ip = pHeader + PCAP_ETHERNET_HEADER_SIZE;
+    ip[0] = 0x45;
+    ip[1] = 0x00;
+    ip[2] = (BYTE) (ipTotalLen >> 8);
+    ip[3] = (BYTE) (ipTotalLen & 0xFF);
+    ip[4] = 0x00;
+    ip[5] = 0x00;
+    ip[6] = 0x40;
+    ip[7] = 0x00;
+    ip[8] = 0x40;
+    ip[9] = protocol;
+    ip[10] = 0x00;
+    ip[11] = 0x00;
+    MEMCPY(ip + 12, &srcIp, 4);
+    MEMCPY(ip + 16, &dstIp, 4);
+    cksum = ipChecksum(ip, PCAP_IPV4_HEADER_SIZE);
+    ip[10] = (BYTE) (cksum >> 8);
+    ip[11] = (BYTE) (cksum & 0xFF);
+}
+
+static STATUS pcapDumpWriteRaw(PPcapDumpContext pCtx, BYTE* pTransportHeader, UINT32 transportHeaderLen, PBYTE pBuffer, UINT32 bufferLen)
 {
     STATUS retStatus = STATUS_SUCCESS;
     BYTE recordHeader[16];
-    BYTE transportHeader[PCAP_TRANSPORT_OVERHEAD];
     UINT64 now, sec, usec;
     UINT32 totalLen;
+
+    totalLen = transportHeaderLen + bufferLen;
+
+    now = GETTIME();
+    sec = now / (10 * 1000 * 1000);
+    usec = (now / 10) % 1000000;
+
+    recordHeader[0] = (BYTE) (sec & 0xFF);
+    recordHeader[1] = (BYTE) ((sec >> 8) & 0xFF);
+    recordHeader[2] = (BYTE) ((sec >> 16) & 0xFF);
+    recordHeader[3] = (BYTE) ((sec >> 24) & 0xFF);
+    recordHeader[4] = (BYTE) (usec & 0xFF);
+    recordHeader[5] = (BYTE) ((usec >> 8) & 0xFF);
+    recordHeader[6] = (BYTE) ((usec >> 16) & 0xFF);
+    recordHeader[7] = (BYTE) ((usec >> 24) & 0xFF);
+    recordHeader[8] = (BYTE) (totalLen & 0xFF);
+    recordHeader[9] = (BYTE) ((totalLen >> 8) & 0xFF);
+    recordHeader[10] = (BYTE) ((totalLen >> 16) & 0xFF);
+    recordHeader[11] = (BYTE) ((totalLen >> 24) & 0xFF);
+    recordHeader[12] = recordHeader[8];
+    recordHeader[13] = recordHeader[9];
+    recordHeader[14] = recordHeader[10];
+    recordHeader[15] = recordHeader[11];
+
+    MUTEX_LOCK(pCtx->lock);
+    if (fwrite(recordHeader, 1, SIZEOF(recordHeader), pCtx->pFile) != SIZEOF(recordHeader) ||
+        fwrite(pTransportHeader, 1, transportHeaderLen, pCtx->pFile) != transportHeaderLen ||
+        fwrite(pBuffer, 1, bufferLen, pCtx->pFile) != bufferLen) {
+        retStatus = STATUS_WRITE_TO_FILE_FAILED;
+    }
+    MUTEX_UNLOCK(pCtx->lock);
+
+    return retStatus;
+}
+
+STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, BOOL isRtcp, PCAP_PACKET_DIRECTION direction)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BYTE transportHeader[PCAP_TRANSPORT_OVERHEAD];
     UINT16 srcPort, dstPort;
     UINT32 srcIp, dstIp;
 
     CHK(pCtx != NULL && pCtx->initialized && pBuffer != NULL && bufferLen > 0, STATUS_NULL_ARG);
-
-    totalLen = PCAP_TRANSPORT_OVERHEAD + bufferLen;
 
     srcPort = isRtcp ? PCAP_FAKE_RTCP_PORT : PCAP_FAKE_RTP_PORT;
     dstPort = srcPort;
@@ -170,37 +239,30 @@ STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLe
     }
 
     buildEthIpUdpHeader(transportHeader, bufferLen, srcPort, dstPort, srcIp, dstIp);
+    retStatus = pcapDumpWriteRaw(pCtx, transportHeader, SIZEOF(transportHeader), pBuffer, bufferLen);
 
-    now = GETTIME(); // 100ns units
-    sec = now / (10 * 1000 * 1000);
-    usec = (now / 10) % 1000000;
+CleanUp:
+    return retStatus;
+}
 
-    // PCAP packet record header (little-endian)
-    recordHeader[0] = (BYTE) (sec & 0xFF);
-    recordHeader[1] = (BYTE) ((sec >> 8) & 0xFF);
-    recordHeader[2] = (BYTE) ((sec >> 16) & 0xFF);
-    recordHeader[3] = (BYTE) ((sec >> 24) & 0xFF);
-    recordHeader[4] = (BYTE) (usec & 0xFF);
-    recordHeader[5] = (BYTE) ((usec >> 8) & 0xFF);
-    recordHeader[6] = (BYTE) ((usec >> 16) & 0xFF);
-    recordHeader[7] = (BYTE) ((usec >> 24) & 0xFF);
-    // incl_len = orig_len = totalLen
-    recordHeader[8] = (BYTE) (totalLen & 0xFF);
-    recordHeader[9] = (BYTE) ((totalLen >> 8) & 0xFF);
-    recordHeader[10] = (BYTE) ((totalLen >> 16) & 0xFF);
-    recordHeader[11] = (BYTE) ((totalLen >> 24) & 0xFF);
-    recordHeader[12] = recordHeader[8];
-    recordHeader[13] = recordHeader[9];
-    recordHeader[14] = recordHeader[10];
-    recordHeader[15] = recordHeader[11];
+STATUS pcapDumpWriteSctpPacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, PCAP_PACKET_DIRECTION direction)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BYTE transportHeader[PCAP_IP_TRANSPORT_OVERHEAD];
+    UINT32 srcIp, dstIp;
 
-    MUTEX_LOCK(pCtx->lock);
-    if (fwrite(recordHeader, 1, SIZEOF(recordHeader), pCtx->pFile) != SIZEOF(recordHeader) ||
-        fwrite(transportHeader, 1, SIZEOF(transportHeader), pCtx->pFile) != SIZEOF(transportHeader) ||
-        fwrite(pBuffer, 1, bufferLen, pCtx->pFile) != bufferLen) {
-        retStatus = STATUS_WRITE_TO_FILE_FAILED;
+    CHK(pCtx != NULL && pCtx->initialized && pBuffer != NULL && bufferLen > 0, STATUS_NULL_ARG);
+
+    if (direction == PCAP_PACKET_DIRECTION_SEND) {
+        srcIp = PCAP_IP_LOCAL;
+        dstIp = PCAP_IP_REMOTE;
+    } else {
+        srcIp = PCAP_IP_REMOTE;
+        dstIp = PCAP_IP_LOCAL;
     }
-    MUTEX_UNLOCK(pCtx->lock);
+
+    buildEthIpHeader(transportHeader, bufferLen, 132, srcIp, dstIp); // IP protocol 132 = SCTP
+    retStatus = pcapDumpWriteRaw(pCtx, transportHeader, SIZEOF(transportHeader), pBuffer, bufferLen);
 
 CleanUp:
     return retStatus;

--- a/src/source/PcapDump/PcapDump.c
+++ b/src/source/PcapDump/PcapDump.c
@@ -1,0 +1,231 @@
+/**
+ * PCAP file dump for unencrypted RTP/RTCP packets.
+ *
+ * Each packet is wrapped in a fake Ethernet/IPv4/UDP frame so that
+ * Wireshark recognises the file immediately and applies the correct
+ * RTP/RTCP dissectors based on the UDP port numbers.
+ *
+ * Send packets use 10.0.0.1 -> 10.0.0.2, receive packets use
+ * 10.0.0.2 -> 10.0.0.1, making it easy to set display filters.
+ */
+#define LOG_CLASS "PcapDump"
+#include "../Include_i.h"
+
+// Fake MAC addresses (locally-administered)
+static const BYTE PCAP_SRC_MAC[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x01};
+static const BYTE PCAP_DST_MAC[6] = {0x02, 0x00, 0x00, 0x00, 0x00, 0x02};
+
+// Fake IPs in network byte order: 10.0.0.1 and 10.0.0.2
+#define PCAP_IP_LOCAL  0x0100000AU
+#define PCAP_IP_REMOTE 0x0200000AU
+
+static UINT16 ipChecksum(const BYTE* pData, UINT32 len)
+{
+    UINT32 sum = 0;
+    UINT32 i;
+    for (i = 0; i + 1 < len; i += 2) {
+        sum += (UINT32) pData[i] << 8 | pData[i + 1];
+    }
+    if (i < len) {
+        sum += (UINT32) pData[i] << 8;
+    }
+    while (sum >> 16) {
+        sum = (sum & 0xFFFF) + (sum >> 16);
+    }
+    return (UINT16) ~sum;
+}
+
+STATUS pcapDumpCreate(PCHAR filePath, PPcapDumpContext* ppCtx)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PPcapDumpContext pCtx = NULL;
+    BYTE globalHeader[24];
+
+    CHK(filePath != NULL && ppCtx != NULL, STATUS_NULL_ARG);
+
+    pCtx = (PPcapDumpContext) MEMCALLOC(1, SIZEOF(PcapDumpContext));
+    CHK(pCtx != NULL, STATUS_NOT_ENOUGH_MEMORY);
+
+    pCtx->lock = MUTEX_CREATE(TRUE);
+
+    pCtx->pFile = fopen(filePath, "wb");
+    CHK(pCtx->pFile != NULL, STATUS_OPEN_FILE_FAILED);
+
+    // PCAP global header (24 bytes, little-endian)
+    // magic_number = 0xA1B2C3D4
+    globalHeader[0] = 0xD4;
+    globalHeader[1] = 0xC3;
+    globalHeader[2] = 0xB2;
+    globalHeader[3] = 0xA1;
+    // version_major = 2
+    globalHeader[4] = 0x02;
+    globalHeader[5] = 0x00;
+    // version_minor = 4
+    globalHeader[6] = 0x04;
+    globalHeader[7] = 0x00;
+    // thiszone = 0
+    MEMSET(globalHeader + 8, 0, 4);
+    // sigfigs = 0
+    MEMSET(globalHeader + 12, 0, 4);
+    // snaplen = 65535
+    globalHeader[16] = 0xFF;
+    globalHeader[17] = 0xFF;
+    globalHeader[18] = 0x00;
+    globalHeader[19] = 0x00;
+    // network = 1 (LINKTYPE_ETHERNET)
+    globalHeader[20] = 0x01;
+    globalHeader[21] = 0x00;
+    globalHeader[22] = 0x00;
+    globalHeader[23] = 0x00;
+
+    CHK(fwrite(globalHeader, 1, SIZEOF(globalHeader), pCtx->pFile) == SIZEOF(globalHeader), STATUS_WRITE_TO_FILE_FAILED);
+    fflush(pCtx->pFile);
+
+    pCtx->initialized = TRUE;
+    *ppCtx = pCtx;
+    pCtx = NULL;
+
+CleanUp:
+    if (pCtx != NULL) {
+        if (pCtx->pFile != NULL) {
+            fclose(pCtx->pFile);
+        }
+        if (IS_VALID_MUTEX_VALUE(pCtx->lock)) {
+            MUTEX_FREE(pCtx->lock);
+        }
+        MEMFREE(pCtx);
+    }
+    return retStatus;
+}
+
+static VOID buildEthIpUdpHeader(BYTE* pHeader, UINT32 payloadLen, UINT16 srcPort, UINT16 dstPort, UINT32 srcIp, UINT32 dstIp)
+{
+    UINT16 ipTotalLen = (UINT16) (PCAP_IPV4_HEADER_SIZE + PCAP_UDP_HEADER_SIZE + payloadLen);
+    UINT16 udpLen = (UINT16) (PCAP_UDP_HEADER_SIZE + payloadLen);
+    UINT16 cksum;
+    BYTE* ip;
+    BYTE* udp;
+
+    // Ethernet header (14 bytes)
+    MEMCPY(pHeader, PCAP_DST_MAC, 6);
+    MEMCPY(pHeader + 6, PCAP_SRC_MAC, 6);
+    pHeader[12] = 0x08; // EtherType = 0x0800 (IPv4)
+    pHeader[13] = 0x00;
+
+    // IPv4 header (20 bytes)
+    ip = pHeader + PCAP_ETHERNET_HEADER_SIZE;
+    ip[0] = 0x45;                         // Version=4, IHL=5
+    ip[1] = 0x00;                         // DSCP/ECN
+    ip[2] = (BYTE) (ipTotalLen >> 8);     // Total length (big-endian)
+    ip[3] = (BYTE) (ipTotalLen & 0xFF);
+    ip[4] = 0x00;                         // Identification
+    ip[5] = 0x00;
+    ip[6] = 0x40;                         // Flags: Don't Fragment
+    ip[7] = 0x00;
+    ip[8] = 0x40;                         // TTL = 64
+    ip[9] = 0x11;                         // Protocol = UDP
+    ip[10] = 0x00;                        // Checksum placeholder
+    ip[11] = 0x00;
+    MEMCPY(ip + 12, &srcIp, 4);
+    MEMCPY(ip + 16, &dstIp, 4);
+    cksum = ipChecksum(ip, PCAP_IPV4_HEADER_SIZE);
+    ip[10] = (BYTE) (cksum >> 8);
+    ip[11] = (BYTE) (cksum & 0xFF);
+
+    // UDP header (8 bytes)
+    udp = ip + PCAP_IPV4_HEADER_SIZE;
+    udp[0] = (BYTE) (srcPort >> 8);
+    udp[1] = (BYTE) (srcPort & 0xFF);
+    udp[2] = (BYTE) (dstPort >> 8);
+    udp[3] = (BYTE) (dstPort & 0xFF);
+    udp[4] = (BYTE) (udpLen >> 8);
+    udp[5] = (BYTE) (udpLen & 0xFF);
+    udp[6] = 0x00; // Checksum = 0 (optional in IPv4)
+    udp[7] = 0x00;
+}
+
+STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, BOOL isRtcp, PCAP_PACKET_DIRECTION direction)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    BYTE recordHeader[16];
+    BYTE transportHeader[PCAP_TRANSPORT_OVERHEAD];
+    UINT64 now, sec, usec;
+    UINT32 totalLen;
+    UINT16 srcPort, dstPort;
+    UINT32 srcIp, dstIp;
+
+    CHK(pCtx != NULL && pCtx->initialized && pBuffer != NULL && bufferLen > 0, STATUS_NULL_ARG);
+
+    totalLen = PCAP_TRANSPORT_OVERHEAD + bufferLen;
+
+    srcPort = isRtcp ? PCAP_FAKE_RTCP_PORT : PCAP_FAKE_RTP_PORT;
+    dstPort = srcPort;
+
+    if (direction == PCAP_PACKET_DIRECTION_SEND) {
+        srcIp = PCAP_IP_LOCAL;
+        dstIp = PCAP_IP_REMOTE;
+    } else {
+        srcIp = PCAP_IP_REMOTE;
+        dstIp = PCAP_IP_LOCAL;
+    }
+
+    buildEthIpUdpHeader(transportHeader, bufferLen, srcPort, dstPort, srcIp, dstIp);
+
+    now = GETTIME(); // 100ns units
+    sec = now / (10 * 1000 * 1000);
+    usec = (now / 10) % 1000000;
+
+    // PCAP packet record header (little-endian)
+    recordHeader[0] = (BYTE) (sec & 0xFF);
+    recordHeader[1] = (BYTE) ((sec >> 8) & 0xFF);
+    recordHeader[2] = (BYTE) ((sec >> 16) & 0xFF);
+    recordHeader[3] = (BYTE) ((sec >> 24) & 0xFF);
+    recordHeader[4] = (BYTE) (usec & 0xFF);
+    recordHeader[5] = (BYTE) ((usec >> 8) & 0xFF);
+    recordHeader[6] = (BYTE) ((usec >> 16) & 0xFF);
+    recordHeader[7] = (BYTE) ((usec >> 24) & 0xFF);
+    // incl_len = orig_len = totalLen
+    recordHeader[8] = (BYTE) (totalLen & 0xFF);
+    recordHeader[9] = (BYTE) ((totalLen >> 8) & 0xFF);
+    recordHeader[10] = (BYTE) ((totalLen >> 16) & 0xFF);
+    recordHeader[11] = (BYTE) ((totalLen >> 24) & 0xFF);
+    recordHeader[12] = recordHeader[8];
+    recordHeader[13] = recordHeader[9];
+    recordHeader[14] = recordHeader[10];
+    recordHeader[15] = recordHeader[11];
+
+    MUTEX_LOCK(pCtx->lock);
+    if (fwrite(recordHeader, 1, SIZEOF(recordHeader), pCtx->pFile) != SIZEOF(recordHeader) ||
+        fwrite(transportHeader, 1, SIZEOF(transportHeader), pCtx->pFile) != SIZEOF(transportHeader) ||
+        fwrite(pBuffer, 1, bufferLen, pCtx->pFile) != bufferLen) {
+        retStatus = STATUS_WRITE_TO_FILE_FAILED;
+    }
+    MUTEX_UNLOCK(pCtx->lock);
+
+CleanUp:
+    return retStatus;
+}
+
+STATUS pcapDumpFree(PPcapDumpContext* ppCtx)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PPcapDumpContext pCtx;
+
+    CHK(ppCtx != NULL, STATUS_NULL_ARG);
+    pCtx = *ppCtx;
+    CHK(pCtx != NULL, retStatus);
+
+    if (pCtx->pFile != NULL) {
+        fflush(pCtx->pFile);
+        fclose(pCtx->pFile);
+        pCtx->pFile = NULL;
+    }
+    if (IS_VALID_MUTEX_VALUE(pCtx->lock)) {
+        MUTEX_FREE(pCtx->lock);
+    }
+    MEMFREE(pCtx);
+    *ppCtx = NULL;
+
+CleanUp:
+    return retStatus;
+}

--- a/src/source/PcapDump/PcapDump.c
+++ b/src/source/PcapDump/PcapDump.c
@@ -114,17 +114,17 @@ static VOID buildEthIpUdpHeader(BYTE* pHeader, UINT32 payloadLen, UINT16 srcPort
 
     // IPv4 header (20 bytes)
     ip = pHeader + PCAP_ETHERNET_HEADER_SIZE;
-    ip[0] = 0x45;                         // Version=4, IHL=5
-    ip[1] = 0x00;                         // DSCP/ECN
-    ip[2] = (BYTE) (ipTotalLen >> 8);     // Total length (big-endian)
+    ip[0] = 0x45;                     // Version=4, IHL=5
+    ip[1] = 0x00;                     // DSCP/ECN
+    ip[2] = (BYTE) (ipTotalLen >> 8); // Total length (big-endian)
     ip[3] = (BYTE) (ipTotalLen & 0xFF);
-    ip[4] = 0x00;                         // Identification
+    ip[4] = 0x00; // Identification
     ip[5] = 0x00;
-    ip[6] = 0x40;                         // Flags: Don't Fragment
+    ip[6] = 0x40; // Flags: Don't Fragment
     ip[7] = 0x00;
-    ip[8] = 0x40;                         // TTL = 64
-    ip[9] = 0x11;                         // Protocol = UDP
-    ip[10] = 0x00;                        // Checksum placeholder
+    ip[8] = 0x40;  // TTL = 64
+    ip[9] = 0x11;  // Protocol = UDP
+    ip[10] = 0x00; // Checksum placeholder
     ip[11] = 0x00;
     MEMCPY(ip + 12, &srcIp, 4);
     MEMCPY(ip + 16, &dstIp, 4);

--- a/src/source/PcapDump/PcapDump.h
+++ b/src/source/PcapDump/PcapDump.h
@@ -1,0 +1,49 @@
+/*******************************************
+PCAP dump internal include file
+Captures unencrypted RTP/RTCP packets to
+standard pcap format for offline analysis.
+Wraps each packet in Ethernet/IPv4/UDP so
+Wireshark auto-detects RTP/RTCP dissectors.
+*******************************************/
+#ifndef __KINESIS_VIDEO_WEBRTC_CLIENT_PCAP_DUMP__
+#define __KINESIS_VIDEO_WEBRTC_CLIENT_PCAP_DUMP__
+
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// PCAP file format constants
+#define PCAP_LINKTYPE_ETHERNET 1
+#define PCAP_SNAPLEN           65535
+
+// Ethernet + IPv4 + UDP overhead
+#define PCAP_ETHERNET_HEADER_SIZE 14
+#define PCAP_IPV4_HEADER_SIZE     20
+#define PCAP_UDP_HEADER_SIZE      8
+#define PCAP_TRANSPORT_OVERHEAD   (PCAP_ETHERNET_HEADER_SIZE + PCAP_IPV4_HEADER_SIZE + PCAP_UDP_HEADER_SIZE)
+
+// Fake UDP ports — Wireshark applies RTP dissector on these
+#define PCAP_FAKE_RTP_PORT  5004
+#define PCAP_FAKE_RTCP_PORT 5005
+
+typedef enum {
+    PCAP_PACKET_DIRECTION_SEND = 0,
+    PCAP_PACKET_DIRECTION_RECV = 1,
+} PCAP_PACKET_DIRECTION;
+
+typedef struct __PcapDumpContext {
+    FILE* pFile;
+    MUTEX lock;
+    BOOL initialized;
+} PcapDumpContext, *PPcapDumpContext;
+
+STATUS pcapDumpCreate(PCHAR filePath, PPcapDumpContext* ppCtx);
+STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, BOOL isRtcp, PCAP_PACKET_DIRECTION direction);
+STATUS pcapDumpFree(PPcapDumpContext* ppCtx);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __KINESIS_VIDEO_WEBRTC_CLIENT_PCAP_DUMP__ */

--- a/src/source/PcapDump/PcapDump.h
+++ b/src/source/PcapDump/PcapDump.h
@@ -24,9 +24,12 @@ extern "C" {
 #define PCAP_UDP_HEADER_SIZE      8
 #define PCAP_TRANSPORT_OVERHEAD   (PCAP_ETHERNET_HEADER_SIZE + PCAP_IPV4_HEADER_SIZE + PCAP_UDP_HEADER_SIZE)
 
-// Fake UDP ports — Wireshark applies RTP dissector on these
+// Fake UDP ports — Wireshark applies RTP/RTCP dissectors on these
 #define PCAP_FAKE_RTP_PORT  5004
 #define PCAP_FAKE_RTCP_PORT 5005
+
+// Ethernet + IPv4 overhead (no UDP — used for SCTP with IP proto 132)
+#define PCAP_IP_TRANSPORT_OVERHEAD (PCAP_ETHERNET_HEADER_SIZE + PCAP_IPV4_HEADER_SIZE)
 
 typedef enum {
     PCAP_PACKET_DIRECTION_SEND = 0,
@@ -41,6 +44,7 @@ typedef struct __PcapDumpContext {
 
 STATUS pcapDumpCreate(PCHAR filePath, PPcapDumpContext* ppCtx);
 STATUS pcapDumpWritePacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, BOOL isRtcp, PCAP_PACKET_DIRECTION direction);
+STATUS pcapDumpWriteSctpPacket(PPcapDumpContext pCtx, PBYTE pBuffer, UINT32 bufferLen, PCAP_PACKET_DIRECTION direction);
 STATUS pcapDumpFree(PPcapDumpContext* ppCtx);
 
 #ifdef __cplusplus

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -244,6 +244,11 @@ VOID onInboundPacket(UINT64 customData, PBYTE buff, UINT32 buffLen)
                 CHK(FALSE, STATUS_SUCCESS);
             }
 
+            // PCAP: capture decrypted inbound RTCP
+            if (pKvsPeerConnection->pPcapDump != NULL) {
+                pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, buff, signedBuffLen, TRUE, PCAP_PACKET_DIRECTION_RECV);
+            }
+
             CHK_STATUS(onRtcpPacket(pKvsPeerConnection, buff, signedBuffLen));
         } else {
             CHK_STATUS(sendPacketToRtpReceiver(pKvsPeerConnection, buff, signedBuffLen));
@@ -337,6 +342,11 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
         DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
         packetsFailedDecryption++;
         CHK(FALSE, STATUS_SUCCESS);
+    }
+
+    // PCAP: capture decrypted inbound RTP
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pBuffer, bufferLen, FALSE, PCAP_PACKET_DIRECTION_RECV);
     }
 
     CHK(NULL != (pPayload = (PBYTE) MEMALLOC(bufferLen)), STATUS_NOT_ENOUGH_MEMORY);
@@ -907,6 +917,12 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         putUnalignedInt32BigEndian(rawPacket + 16, rtpTime);
         putUnalignedInt32BigEndian(rawPacket + 20, packetCount);
         putUnalignedInt32BigEndian(rawPacket + 24, octetCount);
+
+        // PCAP: capture unencrypted outbound RTCP (Sender Report)
+        if (pKvsPeerConnection->pPcapDump != NULL) {
+            pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rawPacket, packetLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
+        }
+
         CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
         CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen));
     }
@@ -978,6 +994,12 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
             PBYTE rrRawPacket = (PBYTE) MEMALLOC(rrAllocSize);
             CHK(rrRawPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
             MEMCPY(rrRawPacket, rrPacket, rrPacketLen);
+
+            // PCAP: capture unencrypted outbound RTCP (Receiver Report)
+            if (pKvsPeerConnection->pPcapDump != NULL) {
+                pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rrRawPacket, rrPacketLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
+            }
+
             retStatus = encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rrRawPacket, (PINT32) &rrPacketLen);
             if (STATUS_SUCCEEDED(retStatus)) {
                 retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rrRawPacket, rrPacketLen);
@@ -1281,6 +1303,12 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     pKvsPeerConnection->sctpTimerCallbackId = MAX_UINT32;
 #endif
 
+    // PCAP dump
+    if (pConfiguration->kvsRtcConfiguration.pcapFilePath[0] != '\0') {
+        CHK_STATUS(pcapDumpCreate(pConfiguration->kvsRtcConfiguration.pcapFilePath, &pKvsPeerConnection->pPcapDump));
+        DLOGI("PCAP dump enabled: %s", pConfiguration->kvsRtcConfiguration.pcapFilePath);
+    }
+
     *ppPeerConnection = (PRtcPeerConnection) pKvsPeerConnection;
 
 CleanUp:
@@ -1456,6 +1484,11 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccReceiverLock)) {
         MUTEX_FREE(pKvsPeerConnection->twccReceiverLock);
         pKvsPeerConnection->twccReceiverLock = INVALID_MUTEX_VALUE;
+    }
+
+    // Free PCAP dump
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpFree(&pKvsPeerConnection->pPcapDump);
     }
 
     PROFILE_WITH_START_TIME_OBJ(startTime, pKvsPeerConnection->peerConnectionDiagnostics.freePeerConnectionTime, "Free peer connection");

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -943,6 +943,8 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         UINT8 rrFraction;
         INT32 rrCumulativeLost;
         UINT32 rrPacketLen;
+        UINT32 rrLastSRNtpMid;
+        UINT64 rrLastSRReceivedTime;
         BYTE rrPacket[RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN]; // header + sender SSRC + 1 report block
 
         MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
@@ -972,6 +974,8 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         } else {
             rrCumulativeLost = (INT32) rrLost;
         }
+        rrLastSRNtpMid = pKvsRtpTransceiver->lastSRNtpMid;
+        rrLastSRReceivedTime = pKvsRtpTransceiver->lastSRReceivedTime;
         MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
 
         rrPacketLen = sizeof(rrPacket);
@@ -988,11 +992,11 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         rrPacket[15] = rrCumulativeLost & 0xFF;
         putUnalignedInt32BigEndian(rrPacket + 16, rrExtMax);                                             // extended highest sequence number
         putUnalignedInt32BigEndian(rrPacket + 20, (UINT32) (pKvsRtpTransceiver->pJitterBuffer->jitter)); // interarrival jitter
-        putUnalignedInt32BigEndian(rrPacket + 24, pKvsRtpTransceiver->lastSRNtpMid);                     // LSR
+        putUnalignedInt32BigEndian(rrPacket + 24, rrLastSRNtpMid);                                       // LSR
 
         // DLSR: delay since last SR in 1/65536 sec units
-        if (pKvsRtpTransceiver->lastSRReceivedTime != 0) {
-            UINT64 dlsrTime = currentTime - pKvsRtpTransceiver->lastSRReceivedTime;
+        if (rrLastSRReceivedTime != 0) {
+            UINT64 dlsrTime = currentTime - rrLastSRReceivedTime;
             UINT32 dlsr = (UINT32) KVS_CONVERT_TIMESCALE(dlsrTime, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
             putUnalignedInt32BigEndian(rrPacket + 28, dlsr);
         }

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -230,6 +230,10 @@ VOID onInboundPacket(UINT64 customData, PBYTE buff, UINT32 buffLen)
                 }
 
                 if (signedBuffLen > 0) {
+                    // PCAP: capture decrypted inbound SCTP
+                    if (pKvsPeerConnection->pPcapDump != NULL) {
+                        pcapDumpWriteSctpPacket(pKvsPeerConnection->pPcapDump, buff, signedBuffLen, PCAP_PACKET_DIRECTION_RECV);
+                    }
                     CHK_STATUS(putSctpPacket(pKvsPeerConnection->pSctpSession, buff, signedBuffLen));
                 }
             }
@@ -741,6 +745,12 @@ VOID onSctpSessionOutboundPacket(UINT64 customData, PBYTE pPacket, UINT32 packet
     }
 
     pKvsPeerConnection = (PKvsPeerConnection) customData;
+
+    // PCAP: capture plaintext outbound SCTP
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWriteSctpPacket(pKvsPeerConnection->pPcapDump, pPacket, packetLen, PCAP_PACKET_DIRECTION_SEND);
+    }
+
     CHK_STATUS(dtlsSessionPutApplicationData(pKvsPeerConnection->pDtlsSession, pPacket, packetLen));
 
 CleanUp:

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -181,6 +181,8 @@ typedef struct {
 
     UINT32 jitterBufferMaxLatency; //!< Max latency for jitter buffer, from KvsRtcConfiguration
     BOOL useRealTimeJitterBuffer;  //!< Use real-time jitter buffer, from KvsRtcConfiguration
+
+    PPcapDumpContext pPcapDump; //!< PCAP dump context, NULL when disabled
 } KvsPeerConnection, *PKvsPeerConnection;
 
 typedef struct {

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -66,16 +66,15 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
         UINT32 packetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 16);
         UINT32 octetCnt = getUnalignedInt32BigEndian(pRtcpPacket->payload + 20);
         DLOGV("RTCP_PACKET_TYPE_SENDER_REPORT %d %" PRIu64 " rtpTs: %u %u pkts %u bytes", senderSSRC, ntpTime, rtpTs, packetCnt, octetCnt);
-        // Store for LSR/DLSR in outgoing RR
-        pTransceiver->lastSRNtpMid = (UINT32) ((ntpTime >> 16U) & 0xffffffffULL);
-        pTransceiver->lastSRReceivedTime = GETTIME();
-
+        // Store for LSR/DLSR in outgoing RR (protected by statsLock)
         // Populate remote outbound stats
         UINT64 ntpSec = ntpTime >> 32U;
         UINT64 ntpFrac = ntpTime & 0xffffffffULL;
         UINT64 unixMs = (ntpSec - NTP_OFFSET) * 1000ULL + (ntpFrac * 1000ULL / NTP_TIMESCALE);
 
         MUTEX_LOCK(pTransceiver->statsLock);
+        pTransceiver->lastSRNtpMid = (UINT32) ((ntpTime >> 16U) & 0xffffffffULL);
+        pTransceiver->lastSRReceivedTime = GETTIME();
         pTransceiver->remoteOutboundStats.reportsSent++;
         pTransceiver->remoteOutboundStats.sent.packetsSent = packetCnt;
         pTransceiver->remoteOutboundStats.sent.bytesSent = octetCnt;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -684,6 +684,11 @@ static STATUS writeRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pPack
 
     MEMCPY(pRawPacket, pPacket, packetLen);
 
+    // PCAP: capture unencrypted outbound RTCP
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pRawPacket, packetLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
+    }
+
     CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, pRawPacket, (PINT32) &packetLen));
     CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pRawPacket, packetLen));
 
@@ -1225,6 +1230,11 @@ STATUS sendRtcpTwccFeedback(PKvsPeerConnection pKvsPeerConnection)
     pManager->lastSeqNum = 0;
 
     MUTEX_UNLOCK(pKvsPeerConnection->twccReceiverLock);
+
+    // PCAP: capture unencrypted outbound RTCP (TWCC feedback)
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pPacket, packetLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
+    }
 
     // Encrypt and send
     MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -420,6 +420,11 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
         }
 
+        // PCAP: capture unencrypted outbound RTP (main send path)
+        if (pKvsPeerConnection->pPcapDump != NULL) {
+            pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rawPacket, packetLen, FALSE, PCAP_PACKET_DIRECTION_SEND);
+        }
+
         CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
 
         // Check if pacing is enabled (only for video - audio bypasses pacer to avoid latency)
@@ -564,6 +569,12 @@ STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPack
     pRawPacket = MEMALLOC(pRtpPacket->rawPacketLength + SRTP_AUTH_TAG_OVERHEAD); // For SRTP authentication tag
     rawLen = pRtpPacket->rawPacketLength;
     MEMCPY(pRawPacket, pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength);
+
+    // PCAP: capture unencrypted outbound RTP
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pRawPacket, rawLen, FALSE, PCAP_PACKET_DIRECTION_SEND);
+    }
+
     CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, pRawPacket, &rawLen));
     CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pRawPacket, rawLen));
 

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -103,7 +103,7 @@ typedef struct {
     UINT32 rrReceivedPrior; // received at last RR interval
     BOOL rrSeqInitialized;  // whether first packet has been seen
 
-    // For LSR/DLSR in outgoing RR
+    // For LSR/DLSR in outgoing RR (protected by statsLock)
     UINT32 lastSRNtpMid;       // middle 32 bits of last received SR NTP timestamp
     UINT64 lastSRReceivedTime; // wallclock (100ns) when last SR was received
 

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2420,9 +2420,7 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
     PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
 
     initRtcConfiguration(&configuration);
-    STRCPY(configuration.kvsRtcConfiguration.pcapFilePath, "/tmp/webrtc-offer.pcap");
     ASSERT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &offerPc));
-    STRCPY(configuration.kvsRtcConfiguration.pcapFilePath, "/tmp/webrtc-answer.pcap");
     ASSERT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &answerPc));
 
     addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver,

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2420,7 +2420,9 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
     PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
 
     initRtcConfiguration(&configuration);
+    STRCPY(configuration.kvsRtcConfiguration.pcapFilePath, "/tmp/webrtc-offer.pcap");
     ASSERT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &offerPc));
+    STRCPY(configuration.kvsRtcConfiguration.pcapFilePath, "/tmp/webrtc-answer.pcap");
     ASSERT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &answerPc));
 
     addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver,
@@ -2621,11 +2623,24 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
     {
         RtcStats rtcMetrics{};
 
-        // Wait for at least one RTCP RR to arrive (first SR at 3s, RR follows ~200ms later)
+        // Wait for at least one RTCP RR to arrive.
         for (INT32 i = 0; i < 50; i++) {
             rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_INBOUND_RTP;
             ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(offerPc, offerVideoTransceiver, &rtcMetrics));
             if (rtcMetrics.rtcStatsObject.remoteInboundRtpStreamStats.reportsReceived > 0) {
+                break;
+            }
+            THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
+
+        // Wait for the offer's Sender Report to fire.
+        // SR needs RTCP_FIRST_REPORT_DELAY (3s) + 2.5s firstFrameWallClockTime guard.
+        // Poll until the offer receives an RR with non-zero LSR (meaning the answer
+        // received our SR), visible as roundTripTime > 0.
+        for (INT32 i = 0; i < 80; i++) {
+            rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_INBOUND_RTP;
+            ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(offerPc, offerVideoTransceiver, &rtcMetrics));
+            if (rtcMetrics.rtcStatsObject.remoteInboundRtpStreamStats.roundTripTime > 0) {
                 break;
             }
             THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);


### PR DESCRIPTION
## Summary
- Adds optional PCAP file capture for unencrypted RTP, RTCP, and SCTP packets (both sent and received)
- Packets are wrapped in fake Ethernet/IPv4/UDP headers so Wireshark auto-detects RTP/RTCP/SCTP dissectors
- Enabled by setting `pcapFilePath` in `KvsRtcConfiguration`; disabled by default (empty path)

*What was changed?*
Added a new PcapDump module (`src/source/PcapDump/`) that writes decrypted RTP, RTCP, and SCTP packets to standard pcap files. Instrumented the send and receive paths in PeerConnection, Rtp, and Rtcp to capture packets before encryption / after decryption. Added `pcapFilePath` field to `KvsRtcConfiguration` to enable the feature.

*Why was it changed?*
Debugging WebRTC media and data channel issues requires inspecting actual RTP/RTCP/SCTP packet contents. Currently only encrypted (SRTP/DTLS) traffic is visible on the wire. This feature captures the unencrypted packets in a Wireshark-compatible format for offline analysis.

*How was it changed?*
- New `PcapDump.c` / `PcapDump.h` implementing pcap file writing with fake Ethernet/IPv4/UDP (for RTP/RTCP) and Ethernet/IPv4 (for SCTP, IP protocol 132) framing.
- Hook points added in `onInboundPacket`, `sendPacketToRtpReceiver`, `writeFrame`, `writeRtpPacket`, `onSctpSessionOutboundPacket`, `rtcpReportsCallback`, `writeRtcpPacket`, and `sendRtcpTwccFeedback`.
- `KvsRtcConfiguration` extended with `pcapFilePath[1024]`.
- `KvsPeerConnection` extended with `pPcapDump` context pointer, created/freed in `createPeerConnection`/`freePeerConnection`.
- Updated `fullCycleVideoAudioDataChannel` test to enable pcap capture.

*What testing was done for the changes?*
Ran `fullCycleVideoAudioDataChannel` test which exercises video, audio, and data channel paths with pcap enabled. Verified the generated pcap files open correctly in Wireshark and show decoded RTP/RTCP/SCTP packets with correct timestamps and direction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.