### PR TITLE
Fix JitterBuffer leak of stranded reordered packets at destroy

### DIFF
--- a/src/source/PeerConnection/JitterBuffer.c
+++ b/src/source/PeerConnection/JitterBuffer.c
@@ -809,6 +809,16 @@ CleanUp:
     return retStatus;
 }
 
+static STATUS freeRtpPacketHashEntry(UINT64 customData, PHashEntry pEntry)
+{
+    UNUSED_PARAM(customData);
+    if (pEntry != NULL && pEntry->value != 0) {
+        PRtpPacket pPacket = (PRtpPacket) pEntry->value;
+        freeRtpPacket(&pPacket);
+    }
+    return STATUS_SUCCESS;
+}
+
 static STATUS defaultDestroy(PJitterBuffer* ppJitterBuffer)
 {
     ENTERS();
@@ -838,6 +848,11 @@ static STATUS defaultDestroy(PJitterBuffer* ppJitterBuffer)
         }
         defaultDropBufferData((PJitterBuffer) pInternal, pInternal->headSequenceNumber, pInternal->tailSequenceNumber, 0);
     }
+    // Free any RtpPackets that remain in the hash table. Reordered packets can be
+    // inserted with sequence numbers outside [headSequenceNumber, tailSequenceNumber]
+    // (e.g. a late packet arriving after its frame has already been delivered), and
+    // the range-based defaultDropBufferData above won't reach them.
+    hashTableIterateEntries(pInternal->pPkgBufferHashTable, 0, freeRtpPacketHashEntry);
     hashTableFree(pInternal->pPkgBufferHashTable);
 
     SAFE_MEMFREE(*ppJitterBuffer);


### PR DESCRIPTION
*What was changed?*

`defaultDestroy` in `src/source/PeerConnection/JitterBuffer.c` now iterates `pPkgBufferHashTable` with `hashTableIterateEntries` and calls `freeRtpPacket` on every remaining value before `hashTableFree`, via a new `freeRtpPacketHashEntry` helper.

*Why was it changed?*

The previous final cleanup relied on `defaultDropBufferData(headSequenceNumber, tailSequenceNumber, 0)`, which only frees packets whose sequence numbers fall inside `[head, tail]`. Once `firstFrameProcessed` is set, `headSequenceNumberCheck` will not lower the head for a late/reordered packet, so such a packet gets inserted into the hashtable with a sequence number that the range-based scan in the parse loop and in `defaultDestroy` can never reach. Every stray packet was leaked on teardown.

Reproduced by temporarily changing `timestamp += 3000` to `1500` in `tst/H264JitterBufferIntegrationTest.cpp::packetizeAllFrames` (tighter latency window vs. reorder distance). On the `Default32ms` variants the instrumented allocator reported `Possible memory leak of size 89550`, with e.g. 104 packets left in the hashtable at destroy with `head=2621, tail=2620`.

*How was it changed?*

- Added `freeRtpPacketHashEntry`, a `HashEntryCallbackFunc` that casts the entry's value to `PRtpPacket` and calls `freeRtpPacket`.
- In `defaultDestroy`, after the existing parse/drain loop and the final `defaultDropBufferData`, call `hashTableIterateEntries(pInternal->pPkgBufferHashTable, 0, freeRtpPacketHashEntry)` before `hashTableFree`. This releases any stray packets regardless of where their sequence numbers sit relative to head/tail.
- Short comment at the call site documents the hidden invariant (late reordered packets can live outside `[head, tail]`).

*What testing was done for the changes?*

- Local build: `cmake --build build-no-build-deps --target webrtc_client_test`.
- Ran `./build-no-build-deps/tst/webrtc_client_test --gtest_filter='*H264JitterBuffer*'` against the repro (`timestamp += 1500`): all 40 `H264JitterBufferIntegrationTest` cases pass and the `Possible memory leak` warning from `resetInstrumentedAllocators` no longer appears. The test change was reverted before commit.
- Re-ran the same filter on the unmodified test file: still 40/40 passing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.