### PR TITLE
Improve GCC estimator: windowed bitrate, aggressive loss control

### DIFF
--- a/src/source/PeerConnection/Gcc.c
+++ b/src/source/PeerConnection/Gcc.c
@@ -228,9 +228,10 @@ STATUS gccUpdateDelayController(PGccRateController pRateCtrl, GccSignal signal, 
                 pRateCtrl->A_hat = (UINT64) (eta * pRateCtrl->A_hat);
             }
 
-            // Don't let estimate diverge too far from actual sending rate
-            // A_hat(i) < 1.5 * R_hat(i)
-            if (incomingBitrate > 0 && pRateCtrl->A_hat > (UINT64) (1.5 * incomingBitrate)) {
+            // Don't let estimate diverge too far from actual acknowledged rate.
+            // Skip the cap when acked rate is below minBitrate — the clamp at the
+            // end already enforces the floor, and capping here would prevent growth.
+            if (incomingBitrate > minBitrate && pRateCtrl->A_hat > (UINT64) (1.5 * incomingBitrate)) {
                 pRateCtrl->A_hat = (UINT64) (1.5 * incomingBitrate);
             }
             break;
@@ -278,13 +279,13 @@ STATUS gccUpdateLossController(PGccRateController pRateCtrl, DOUBLE lossRatio, U
 
     CHK(pRateCtrl != NULL, STATUS_NULL_ARG);
 
-    // RFC Section 6: Loss-based control
+    // Loss-based control (more aggressive than RFC Section 6)
     if (lossRatio > GCC_LOSS_THRESHOLD_HIGH) {
-        // More than 10% loss: reduce by half the loss ratio
-        pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * (1.0 - 0.5 * lossRatio));
+        // More than 10% loss: reduce proportionally to loss
+        pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * (1.0 - lossRatio));
     } else if (lossRatio > GCC_LOSS_THRESHOLD_LOW) {
-        // 2-10% loss: hold steady
-        // As_hat unchanged
+        // 2-10% loss: reduce gently (5%)
+        pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * 0.95);
     } else {
         // Less than 2% loss: increase by 5%
         pRateCtrl->As_hat = (UINT64) (pRateCtrl->As_hat * 1.05);
@@ -299,6 +300,72 @@ STATUS gccUpdateLossController(PGccRateController pRateCtrl, DOUBLE lossRatio, U
 
 CleanUp:
     return retStatus;
+}
+
+//
+// Acknowledged Bitrate Estimator (port of WebRTC BitrateEstimator)
+//
+
+VOID gccBitrateEstimatorInit(PGccBitrateEstimator pEstimator)
+{
+    if (pEstimator == NULL) {
+        return;
+    }
+    pEstimator->sumBytes = 0;
+    pEstimator->currentWindowMs = 0;
+    pEstimator->prevTimeMs = -1;
+    pEstimator->bitrateEstimateKbps = -1.0;
+}
+
+VOID gccBitrateEstimatorUpdate(PGccBitrateEstimator pEstimator, INT64 timeMs, UINT32 packetSize)
+{
+    INT64 rateWindowMs;
+    DOUBLE bitrateSampleKbps;
+
+    if (pEstimator == NULL) {
+        return;
+    }
+
+    rateWindowMs = (pEstimator->bitrateEstimateKbps < 0.0) ? GCC_INITIAL_RATE_WINDOW_MS : GCC_RATE_WINDOW_MS;
+
+    // Reset if time moves backwards
+    if (timeMs < pEstimator->prevTimeMs) {
+        pEstimator->prevTimeMs = -1;
+        pEstimator->sumBytes = 0;
+        pEstimator->currentWindowMs = 0;
+    }
+
+    if (pEstimator->prevTimeMs >= 0) {
+        INT64 elapsed = timeMs - pEstimator->prevTimeMs;
+        pEstimator->currentWindowMs += elapsed;
+        if (elapsed > rateWindowMs) {
+            pEstimator->sumBytes = 0;
+            pEstimator->currentWindowMs %= rateWindowMs;
+        }
+    }
+    pEstimator->prevTimeMs = timeMs;
+
+    bitrateSampleKbps = -1.0;
+    if (pEstimator->currentWindowMs >= rateWindowMs) {
+        bitrateSampleKbps = 8.0 * (DOUBLE) pEstimator->sumBytes / (DOUBLE) rateWindowMs;
+        pEstimator->currentWindowMs -= rateWindowMs;
+        pEstimator->sumBytes = 0;
+    }
+    pEstimator->sumBytes += packetSize;
+
+    if (bitrateSampleKbps < 0.0) {
+        return;
+    }
+
+    pEstimator->bitrateEstimateKbps = bitrateSampleKbps;
+}
+
+UINT64 gccBitrateEstimatorGetBitrate(PGccBitrateEstimator pEstimator)
+{
+    if (pEstimator == NULL || pEstimator->bitrateEstimateKbps < 0.0) {
+        return 0;
+    }
+    return (UINT64) (pEstimator->bitrateEstimateKbps * 1000.0);
 }
 
 //
@@ -425,6 +492,7 @@ STATUS createGccController(PGccController* ppController, PGccConfig pConfig)
     CHK_STATUS(gccKalmanInit(&pController->kalman));
     CHK_STATUS(gccOveruseDetectorInit(&pController->overuse));
     CHK_STATUS(gccRateControllerInit(&pController->rateCtrl, pController->initialBitrate));
+    gccBitrateEstimatorInit(&pController->bitrateEstim);
 
     // Initialize packet group tracking
     MEMSET(&pController->currentGroup, 0, SIZEOF(GccPacketGroup));
@@ -477,7 +545,6 @@ STATUS gccOnTwccPacketReports(PGccController pController, PTwccPacketReport pRep
     GccSignal signal;
     UINT64 now, dtKvs;
     UINT64 incomingBitrate = 0;
-    UINT64 duration = 0;
 
     CHK(pController != NULL && pReports != NULL && reportCount > 0, STATUS_NULL_ARG);
 
@@ -503,6 +570,10 @@ STATUS gccOnTwccPacketReports(PGccController pController, PTwccPacketReport pRep
             receivedCount++;
             receivedBytes += pReports[i].packetSize;
 
+            // Feed each received packet into the bitrate estimator using send time
+            INT64 sendTimeMs = (INT64) (pReports[i].sendTimeKvs / HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+            gccBitrateEstimatorUpdate(&pController->bitrateEstim, sendTimeMs, pReports[i].packetSize);
+
             // Process packet for grouping
             gccProcessPacket(pController, pReports[i].sendTimeKvs, pReports[i].arrivalTimeKvs, pReports[i].packetSize, pReports[i].seqNum);
         } else {
@@ -516,24 +587,8 @@ STATUS gccOnTwccPacketReports(PGccController pController, PTwccPacketReport pRep
         pController->currentLossRatio = (DOUBLE) lostCount / (DOUBLE) (receivedCount + lostCount);
     }
 
-    // Calculate incoming bitrate from received packets
-    // Find duration from first to last received packet
-    UINT64 firstSendTime = 0, lastSendTime = 0;
-    for (i = 0; i < reportCount; i++) {
-        if (pReports[i].received) {
-            if (firstSendTime == 0 || pReports[i].sendTimeKvs < firstSendTime) {
-                firstSendTime = pReports[i].sendTimeKvs;
-            }
-            if (pReports[i].sendTimeKvs > lastSendTime) {
-                lastSendTime = pReports[i].sendTimeKvs;
-            }
-        }
-    }
-    if (lastSendTime > firstSendTime) {
-        duration = lastSendTime - firstSendTime;
-        // Convert to bps: bytes * 8 / seconds
-        incomingBitrate = (UINT64) ((DOUBLE) receivedBytes * 8.0 * HUNDREDS_OF_NANOS_IN_A_SECOND / (DOUBLE) duration);
-    }
+    // Get smoothed acknowledged bitrate from per-packet estimator
+    incomingBitrate = gccBitrateEstimatorGetBitrate(&pController->bitrateEstim);
 
     // Finalize current group and get inter-group delay variation
     while (gccFinalizeGroup(pController, &d_i)) {

--- a/src/source/PeerConnection/Gcc_i.h
+++ b/src/source/PeerConnection/Gcc_i.h
@@ -33,6 +33,10 @@ extern "C" {
 #define GCC_LOSS_THRESHOLD_LOW     0.02    // 2% loss threshold
 #define GCC_LOSS_THRESHOLD_HIGH    0.10    // 10% loss threshold
 
+// Acknowledged bitrate estimator parameters (matches WebRTC BitrateEstimator)
+#define GCC_INITIAL_RATE_WINDOW_MS 500 // Larger initial window for stable first estimate
+#define GCC_RATE_WINDOW_MS         150 // Steady-state window (ms), ~4-5 video frames at 30fps
+
 // Default bitrate bounds
 #define GCC_DEFAULT_MIN_BITRATE     100000  // 100 kbps
 #define GCC_DEFAULT_MAX_BITRATE     2500000 // 2.5 Mbps
@@ -83,6 +87,17 @@ typedef struct {
 } GccOveruseDetector, *PGccOveruseDetector;
 
 /**
+ * Acknowledged bitrate estimator (port of WebRTC BitrateEstimator).
+ * Per-packet sliding window producing throughput samples.
+ */
+typedef struct {
+    INT64 sumBytes;             //!< Accumulated bytes in current window
+    INT64 currentWindowMs;      //!< Current window duration (ms)
+    INT64 prevTimeMs;           //!< Previous packet time (ms), -1 = uninitialized
+    DOUBLE bitrateEstimateKbps; //!< Current estimate (kbps), -1.0 = no estimate
+} GccBitrateEstimator, *PGccBitrateEstimator;
+
+/**
  * Rate controller state (RFC Section 5.5)
  */
 typedef struct {
@@ -105,9 +120,10 @@ struct __GccController {
     MUTEX lock; //!< Thread safety
 
     // Sub-components
-    GccKalmanState kalman;      //!< Kalman filter state
-    GccOveruseDetector overuse; //!< Over-use detector state
-    GccRateController rateCtrl; //!< Rate controller state
+    GccKalmanState kalman;            //!< Kalman filter state
+    GccOveruseDetector overuse;       //!< Over-use detector state
+    GccRateController rateCtrl;       //!< Rate controller state
+    GccBitrateEstimator bitrateEstim; //!< Acknowledged bitrate estimator
 
     // Packet group tracking
     GccPacketGroup currentGroup; //!< Current packet group being built
@@ -213,6 +229,10 @@ STATUS gccProcessPacket(PGccController pController, UINT64 sendTimeKvs, UINT64 a
  * @return TRUE if a new d(i) value was computed
  */
 BOOL gccFinalizeGroup(PGccController pController, DOUBLE* pD_i);
+
+VOID gccBitrateEstimatorInit(PGccBitrateEstimator pEstimator);
+VOID gccBitrateEstimatorUpdate(PGccBitrateEstimator pEstimator, INT64 timeMs, UINT32 packetSize);
+UINT64 gccBitrateEstimatorGetBitrate(PGccBitrateEstimator pEstimator);
 
 #ifdef __cplusplus
 }

--- a/tst/GccFunctionalityTest.cpp
+++ b/tst/GccFunctionalityTest.cpp
@@ -376,10 +376,10 @@ TEST_F(GccFunctionalityTest, lossControllerMidLossHold)
 
     UINT64 initialAsHat = rateCtrl.As_hat;
 
-    // 2-10% loss should hold steady
+    // 2-10% loss should reduce gently (5%)
     gccUpdateLossController(&rateCtrl, 0.05, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
 
-    EXPECT_EQ(initialAsHat, rateCtrl.As_hat);
+    EXPECT_EQ((UINT64)(initialAsHat * 0.95), rateCtrl.As_hat);
 }
 
 TEST_F(GccFunctionalityTest, lossControllerHighLossDecrease)
@@ -389,11 +389,11 @@ TEST_F(GccFunctionalityTest, lossControllerHighLossDecrease)
 
     UINT64 initialAsHat = rateCtrl.As_hat;
 
-    // More than 10% loss should decrease by half the loss ratio
+    // More than 10% loss should decrease proportionally to loss
     gccUpdateLossController(&rateCtrl, 0.20, GCC_DEFAULT_MIN_BITRATE, GCC_DEFAULT_MAX_BITRATE);
 
     EXPECT_LT(rateCtrl.As_hat, initialAsHat);
-    EXPECT_EQ((UINT64)(initialAsHat * (1.0 - 0.5 * 0.20)), rateCtrl.As_hat);
+    EXPECT_EQ((UINT64)(initialAsHat * (1.0 - 0.20)), rateCtrl.As_hat);
 }
 
 TEST_F(GccFunctionalityTest, lossControllerBoundsEnforcement)


### PR DESCRIPTION
*What was changed?*
Three improvements to the GCC congestion controller in `Gcc.c` and `Gcc_i.h`: per-packet windowed bitrate estimator, more aggressive loss-based control, and a fix for the 1.5x acknowledged bitrate cap.

*Why was it changed?*
The GCC target bitrate was stuck at minimum because: (1) the per-report incoming bitrate calculation produced wildly inaccurate values (e.g. 20 kbps when actual throughput was 4 Mbps), causing the 1.5x cap to pin A_hat at minimum; (2) the loss controller was too gentle — 20% loss only reduced As_hat by 10%; (3) the 1.5x cap applied even when the acknowledged rate was below minBitrate, preventing A_hat from ever growing past minimum during audio-only startup.

*How was it changed?*
1. **Windowed bitrate estimator** (based on WebRTC `BitrateEstimator`): replaced single-report instantaneous calculation with a per-packet 150ms sliding window. Each acknowledged packet is fed individually using send time. Window produces throughput samples that track actual sending rate.

2. **Aggressive loss control**: >10% loss now reduces by `(1 - lossRatio)` instead of `(1 - 0.5*lossRatio)`. 2-10% loss reduces 5% per report instead of holding steady.

3. **1.5x cap fix**: skip the cap when `incomingBitrate < minBitrate` — the bounds clamp already enforces the minimum floor.

*What testing was done for the changes?*
- All 42 GccFunctionalityTest tests pass (test expectations updated for new loss behavior)
- Verified with pcap replay from real Chrome session: target bitrate reaches 5-6 Mbps (was stuck at 2.1 Mbps minimum)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.