### PR TITLE
Fix TSAN data race on twccFeedbackTimerId

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1953,10 +1953,19 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     }
 
     // Start TWCC feedback timer when remote offers TWCC
-    if (pKvsPeerConnection->twccExtId != 0 && pKvsPeerConnection->twccFeedbackTimerId == MAX_UINT32) {
-        CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, TWCC_FEEDBACK_INITIAL_DELAY, TIMER_QUEUE_SINGLE_INVOCATION_PERIOD,
-                                      twccFeedbackCallback, (UINT64) pKvsPeerConnection, &pKvsPeerConnection->twccFeedbackTimerId));
-        DLOGI("Started TWCC feedback timer with extension ID %u", pKvsPeerConnection->twccExtId);
+    if (pKvsPeerConnection->twccExtId != 0) {
+        MUTEX_LOCK(pKvsPeerConnection->twccLock);
+        BOOL startTimer = pKvsPeerConnection->twccFeedbackTimerId == MAX_UINT32;
+        MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+        if (startTimer) {
+            UINT32 timerId = MAX_UINT32;
+            CHK_STATUS(timerQueueAddTimer(pKvsPeerConnection->timerQueueHandle, TWCC_FEEDBACK_INITIAL_DELAY, TIMER_QUEUE_SINGLE_INVOCATION_PERIOD,
+                                          twccFeedbackCallback, (UINT64) pKvsPeerConnection, &timerId));
+            MUTEX_LOCK(pKvsPeerConnection->twccLock);
+            pKvsPeerConnection->twccFeedbackTimerId = timerId;
+            MUTEX_UNLOCK(pKvsPeerConnection->twccLock);
+            DLOGI("Started TWCC feedback timer with extension ID %u", pKvsPeerConnection->twccExtId);
+        }
     }
 
 CleanUp:


### PR DESCRIPTION
## Summary
- Fix ThreadSanitizer data race on `twccFeedbackTimerId` between `setRemoteDescription` (main thread) and `twccFeedbackCallback` (timer thread)

*What was changed?*
Protected reads and writes of `twccFeedbackTimerId` in `setRemoteDescription` with the existing `twccLock` mutex, matching the locking already used in `twccFeedbackCallback`.

*Why was it changed?*
TSAN detected a data race: `setRemoteDescription` reads `twccFeedbackTimerId` without holding `twccLock`, while `twccFeedbackCallback` writes it under `twccLock` on the timer thread. This race was observed in the `iceRestartTest` under the TSAN CI build.

*How was it changed?*
In `setRemoteDescription`, the check of `twccFeedbackTimerId == MAX_UINT32` and the subsequent write after `timerQueueAddTimer` are now both done under `twccLock`. The timer creation itself (`timerQueueAddTimer`) remains outside the lock to avoid holding it during a potentially blocking call.

*What testing was done for the changes?*
Built and ran tests locally on macOS with mbedTLS. The fix targets the TSAN superbuild-linux CI job which previously failed with this race.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.