### PR TITLE
Add SAFE_STRCPY macro, fix unsafe STRCPY in Metrics.c

### DIFF
--- a/src/source/Include_i.h
+++ b/src/source/Include_i.h
@@ -74,6 +74,13 @@ extern "C" {
 #endif
 #endif
 
+// STRNCPY that always null-terminates. dst must be a fixed-size array (not a pointer).
+#define SAFE_STRCPY(dst, src)                                                                                                                        \
+    do {                                                                                                                                             \
+        STRNCPY((dst), (src), ARRAY_SIZE(dst));                                                                                                      \
+        (dst)[ARRAY_SIZE(dst) - 1] = '\0';                                                                                                           \
+    } while (FALSE)
+
 // Max uFrag and uPwd length as documented in https://tools.ietf.org/html/rfc5245#section-15.4
 #define ICE_MAX_UFRAG_LEN 256
 #define ICE_MAX_UPWD_LEN  256

--- a/src/source/Metrics/Metrics.c
+++ b/src/source/Metrics/Metrics.c
@@ -20,8 +20,8 @@ STATUS getIceCandidatePairStats(PRtcPeerConnection pRtcPeerConnection, PRtcIceCa
     CHK(pIceAgent->pDataSendingIceCandidatePair != NULL, STATUS_SUCCESS);
     PRtcIceCandidatePairDiagnostics pRtcIceCandidatePairDiagnostics = pIceAgent->pDataSendingIceCandidatePair->pRtcIceCandidatePairDiagnostics;
     if (pRtcIceCandidatePairDiagnostics != NULL) {
-        STRCPY(pRtcIceCandidatePairStats->localCandidateId, pRtcIceCandidatePairDiagnostics->localCandidateId);
-        STRCPY(pRtcIceCandidatePairStats->remoteCandidateId, pRtcIceCandidatePairDiagnostics->remoteCandidateId);
+        SAFE_STRCPY(pRtcIceCandidatePairStats->localCandidateId, pRtcIceCandidatePairDiagnostics->localCandidateId);
+        SAFE_STRCPY(pRtcIceCandidatePairStats->remoteCandidateId, pRtcIceCandidatePairDiagnostics->remoteCandidateId);
         pRtcIceCandidatePairStats->state = pRtcIceCandidatePairDiagnostics->state;
         pRtcIceCandidatePairStats->nominated = pRtcIceCandidatePairDiagnostics->nominated;
 
@@ -74,14 +74,14 @@ STATUS getIceCandidateStats(PRtcPeerConnection pRtcPeerConnection, BOOL isRemote
     if (pRtcIceCandidateDiagnostics != NULL) {
         if (!isRemote) {
             pRtcIceCandidateDiagnostics = pIceAgent->pRtcSelectedLocalIceCandidateDiagnostics;
-            STRCPY(pRtcIceCandidateStats->relayProtocol, pRtcIceCandidateDiagnostics->relayProtocol);
-            STRCPY(pRtcIceCandidateStats->url, pRtcIceCandidateDiagnostics->url);
+            SAFE_STRCPY(pRtcIceCandidateStats->relayProtocol, pRtcIceCandidateDiagnostics->relayProtocol);
+            SAFE_STRCPY(pRtcIceCandidateStats->url, pRtcIceCandidateDiagnostics->url);
         }
-        STRCPY(pRtcIceCandidateStats->address, pRtcIceCandidateDiagnostics->address);
-        STRCPY(pRtcIceCandidateStats->candidateType, pRtcIceCandidateDiagnostics->candidateType);
+        SAFE_STRCPY(pRtcIceCandidateStats->address, pRtcIceCandidateDiagnostics->address);
+        SAFE_STRCPY(pRtcIceCandidateStats->candidateType, pRtcIceCandidateDiagnostics->candidateType);
         pRtcIceCandidateStats->port = pRtcIceCandidateDiagnostics->port;
         pRtcIceCandidateStats->priority = pRtcIceCandidateDiagnostics->priority;
-        STRCPY(pRtcIceCandidateStats->protocol, pRtcIceCandidateDiagnostics->protocol);
+        SAFE_STRCPY(pRtcIceCandidateStats->protocol, pRtcIceCandidateDiagnostics->protocol);
     }
 CleanUp:
     if (locked) {
@@ -108,8 +108,8 @@ STATUS getIceServerStats(PRtcPeerConnection pRtcPeerConnection, PRtcIceServerSta
 
     if (pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex] != NULL) {
         pRtcIceServerStats->port = pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->port;
-        STRCPY(pRtcIceServerStats->protocol, pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->protocol);
-        STRCPY(pRtcIceServerStats->url, pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->url);
+        SAFE_STRCPY(pRtcIceServerStats->protocol, pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->protocol);
+        SAFE_STRCPY(pRtcIceServerStats->url, pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->url);
         pRtcIceServerStats->totalRequestsSent = pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->totalRequestsSent;
         pRtcIceServerStats->totalResponsesReceived = pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->totalResponsesReceived;
         pRtcIceServerStats->totalRoundTripTime = pIceAgent->pRtcIceServerDiagnostics[pRtcIceServerStats->iceServerIndex]->totalRoundTripTime;
@@ -238,7 +238,7 @@ STATUS getDataChannelStats(PRtcPeerConnection pRtcPeerConnection, PRtcDataChanne
     pKvsDataChannel = (PKvsDataChannel) hashValue;
     pRtcDataChannelStats->bytesReceived = (UINT64) ATOMIC_LOAD(&pKvsDataChannel->atomicBytesReceived);
     pRtcDataChannelStats->bytesSent = (UINT64) ATOMIC_LOAD(&pKvsDataChannel->atomicBytesSent);
-    STRCPY(pRtcDataChannelStats->label, pKvsDataChannel->rtcDataChannelDiagnostics.label);
+    SAFE_STRCPY(pRtcDataChannelStats->label, pKvsDataChannel->rtcDataChannelDiagnostics.label);
     pRtcDataChannelStats->messagesReceived = (UINT32) ATOMIC_LOAD(&pKvsDataChannel->atomicMessagesReceived);
     pRtcDataChannelStats->messagesSent = (UINT32) ATOMIC_LOAD(&pKvsDataChannel->atomicMessagesSent);
     pRtcDataChannelStats->state = pKvsDataChannel->rtcDataChannelDiagnostics.state;


### PR DESCRIPTION
## Summary
- Add `SAFE_STRCPY(dst, src)` macro in `Include_i.h` that wraps `STRNCPY` + null-termination for fixed-size array destinations
- Replace all 10 unsafe `STRCPY` calls in `Metrics.c` with `SAFE_STRCPY` across `getIceCandidatePairStats`, `getIceCandidateStats`, `getIceServerStats`, and `getDataChannelStats`

*What was changed?*
All STRCPY calls in Metrics.c that copy from diagnostics structs into stats structs were replaced with a new SAFE_STRCPY macro that uses bounded STRNCPY and guarantees null-termination.

*Why was it changed?*
STRCPY does not bounds-check. If a source string exceeds the destination buffer size, it causes a buffer overflow. The stats structs use fixed-size char arrays, making them vulnerable when the diagnostics source data is longer than expected.

*How was it changed?*
A SAFE_STRCPY(dst, src) macro was added to Include_i.h. It uses STRNCPY with ARRAY_SIZE(dst) as the limit and explicitly sets the last byte to '\0'. All 10 STRCPY calls in Metrics.c were replaced with this macro.

*What testing was done for the changes?*
Code review verified that all destination arguments are fixed-size struct member arrays (not pointers), which is required for ARRAY_SIZE to work correctly. The macro expands to the same STRNCPY+null-terminate pattern that was already validated in the upstream Metrics.c.patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.