### PR TITLE
RTCRemoteOutboundRtpStreamStats from RTCP Sender Reports

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -458,6 +458,21 @@ typedef struct {
 } RtcRemoteInboundRtpStreamStats, *PRtcRemoteInboundRtpStreamStats;
 
 /**
+ * @brief RTCRemoteOutboundRtpStreamStats Represents the remote endpoint's measurement metrics for a particular outgoing RTP stream
+ *
+ * Reference: https://www.w3.org/TR/webrtc-stats/#remoteoutboundrtpstats-dict*
+ */
+typedef struct {
+    RTCSentRtpStreamStats sent;          //!< Inherited from RTCSentRtpStreamStats (packetsSent, bytesSent, ssrc, kind)
+    DOMString localId;                   //!< Reference to local RTCInboundRtpStreamStats
+    DOMHighResTimeStamp remoteTimestamp; //!< NTP timestamp from SR converted to ms since Unix epoch
+    UINT64 reportsSent;                  //!< Count of SR blocks received for this SSRC
+    DOUBLE roundTripTime;                //!< Latest RTT in seconds
+    DOUBLE totalRoundTripTime;           //!< Cumulative RTT in seconds
+    UINT64 roundTripTimeMeasurements;    //!< Count of valid RTT measurements
+} RtcRemoteOutboundRtpStreamStats, *PRtcRemoteOutboundRtpStreamStats;
+
+/**
  * @brief The RTCInboundRtpStreamStats dictionary represents the measurement metrics for the incoming RTP media stream. The timestamp reported in the
  * statistics object is the time at which the data was sampled.
  *
@@ -659,14 +674,15 @@ typedef struct {
  * be populated internally
  */
 typedef struct {
-    RtcIceCandidatePairStats iceCandidatePairStats;             //!< ICE Candidate Pair  stats object
-    RtcIceCandidateStats localIceCandidateStats;                //!< local ICE Candidate stats object
-    RtcIceCandidateStats remoteIceCandidateStats;               //!< remote ICE Candidate stats object
-    RtcIceServerStats iceServerStats;                           //!< ICE Server Pair stats object
-    RtcTransportStats transportStats;                           //!< Transport stats object
-    RtcOutboundRtpStreamStats outboundRtpStreamStats;           //!< Outbound RTP Stream stats object
-    RtcRemoteInboundRtpStreamStats remoteInboundRtpStreamStats; //!< Remote Inbound RTP Stream stats object
-    RtcInboundRtpStreamStats inboundRtpStreamStats;             //!< Inbound RTP Stream stats object
+    RtcIceCandidatePairStats iceCandidatePairStats;               //!< ICE Candidate Pair  stats object
+    RtcIceCandidateStats localIceCandidateStats;                  //!< local ICE Candidate stats object
+    RtcIceCandidateStats remoteIceCandidateStats;                 //!< remote ICE Candidate stats object
+    RtcIceServerStats iceServerStats;                             //!< ICE Server Pair stats object
+    RtcTransportStats transportStats;                             //!< Transport stats object
+    RtcOutboundRtpStreamStats outboundRtpStreamStats;             //!< Outbound RTP Stream stats object
+    RtcRemoteInboundRtpStreamStats remoteInboundRtpStreamStats;   //!< Remote Inbound RTP Stream stats object
+    RtcRemoteOutboundRtpStreamStats remoteOutboundRtpStreamStats; //!< Remote Outbound RTP Stream stats object
+    RtcInboundRtpStreamStats inboundRtpStreamStats;               //!< Inbound RTP Stream stats object
     RtcDataChannelStats rtcDataChannelStats;
 } RtcStatsObject, *PRtcStatsObject;
 /*!@} */

--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -156,6 +156,30 @@ CleanUp:
     return retStatus;
 }
 
+STATUS getRtpRemoteOutboundStats(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTransceiver pTransceiver,
+                                 PRtcRemoteOutboundRtpStreamStats pRtcRemoteOutboundRtpStreamStats)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PDoubleListNode node = NULL;
+    UINT64 hashValue = 0;
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pRtcPeerConnection;
+    CHK(pRtcPeerConnection != NULL || pRtcRemoteOutboundRtpStreamStats != NULL, STATUS_NULL_ARG);
+    PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pTransceiver;
+    if (pKvsRtpTransceiver == NULL) {
+        CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &node));
+        CHK_STATUS(doubleListGetNodeData(node, &hashValue));
+        pKvsRtpTransceiver = (PKvsRtpTransceiver) hashValue;
+        CHK(pKvsRtpTransceiver != NULL, STATUS_NOT_FOUND);
+    }
+    // check if specified transceiver belongs to this connection
+    CHK_STATUS(hasTransceiverWithSsrc(pKvsPeerConnection, pKvsRtpTransceiver->sender.ssrc));
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    *pRtcRemoteOutboundRtpStreamStats = pKvsRtpTransceiver->remoteOutboundStats;
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+CleanUp:
+    return retStatus;
+}
+
 STATUS getRtpOutboundStats(PRtcPeerConnection pRtcPeerConnection, PRtcRtpTransceiver pTransceiver,
                            PRtcOutboundRtpStreamStats pRtcOutboundRtpStreamStats)
 {
@@ -260,9 +284,11 @@ STATUS rtcPeerConnectionGetMetrics(PRtcPeerConnection pRtcPeerConnection, PRtcRt
             CHK_STATUS(getDataChannelStats(pRtcPeerConnection, &pRtcMetrics->rtcStatsObject.rtcDataChannelStats));
             DLOGD("RTC Data Channel Stats requested at %" PRIu64, pRtcMetrics->timestamp);
             break;
+        case RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP:
+            CHK_STATUS(getRtpRemoteOutboundStats(pRtcPeerConnection, pRtcRtpTransceiver, &pRtcMetrics->rtcStatsObject.remoteOutboundRtpStreamStats));
+            break;
         case RTC_STATS_TYPE_CERTIFICATE:
         case RTC_STATS_TYPE_CSRC:
-        case RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP:
         case RTC_STATS_TYPE_PEER_CONNECTION:
         case RTC_STATS_TYPE_RECEIVER:
         case RTC_STATS_TYPE_SENDER:

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -57,11 +57,7 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
     PKvsRtpTransceiver pTransceiver = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL, STATUS_NULL_ARG);
-
-    if (pRtcpPacket->payloadLength != RTCP_PACKET_SENDER_REPORT_MINLEN) {
-        // TODO: handle sender report containing receiver report blocks
-        return STATUS_SUCCESS;
-    }
+    CHK(pRtcpPacket->payloadLength >= RTCP_PACKET_SENDER_REPORT_MINLEN, STATUS_RTCP_INPUT_PARTIAL_PACKET);
 
     senderSSRC = getUnalignedInt32BigEndian(pRtcpPacket->payload);
     if (STATUS_SUCCEEDED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, senderSSRC))) {
@@ -73,6 +69,19 @@ static STATUS onRtcpSenderReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKv
         // Store for LSR/DLSR in outgoing RR
         pTransceiver->lastSRNtpMid = (UINT32) ((ntpTime >> 16U) & 0xffffffffULL);
         pTransceiver->lastSRReceivedTime = GETTIME();
+
+        // Populate remote outbound stats
+        UINT64 ntpSec = ntpTime >> 32U;
+        UINT64 ntpFrac = ntpTime & 0xffffffffULL;
+        UINT64 unixMs = (ntpSec - NTP_OFFSET) * 1000ULL + (ntpFrac * 1000ULL / NTP_TIMESCALE);
+
+        MUTEX_LOCK(pTransceiver->statsLock);
+        pTransceiver->remoteOutboundStats.reportsSent++;
+        pTransceiver->remoteOutboundStats.sent.packetsSent = packetCnt;
+        pTransceiver->remoteOutboundStats.sent.bytesSent = octetCnt;
+        pTransceiver->remoteOutboundStats.sent.rtpStream.ssrc = senderSSRC;
+        pTransceiver->remoteOutboundStats.remoteTimestamp = unixMs;
+        MUTEX_UNLOCK(pTransceiver->statsLock);
     } else {
         DLOGW("Received sender report for non existing ssrc: %u", senderSSRC);
     }

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -91,6 +91,7 @@ typedef struct {
     MUTEX statsLock;
     RtcOutboundRtpStreamStats outboundStats;
     RtcRemoteInboundRtpStreamStats remoteInboundStats;
+    RtcRemoteOutboundRtpStreamStats remoteOutboundStats;
     RtcInboundRtpStreamStats inboundStats;
 
     // RFC 3550 A.1/A.3 — receiver sequence number state for RR and packetsLost

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2554,8 +2554,8 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         for (UINT32 i = 0; i < NUM_VIDEO_FRAMES; i++) {
             minVideoPackets += (videoInputFrames[i].data.size() + DEFAULT_MTU_SIZE_BYTES - 1) / DEFAULT_MTU_SIZE_BYTES;
             UINT32 naluOffsets[128], naluLengths[128];
-            UINT32 naluCount = extractNaluInfo((PBYTE) videoInputFrames[i].data.data(), (UINT32) videoInputFrames[i].data.size(),
-                                               naluOffsets, naluLengths, 128);
+            UINT32 naluCount =
+                extractNaluInfo((PBYTE) videoInputFrames[i].data.data(), (UINT32) videoInputFrames[i].data.size(), naluOffsets, naluLengths, 128);
             for (UINT32 j = 0; j < naluCount; j++) {
                 totalNaluBytes += naluLengths[j];
             }
@@ -2613,8 +2613,7 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         rtcMetrics.rtcStatsObject.rtcDataChannelStats.dataChannelIdentifier = pAnswerRemoteDc->id;
         EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, NULL, &rtcMetrics));
         auto& dcTxStats = rtcMetrics.rtcStatsObject.rtcDataChannelStats;
-        EXPECT_EQ(dcTxStats.messagesSent, NUM_DC_MESSAGES)
-            << "DC messagesSent " << dcTxStats.messagesSent << " expected " << NUM_DC_MESSAGES;
+        EXPECT_EQ(dcTxStats.messagesSent, NUM_DC_MESSAGES) << "DC messagesSent " << dcTxStats.messagesSent << " expected " << NUM_DC_MESSAGES;
         EXPECT_EQ(dcTxStats.bytesSent, (UINT64) NUM_DC_MESSAGES * DC_MSG_SIZE);
     }
 
@@ -2641,8 +2640,7 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         auto& videoRemote = rtcMetrics.rtcStatsObject.remoteInboundRtpStreamStats;
         EXPECT_GT(videoRemote.reportsReceived, (UINT64) 0) << "No RTCP RR received for video";
         EXPECT_GE(videoRemote.received.packetsReceived, videoPacketsSent)
-            << "Remote inbound video packetsReceived " << videoRemote.received.packetsReceived
-            << " expected ~" << videoPacketsSent;
+            << "Remote inbound video packetsReceived " << videoRemote.received.packetsReceived << " expected ~" << videoPacketsSent;
         EXPECT_EQ(videoRemote.received.packetsLost, 0) << "Remote inbound video packetsLost " << videoRemote.received.packetsLost;
         EXPECT_GE(videoRemote.received.jitter, 0.0) << "Remote inbound video jitter is negative";
         EXPECT_EQ(videoRemote.fractionLost, 0.0) << "Remote inbound video fractionLost " << videoRemote.fractionLost;
@@ -2657,11 +2655,66 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         auto& audioRemote = rtcMetrics.rtcStatsObject.remoteInboundRtpStreamStats;
         EXPECT_GT(audioRemote.reportsReceived, (UINT64) 0) << "No RTCP RR received for audio";
         EXPECT_GE(audioRemote.received.packetsReceived, audioPacketsSent)
-            << "Remote inbound audio packetsReceived " << audioRemote.received.packetsReceived
-            << " expected ~" << audioPacketsSent;
+            << "Remote inbound audio packetsReceived " << audioRemote.received.packetsReceived << " expected ~" << audioPacketsSent;
         EXPECT_EQ(audioRemote.received.packetsLost, 0) << "Remote inbound audio packetsLost " << audioRemote.received.packetsLost;
         EXPECT_GE(audioRemote.received.jitter, 0.0) << "Remote inbound audio jitter is negative";
         EXPECT_EQ(audioRemote.fractionLost, 0.0) << "Remote inbound audio fractionLost " << audioRemote.fractionLost;
+    }
+
+    // --- Verify remote outbound RTP stats on the answer (from RTCP SR sent by offer) ---
+    {
+        RtcStats rtcMetrics{};
+
+        // Get the offer's outbound stats for comparison — the SR carries these exact values
+        RtcStats offerVideoOutMetrics{}, offerAudioOutMetrics{};
+        offerVideoOutMetrics.requestedTypeOfStats = RTC_STATS_TYPE_OUTBOUND_RTP;
+        EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(offerPc, offerVideoTransceiver, &offerVideoOutMetrics));
+        offerAudioOutMetrics.requestedTypeOfStats = RTC_STATS_TYPE_OUTBOUND_RTP;
+        EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(offerPc, offerAudioTransceiver, &offerAudioOutMetrics));
+
+        // Wait for at least one RTCP SR with final packet counts to arrive on the answer side.
+        // The SR copies outboundStats.sent.packetsSent; all frames were sent before the first SR fires
+        // (SR starts 2.5s after first frame, frames finish in ~500ms), so the SR should carry final counts.
+        for (INT32 i = 0; i < 50; i++) {
+            rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+            ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerVideoTransceiver, &rtcMetrics));
+            if (rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats.sent.packetsSent ==
+                offerVideoOutMetrics.rtcStatsObject.outboundRtpStreamStats.sent.packetsSent) {
+                break;
+            }
+            THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
+
+        UINT64 nowMs = GETTIME() / HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+        // Video remote outbound — packetsSent/bytesSent must match the offer's outbound stats exactly
+        auto& videoRemoteOut = rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats;
+        auto& videoOfferOut = offerVideoOutMetrics.rtcStatsObject.outboundRtpStreamStats;
+        EXPECT_GT(videoRemoteOut.reportsSent, (UINT64) 0) << "No RTCP SR received for video";
+        EXPECT_EQ(videoRemoteOut.sent.packetsSent, videoOfferOut.sent.packetsSent)
+            << "Remote outbound video packetsSent " << videoRemoteOut.sent.packetsSent << " != offer outbound " << videoOfferOut.sent.packetsSent;
+        EXPECT_EQ(videoRemoteOut.sent.bytesSent, videoOfferOut.sent.bytesSent)
+            << "Remote outbound video bytesSent " << videoRemoteOut.sent.bytesSent << " != offer outbound " << videoOfferOut.sent.bytesSent;
+        EXPECT_EQ(videoRemoteOut.sent.rtpStream.ssrc, ((PKvsRtpTransceiver) offerVideoTransceiver)->sender.ssrc)
+            << "Remote outbound video SSRC mismatch";
+        // remoteTimestamp should be a Unix ms timestamp within 60s of now
+        EXPECT_GT(videoRemoteOut.remoteTimestamp, nowMs - 60000) << "Remote outbound video remoteTimestamp too old";
+        EXPECT_LE(videoRemoteOut.remoteTimestamp, nowMs + 1000) << "Remote outbound video remoteTimestamp in the future";
+
+        // Audio remote outbound
+        rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+        EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerAudioTransceiver, &rtcMetrics));
+        auto& audioRemoteOut = rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats;
+        auto& audioOfferOut = offerAudioOutMetrics.rtcStatsObject.outboundRtpStreamStats;
+        EXPECT_GT(audioRemoteOut.reportsSent, (UINT64) 0) << "No RTCP SR received for audio";
+        EXPECT_EQ(audioRemoteOut.sent.packetsSent, audioOfferOut.sent.packetsSent)
+            << "Remote outbound audio packetsSent " << audioRemoteOut.sent.packetsSent << " != offer outbound " << audioOfferOut.sent.packetsSent;
+        EXPECT_EQ(audioRemoteOut.sent.bytesSent, audioOfferOut.sent.bytesSent)
+            << "Remote outbound audio bytesSent " << audioRemoteOut.sent.bytesSent << " != offer outbound " << audioOfferOut.sent.bytesSent;
+        EXPECT_EQ(audioRemoteOut.sent.rtpStream.ssrc, ((PKvsRtpTransceiver) offerAudioTransceiver)->sender.ssrc)
+            << "Remote outbound audio SSRC mismatch";
+        EXPECT_GT(audioRemoteOut.remoteTimestamp, nowMs - 60000) << "Remote outbound audio remoteTimestamp too old";
+        EXPECT_LE(audioRemoteOut.remoteTimestamp, nowMs + 1000) << "Remote outbound audio remoteTimestamp in the future";
     }
 
     closePeerConnection(offerPc);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2701,9 +2701,16 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         EXPECT_GT(videoRemoteOut.remoteTimestamp, nowMs - 60000) << "Remote outbound video remoteTimestamp too old";
         EXPECT_LE(videoRemoteOut.remoteTimestamp, nowMs + 1000) << "Remote outbound video remoteTimestamp in the future";
 
-        // Audio remote outbound
-        rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
-        EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerAudioTransceiver, &rtcMetrics));
+        // Audio remote outbound — wait for SR to arrive (separate timer from video)
+        for (INT32 i = 0; i < 50; i++) {
+            rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+            ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerAudioTransceiver, &rtcMetrics));
+            if (rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats.sent.packetsSent ==
+                offerAudioOutMetrics.rtcStatsObject.outboundRtpStreamStats.sent.packetsSent) {
+                break;
+            }
+            THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
         auto& audioRemoteOut = rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats;
         auto& audioOfferOut = offerAudioOutMetrics.rtcStatsObject.outboundRtpStreamStats;
         EXPECT_GT(audioRemoteOut.reportsSent, (UINT64) 0) << "No RTCP SR received for audio";

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -205,7 +205,7 @@ TEST_F(RtcpFunctionalityTest, onRtcpPacketCompoundSenderReport)
     EXPECT_LT(0, stats.totalRoundTripTime);
     EXPECT_LT(0, stats.roundTripTime);
     // Verify incoming RR fields stored in received stats
-    EXPECT_EQ(0, stats.received.packetsLost); // cumulative lost = 0 in the packet
+    EXPECT_EQ(0, stats.received.packetsLost);     // cumulative lost = 0 in the packet
     EXPECT_DOUBLE_EQ(0.0, stats.received.jitter); // interarrival jitter = 0 in the packet
     freePeerConnection(&pRtcPeerConnection);
 }
@@ -299,8 +299,8 @@ TEST_F(RtcpFunctionalityTest, onpli)
     freePeerConnection(&pRtcPeerConnection);
 }
 
-static void testBwHandler(UINT64 customData, UINT32 txBytes, UINT32 rxBytes, UINT32 txPacketsCnt, UINT32 rxPacketsCnt,
-                                                   UINT64 duration) {
+static void testBwHandler(UINT64 customData, UINT32 txBytes, UINT32 rxBytes, UINT32 txPacketsCnt, UINT32 rxPacketsCnt, UINT64 duration)
+{
     UNUSED_PARAM(customData);
     UNUSED_PARAM(txBytes);
     UNUSED_PARAM(rxBytes);
@@ -329,16 +329,14 @@ static void parseTwcc(const std::string& hex, const uint32_t expectedReceived, c
     rtcpPacket.payload = payload;
     rtcpPacket.payloadLength = payloadLen;
 
-
     EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&config, &pRtcPeerConnection));
     pKvsPeerConnection = reinterpret_cast<PKvsPeerConnection>(pRtcPeerConnection);
-    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, 0,
-                                                                        testBwHandler));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnSenderBandwidthEstimation(pRtcPeerConnection, 0, testBwHandler));
 
     UINT16 baseSeqNum = getUnalignedInt16BigEndian(rtcpPacket.payload + 8);
     UINT16 pktCount = TWCC_PACKET_STATUS_COUNT(rtcpPacket.payload);
 
-    for(i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
+    for (i = baseSeqNum; i < baseSeqNum + pktCount; i++) {
         rtpPacket.header.extension = TRUE;
         rtpPacket.header.extensionProfile = TWCC_EXT_PROFILE;
         rtpPacket.header.extensionLength = SIZEOF(UINT32);
@@ -350,10 +348,10 @@ static void parseTwcc(const std::string& hex, const uint32_t expectedReceived, c
 
     EXPECT_EQ(STATUS_SUCCESS, parseRtcpTwccPacket(&rtcpPacket, pKvsPeerConnection->pTwccManager));
 
-    for(i = 0; i < MAX_UINT16; i++) {
-        if(STATUS_SUCCEEDED(hashTableGet(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, i, &value))) {
+    for (i = 0; i < MAX_UINT16; i++) {
+        if (STATUS_SUCCEEDED(hashTableGet(pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable, i, &value))) {
             PTwccRtpPacketInfo tempTwccRtpPktInfo = (PTwccRtpPacketInfo) value;
-            if(tempTwccRtpPktInfo->remoteTimeKvs == TWCC_PACKET_LOST_TIME) {
+            if (tempTwccRtpPktInfo->remoteTimeKvs == TWCC_PACKET_LOST_TIME) {
                 lost++;
             } else if (tempTwccRtpPktInfo->remoteTimeKvs != TWCC_PACKET_UNITIALIZED_TIME) {
                 received++;
@@ -431,19 +429,17 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableTest)
 
     // Grab the hash table.
     pTwccRtpPktInfosHashTable = pKvsPeerConnection->pTwccManager->pTwccRtpPktInfosHashTable;
- 
+
     pKvsPeerConnection->pTwccManager->prevReportedBaseSeqNum = lowerBound;
     pKvsPeerConnection->pTwccManager->lastReportedSeqNum = upperBound + 10;
 
     // Breakup the packet indexes to be across the max int overflow.
-    for (i = lowerBound; i <= UINT16_MAX && i != 0 ; i++)
-    {
+    for (i = lowerBound; i <= UINT16_MAX && i != 0; i++) {
         pTwccRtpPacketInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
         EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, i, (UINT64) pTwccRtpPacketInfo));
         hashTableInsertionCount++;
     }
-    for (i = 0; i < upperBound; i++)
-    {
+    for (i = 0; i < upperBound; i++) {
         pTwccRtpPacketInfo = (PTwccRtpPacketInfo) MEMCALLOC(1, SIZEOF(TwccRtpPacketInfo));
         EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, i, (UINT64) pTwccRtpPacketInfo));
         hashTableInsertionCount++;
@@ -456,27 +452,29 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableTest)
 
     // Validate hash table size after and before updating (onRtcpTwccPacket case).
     EXPECT_EQ(hashTableInsertionCount, pTwccRtpPktInfosHashTable->itemCount);
-    EXPECT_EQ(STATUS_SUCCESS, updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets));
+    EXPECT_EQ(STATUS_SUCCESS,
+              updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets));
     EXPECT_EQ(0, pTwccRtpPktInfosHashTable->itemCount);
 
     hashTableInsertionCount = 0;
     pTwccRtpPacketInfo = NULL;
-    for (i = 0; i <= upperBound; i++)
-    {
+    for (i = 0; i <= upperBound; i++) {
         EXPECT_EQ(STATUS_SUCCESS, hashTableUpsert(pTwccRtpPktInfosHashTable, i, (UINT64) pTwccRtpPacketInfo));
         hashTableInsertionCount++;
     }
     EXPECT_EQ(hashTableInsertionCount, pTwccRtpPktInfosHashTable->itemCount);
-    EXPECT_EQ(STATUS_SUCCESS, updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets));
+    EXPECT_EQ(STATUS_SUCCESS,
+              updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets));
     EXPECT_EQ(0, pTwccRtpPktInfosHashTable->itemCount);
-    
+
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
     MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
 }
 
-TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
+TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase)
+{
     PRtcPeerConnection pRtcPeerConnection = NULL;
     PKvsPeerConnection pKvsPeerConnection = NULL;
     RtcConfiguration config{};
@@ -503,11 +501,10 @@ TEST_F(RtcpFunctionalityTest, updateTwccHashTableIntPromotionCase) {
 
     // Even though pTwccManager->lastReportedSeqNum is a UINT16, (pTwccManager->lastReportedSeqNum + 1) can get
     // promoted to an int (32) when pTwccManager->lastReportedSeqNum == UINT16_MAX
-    EXPECT_EQ(STATUS_SUCCESS, updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration,
-                                                  &receivedBytes, &receivedPackets,
-                                                  &sentBytes, &sentPackets));
+    EXPECT_EQ(STATUS_SUCCESS,
+              updateTwccHashTable(pKvsPeerConnection->pTwccManager, &duration, &receivedBytes, &receivedPackets, &sentBytes, &sentPackets));
 
-    EXPECT_EQ(0, pTwccRtpPktInfosHashTable->itemCount);  // Ensure the table is cleared again
+    EXPECT_EQ(0, pTwccRtpPktInfosHashTable->itemCount); // Ensure the table is cleared again
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);
     MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
@@ -623,7 +620,7 @@ TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedOutOfOrder)
     MEMCPY(extensionPayload, &twccPayload, 4);
     rtpPacket.receivedTime = GETTIME();
     EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
-    EXPECT_EQ(99, pManager->firstSeqNum);  // Updated to earlier packet
+    EXPECT_EQ(99, pManager->firstSeqNum); // Updated to earlier packet
     EXPECT_EQ(102, pManager->lastSeqNum);
 
     EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
@@ -674,7 +671,7 @@ TEST_F(RtcpFunctionalityTest, twccReceiverOnPacketReceivedSeqNumWraparound)
     rtpPacket.receivedTime = GETTIME();
     EXPECT_EQ(STATUS_SUCCESS, twccReceiverOnPacketReceived(pKvsPeerConnection, &rtpPacket));
     EXPECT_EQ(UINT16_MAX - 1, pManager->firstSeqNum);
-    EXPECT_EQ(0, pManager->lastSeqNum);  // Wrapped to 0
+    EXPECT_EQ(0, pManager->lastSeqNum); // Wrapped to 0
 
     // Add packet at 1
     twccPayload = htonl((1 << 28) | (1 << 24) | (1 << 8));
@@ -818,8 +815,8 @@ TEST_F(RtcpFunctionalityTest, receiverReportSeqOverflow)
 
     MUTEX_LOCK(pT->statsLock);
     pT->inboundStats.received.packetsReceived = 5;
-    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq; // 65536 + 2 = 65538
-    UINT32 expected = extMax - pT->rrBaseSeq + 1;  // 65538 - 65534 + 1 = 5
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq;  // 65536 + 2 = 65538
+    UINT32 expected = extMax - pT->rrBaseSeq + 1; // 65538 - 65534 + 1 = 5
     pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
     MUTEX_UNLOCK(pT->statsLock);
 
@@ -846,7 +843,7 @@ TEST_F(RtcpFunctionalityTest, receiverReportSeqOverflowWithLoss)
 
     MUTEX_LOCK(pT->statsLock);
     pT->inboundStats.received.packetsReceived = 5; // 65533, 65534, 0, 1, 3
-    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq; // 65536 + 3 = 65539
+    UINT32 extMax = pT->rrCycles + pT->rrMaxSeq;   // 65536 + 3 = 65539
     UINT32 expected = extMax - pT->rrBaseSeq + 1;  // 65539 - 65533 + 1 = 7
     pT->inboundStats.received.packetsLost = (INT64) expected - (INT64) pT->inboundStats.received.packetsReceived;
     MUTEX_UNLOCK(pT->statsLock);
@@ -888,11 +885,11 @@ TEST_F(RtcpFunctionalityTest, receiverReportFractionLostPerInterval)
     pT->inboundStats.received.packetsReceived = 97; // 50 + 47
 
     extMax = pT->rrCycles + pT->rrMaxSeq;
-    expected = extMax - pT->rrBaseSeq + 1; // 100
+    expected = extMax - pT->rrBaseSeq + 1;                         // 100
     received = (UINT32) pT->inboundStats.received.packetsReceived; // 97
-    expectedInterval = expected - pT->rrExpectedPrior; // 100 - 50 = 50
-    receivedInterval = received - pT->rrReceivedPrior; // 97 - 50 = 47
-    lostInterval = expectedInterval - receivedInterval; // 3
+    expectedInterval = expected - pT->rrExpectedPrior;             // 100 - 50 = 50
+    receivedInterval = received - pT->rrReceivedPrior;             // 97 - 50 = 47
+    lostInterval = expectedInterval - receivedInterval;            // 3
     UINT8 fraction2 = (expectedInterval == 0 || lostInterval == 0) ? 0 : (UINT8) ((lostInterval << 8) / expectedInterval);
     EXPECT_EQ((3 << 8) / 50, fraction2); // = 15
 
@@ -922,8 +919,8 @@ TEST_F(RtcpFunctionalityTest, receiverReportLargeJump)
     // maxSeq should NOT change
     constexpr UINT16 jumpSeq = 5000;
     UINT16 udelta = jumpSeq - pT->rrMaxSeq; // 4890
-    EXPECT_GT(udelta, 3000); // > MAX_DROPOUT
-    EXPECT_LT(udelta, RTP_SEQ_MOD - 100); // < RTP_SEQ_MOD - MAX_MISORDER
+    EXPECT_GT(udelta, 3000);                // > MAX_DROPOUT
+    EXPECT_LT(udelta, RTP_SEQ_MOD - 100);   // < RTP_SEQ_MOD - MAX_MISORDER
 
     // After this, maxSeq should remain 110, badSeq = 5001
     pT->rrBadSeq = ((UINT32) jumpSeq + 1) & (RTP_SEQ_MOD - 1);
@@ -947,7 +944,7 @@ TEST_F(RtcpFunctionalityTest, twccMakeRunlenMacro)
 
     // Test with NOT_RECEIVED status (00), run length 10
     UINT16 chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_NOTRECEIVED, 10);
-    EXPECT_EQ(0, (chunk >> 15) & 1);  // Bit 15 should be 0 for run-length
+    EXPECT_EQ(0, (chunk >> 15) & 1); // Bit 15 should be 0 for run-length
     EXPECT_EQ(TWCC_STATUS_SYMBOL_NOTRECEIVED, (chunk >> 13) & 3);
     EXPECT_EQ(10, chunk & 0x1FFF);
 
@@ -966,6 +963,115 @@ TEST_F(RtcpFunctionalityTest, twccMakeRunlenMacro)
     // Test max run length (0x1FFF = 8191)
     chunk = TWCC_MAKE_RUNLEN(TWCC_STATUS_SYMBOL_SMALLDELTA, 0x1FFF);
     EXPECT_EQ(0x1FFF, chunk & 0x1FFF);
+}
+
+TEST_F(RtcpFunctionalityTest, remoteOutboundStatsFromSenderReport)
+{
+    // Craft a pure SR packet (no RR blocks): 24 bytes payload
+    // SSRC = 0x12345678
+    // NTP timestamp: sec = 0xE1E32043 (3790012483), frac = 0x00000000
+    // RTP timestamp: 0x00001000
+    // Packet count: 100 (0x00000064)
+    // Octet count: 50000 (0x0000C350)
+    constexpr UINT32 senderSSRC = 0x12345678;
+    constexpr UINT32 ntpSec = 0xE1E32043;
+    constexpr UINT32 ntpFrac = 0x00000000;
+    constexpr UINT32 rtpTs = 0x00001000;
+    constexpr UINT32 packetCount = 100;
+    constexpr UINT32 octetCount = 50000;
+
+    // Build RTCP SR: header (4 bytes) + payload (24 bytes)
+    BYTE srPacket[28];
+    // Header: V=2, P=0, RC=0, PT=200 (SR), length=6 (words-1)
+    srPacket[0] = 0x80;
+    srPacket[1] = 0xC8; // PT=200 (SR)
+    srPacket[2] = 0x00;
+    srPacket[3] = 0x06; // length = 6 (7 words = 28 bytes)
+    // Payload: SSRC
+    putUnalignedInt32BigEndian(srPacket + 4, senderSSRC);
+    // NTP timestamp
+    putUnalignedInt32BigEndian(srPacket + 8, ntpSec);
+    putUnalignedInt32BigEndian(srPacket + 12, ntpFrac);
+    // RTP timestamp
+    putUnalignedInt32BigEndian(srPacket + 16, rtpTs);
+    // Sender packet count
+    putUnalignedInt32BigEndian(srPacket + 20, packetCount);
+    // Sender octet count
+    putUnalignedInt32BigEndian(srPacket + 24, octetCount);
+
+    initTransceiver(senderSSRC);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, srPacket, SIZEOF(srPacket)));
+
+    RtcStats stats{};
+    stats.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+
+    auto& ros = stats.rtcStatsObject.remoteOutboundRtpStreamStats;
+    EXPECT_EQ(1, ros.reportsSent);
+    EXPECT_EQ(packetCount, ros.sent.packetsSent);
+    EXPECT_EQ(octetCount, ros.sent.bytesSent);
+    EXPECT_EQ(senderSSRC, ros.sent.rtpStream.ssrc);
+
+    // NTP sec 0xE1E32043 = 3790012483, minus NTP_OFFSET (2208988800) = 1581023683 Unix sec
+    // With ntpFrac=0, remoteTimestamp should be 1581023683000 ms
+    constexpr UINT64 expectedMs = (UINT64) (ntpSec - 2208988800ULL) * 1000ULL;
+    EXPECT_EQ(expectedMs, ros.remoteTimestamp);
+
+    // Feed a second SR to verify reportsSent increments
+    putUnalignedInt32BigEndian(srPacket + 20, packetCount + 50);
+    putUnalignedInt32BigEndian(srPacket + 24, octetCount + 25000);
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, srPacket, SIZEOF(srPacket)));
+
+    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+    EXPECT_EQ(2, ros.reportsSent);
+    EXPECT_EQ(packetCount + 50, ros.sent.packetsSent);
+    EXPECT_EQ(octetCount + 25000, ros.sent.bytesSent);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, remoteOutboundStatsFromSRWithRRBlocks)
+{
+    // Test that SR with appended RR blocks (payloadLength > 24) is handled
+    // SR header: V=2, P=0, RC=1 (one RR block), PT=200, length=12 (13 words = 52 bytes)
+    // SR sender info (24 bytes) + 1 RR block (24 bytes) = 48 bytes payload
+    constexpr UINT32 senderSSRC = 0xAABBCCDD;
+    constexpr UINT32 reportedSSRC = 0x11223344;
+    BYTE srWithRR[52];
+    MEMSET(srWithRR, 0, SIZEOF(srWithRR));
+    // Header
+    srWithRR[0] = 0x81; // V=2, RC=1
+    srWithRR[1] = 0xC8; // PT=200 (SR)
+    srWithRR[2] = 0x00;
+    srWithRR[3] = 0x0C; // length = 12
+    // SR sender info
+    putUnalignedInt32BigEndian(srWithRR + 4, senderSSRC);
+    putUnalignedInt32BigEndian(srWithRR + 8, 0xE1E32043);  // NTP sec
+    putUnalignedInt32BigEndian(srWithRR + 12, 0x00000000); // NTP frac
+    putUnalignedInt32BigEndian(srWithRR + 16, 0x00001000); // RTP ts
+    putUnalignedInt32BigEndian(srWithRR + 20, 200);        // packet count
+    putUnalignedInt32BigEndian(srWithRR + 24, 80000);      // octet count
+    // RR block (24 bytes at offset 28)
+    putUnalignedInt32BigEndian(srWithRR + 28, reportedSSRC);
+    // rest of RR block is zeros (fraction lost=0, cumulative lost=0, etc.)
+
+    initTransceiver(senderSSRC);
+    addTransceiver(reportedSSRC);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, srWithRR, SIZEOF(srWithRR)));
+
+    RtcStats stats{};
+    stats.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+    EXPECT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(pRtcPeerConnection, pRtcRtpTransceiver, &stats));
+
+    auto& ros = stats.rtcStatsObject.remoteOutboundRtpStreamStats;
+    EXPECT_EQ(1, ros.reportsSent);
+    EXPECT_EQ(200, ros.sent.packetsSent);
+    EXPECT_EQ(80000, ros.sent.bytesSent);
+    EXPECT_EQ(senderSSRC, ros.sent.rtpStream.ssrc);
+
+    freePeerConnection(&pRtcPeerConnection);
 }
 
 } // namespace webrtcclient


### PR DESCRIPTION
## Summary

- Add `RtcRemoteOutboundRtpStreamStats` struct per W3C spec, populated from incoming RTCP Sender Reports
- Fix SR handler to process SRs with appended RR blocks (previously silently dropped)
- Wire up `RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP` in `rtcPeerConnectionGetMetrics()`
- Add unit tests and integration test assertions in `fullCycleVideoAudioDataChannel`

*What was changed?*
Added RTCRemoteOutboundRtpStreamStats support: new struct in Stats.h, storage in KvsRtpTransceiver, SR handler extension in Rtcp.c to populate packetsSent/bytesSent/remoteTimestamp/reportsSent/ssrc, getter in Metrics.c, and switch-case wiring. Fixed the SR length check that was dropping SRs containing receiver report blocks.

*Why was it changed?*
The W3C WebRTC stats spec defines RTCRemoteOutboundRtpStreamStats as the symmetric counterpart to RTCRemoteInboundRtpStreamStats. The SDK already parsed SR fields but only stored LSR/DLSR for outgoing RR computation, returning STATUS_NOT_IMPLEMENTED for this stats type. Additionally, SRs with appended RR blocks were silently dropped.

*How was it changed?*
- Stats.h: Added RtcRemoteOutboundRtpStreamStats struct and RtcStatsObject field
- Rtp.h: Added remoteOutboundStats to KvsRtpTransceiver
- Rtcp.c: Changed `payloadLength != MINLEN` early return to `>= MINLEN` check; added stats population under statsLock (reportsSent++, packetsSent, bytesSent, ssrc, NTP-to-Unix-ms remoteTimestamp)
- Metrics.c: Added getRtpRemoteOutboundStats() getter; wired RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP in switch
- RtcpFunctionalityTest.cpp: Two unit tests — pure SR and SR with RR blocks
- PeerConnectionFunctionalityTest.cpp: Integration assertions in fullCycleVideoAudioDataChannel comparing remote outbound stats against offer's outbound stats with exact equality, plus timestamp sanity checks

*What testing was done for the changes?*
- All 27 RtcpFunctionalityTest tests pass including 2 new tests (remoteOutboundStatsFromSenderReport, remoteOutboundStatsFromSRWithRRBlocks)
- fullCycleVideoAudioDataChannel passes with strict assertions: packetsSent/bytesSent match offer's outbound stats exactly, SSRC matches, remoteTimestamp within 60s of wall clock

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.