### PR TITLE
Fix RTCP Receiver Report math: jitter seed, signed interval loss

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -368,12 +368,14 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
         pTransceiver = (PKvsRtpTransceiver) item;
 
         if (pTransceiver->jitterBufferSsrc == ssrc) {
+            BOOL firstPacket = !pTransceiver->rrSeqInitialized;
             packetsReceived++;
 
-            if (!pTransceiver->rrSeqInitialized) {
+            if (firstPacket) {
                 rrInitSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
+            } else {
+                rrUpdateSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
             }
-            rrUpdateSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
 
             // https://tools.ietf.org/html/rfc3550#section-6.4.1
             // https://tools.ietf.org/html/rfc3550#appendix-A.8
@@ -383,9 +385,15 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
             arrival = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, pTransceiver->pJitterBuffer->clockRate);
             r_ts = pRtpPacket->header.timestamp;
             transit = arrival - r_ts;
-            delta = transit - pTransceiver->pJitterBuffer->transit;
-            pTransceiver->pJitterBuffer->transit = transit;
-            pTransceiver->pJitterBuffer->jitter += (1. / 16.) * ((DOUBLE) ABS(delta) - pTransceiver->pJitterBuffer->jitter);
+            if (firstPacket) {
+                // RFC 3550 §A.8: seed transit on first packet, skip the D(i-1,i) update.
+                pTransceiver->pJitterBuffer->transit = (UINT64) transit;
+                pTransceiver->pJitterBuffer->jitter = 0.0;
+            } else {
+                delta = transit - (INT64) pTransceiver->pJitterBuffer->transit;
+                pTransceiver->pJitterBuffer->transit = (UINT64) transit;
+                pTransceiver->pJitterBuffer->jitter += (ABS(delta) - pTransceiver->pJitterBuffer->jitter) / 16.0;
+            }
 
             headerBytesReceived += RTP_HEADER_LEN(pRtpPacket);
             bytesReceived += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -889,8 +889,9 @@ CleanUp:
 // srtp_protect_rtcp() needs room for auth tag + SRTP trailer past the RTCP payload.
 #define RTCP_SRTP_ENCRYPT_OVERHEAD (SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4)
 
-// Max builder output: SR body is larger than RR body.
-#define RTCP_MAX_REPORT_BODY_LEN (RTCP_PACKET_HEADER_LEN + 24)
+// Max builder output: RR (4 header + 4 sender SSRC + 24 report block = 32)
+// is larger than SR (4 header + 24 body = 28).
+#define RTCP_MAX_REPORT_BODY_LEN (RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN)
 
 static STATUS sendBuiltRtcpReport(PKvsPeerConnection pKvsPeerConnection, PBYTE pReportBody, UINT32 reportLen)
 {

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -878,15 +878,43 @@ CleanUp:
     return retStatus;
 }
 
+// srtp_protect_rtcp() needs room for auth tag + SRTP trailer past the RTCP payload.
+#define RTCP_SRTP_ENCRYPT_OVERHEAD (SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4)
+
+// Max builder output: SR body is larger than RR body.
+#define RTCP_MAX_REPORT_BODY_LEN (RTCP_PACKET_HEADER_LEN + 24)
+
+static STATUS sendBuiltRtcpReport(PKvsPeerConnection pKvsPeerConnection, PBYTE pReportBody, UINT32 reportLen)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    PBYTE rawPacket = NULL;
+    UINT32 allocSize = reportLen + RTCP_SRTP_ENCRYPT_OVERHEAD;
+    UINT32 encryptLen = reportLen;
+
+    CHK(NULL != (rawPacket = (PBYTE) MEMALLOC(allocSize)), STATUS_NOT_ENOUGH_MEMORY);
+    MEMCPY(rawPacket, pReportBody, reportLen);
+
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rawPacket, reportLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
+    }
+
+    CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &encryptLen));
+    CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, encryptLen));
+
+CleanUp:
+    SAFE_MEMFREE(rawPacket);
+    return retStatus;
+}
+
 STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData)
 {
     ENTERS();
     UNUSED_PARAM(timerId);
     STATUS retStatus = STATUS_SUCCESS;
-    BOOL ready = FALSE;
-    UINT64 ntpTime, rtpTime, delay;
-    UINT32 packetCount, octetCount, packetLen, allocSize, ssrc;
-    PBYTE rawPacket = NULL;
+    UINT64 delay;
+    UINT32 ssrc;
+    BYTE reportBody[RTCP_MAX_REPORT_BODY_LEN];
+    UINT32 reportLen;
     PKvsPeerConnection pKvsPeerConnection = NULL;
 
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) customData;
@@ -896,130 +924,21 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
     ssrc = pKvsRtpTransceiver->sender.ssrc;
     DLOGS("rtcpReportsCallback %" PRIu64 " ssrc: %u rtxssrc: %u", currentTime, ssrc, pKvsRtpTransceiver->sender.rtxSsrc);
 
-    // check if ice agent is connected, reschedule in 200msec if not
-    ready = pKvsPeerConnection->pSrtpSession != NULL && pKvsRtpTransceiver->sender.firstFrameWallClockTime != 0 &&
-        currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime >= 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
-    if (!ready) {
-        DLOGV("sender report no frames sent %u", ssrc);
-    } else {
-        // create rtcp sender report packet
-        // https://tools.ietf.org/html/rfc3550#section-6.4.1
-        ntpTime = convertTimestampToNTP(currentTime);
-        rtpTime = pKvsRtpTransceiver->sender.rtpTimeOffset +
-            CONVERT_TIMESTAMP_TO_RTP(pKvsRtpTransceiver->pJitterBuffer->clockRate, currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime);
-        MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
-        packetCount = pKvsRtpTransceiver->outboundStats.sent.packetsSent;
-        octetCount = pKvsRtpTransceiver->outboundStats.sent.bytesSent;
-        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
-        DLOGV("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
-        packetLen = RTCP_PACKET_HEADER_LEN + 24;
-
-        // srtp_protect_rtcp() in encryptRtcpPacket() assumes memory availability to write 10 bytes of authentication tag and
-        // SRTP_MAX_TRAILER_LEN + 4 following the actual rtcp Packet payload
-        allocSize = packetLen + SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
-        CHK(NULL != (rawPacket = (PBYTE) MEMALLOC(allocSize)), STATUS_NOT_ENOUGH_MEMORY);
-        rawPacket[0] = RTCP_PACKET_VERSION_VAL << 6;
-        rawPacket[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_SENDER_REPORT;
-        putUnalignedInt16BigEndian(rawPacket + RTCP_PACKET_LEN_OFFSET,
-                                   (packetLen / RTCP_PACKET_LEN_WORD_SIZE) - 1); // The length of this RTCP packet in 32-bit words minus one
-        putUnalignedInt32BigEndian(rawPacket + 4, ssrc);
-        putUnalignedInt64BigEndian(rawPacket + 8, ntpTime);
-        putUnalignedInt32BigEndian(rawPacket + 16, rtpTime);
-        putUnalignedInt32BigEndian(rawPacket + 20, packetCount);
-        putUnalignedInt32BigEndian(rawPacket + 24, octetCount);
-
-        // PCAP: capture unencrypted outbound RTCP (Sender Report)
-        if (pKvsPeerConnection->pPcapDump != NULL) {
-            pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rawPacket, packetLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
-        }
-
-        CHK_STATUS(encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
-        CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen));
-    }
-
-    // Send RTCP Receiver Report if we are receiving media on this transceiver
-    if (pKvsPeerConnection->pSrtpSession != NULL && pKvsRtpTransceiver->jitterBufferSsrc != 0 && pKvsRtpTransceiver->rrSeqInitialized) {
-        UINT32 rrExtMax, rrExpected, rrReceived, rrLost, rrExpectedInterval, rrReceivedInterval, rrLostInterval;
-        UINT8 rrFraction;
-        INT32 rrCumulativeLost;
-        UINT32 rrPacketLen;
-        UINT32 rrLastSRNtpMid;
-        UINT64 rrLastSRReceivedTime;
-        BYTE rrPacket[RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN]; // header + sender SSRC + 1 report block
-
-        MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
-        rrExtMax = pKvsRtpTransceiver->rrCycles + pKvsRtpTransceiver->rrMaxSeq;
-        rrExpected = rrExtMax - pKvsRtpTransceiver->rrBaseSeq + 1;
-        rrReceived = (UINT32) pKvsRtpTransceiver->inboundStats.received.packetsReceived;
-
-        rrLost = rrExpected - rrReceived;
-
-        rrExpectedInterval = rrExpected - pKvsRtpTransceiver->rrExpectedPrior;
-        pKvsRtpTransceiver->rrExpectedPrior = rrExpected;
-        rrReceivedInterval = rrReceived - pKvsRtpTransceiver->rrReceivedPrior;
-        pKvsRtpTransceiver->rrReceivedPrior = rrReceived;
-        rrLostInterval = rrExpectedInterval - rrReceivedInterval;
-
-        if (rrExpectedInterval == 0 || rrLostInterval == 0) {
-            rrFraction = 0;
+    if (pKvsPeerConnection->pSrtpSession != NULL) {
+        // Sender Report — only emitted once media has been sent (RFC 3550 §6.4)
+        reportLen = sizeof(reportBody);
+        CHK_STATUS(rtcpBuildSenderReport(pKvsRtpTransceiver, currentTime, reportBody, &reportLen));
+        if (reportLen > 0) {
+            CHK_STATUS(sendBuiltRtcpReport(pKvsPeerConnection, reportBody, reportLen));
         } else {
-            rrFraction = (UINT8) ((rrLostInterval << 8) / rrExpectedInterval);
+            DLOGV("sender report no frames sent %u", ssrc);
         }
 
-        // Clamp cumulative lost to 24-bit signed range [-0x800000, 0x7FFFFF]
-        if ((INT32) rrLost > 0x7FFFFF) {
-            rrCumulativeLost = 0x7FFFFF;
-        } else if ((INT32) rrLost < -0x800000) {
-            rrCumulativeLost = -0x800000;
-        } else {
-            rrCumulativeLost = (INT32) rrLost;
-        }
-        rrLastSRNtpMid = pKvsRtpTransceiver->lastSRNtpMid;
-        rrLastSRReceivedTime = pKvsRtpTransceiver->lastSRReceivedTime;
-        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
-
-        rrPacketLen = sizeof(rrPacket);
-        MEMSET(rrPacket, 0, rrPacketLen);
-        rrPacket[0] = (RTCP_PACKET_VERSION_VAL << 6) | 1; // V=2, RC=1
-        rrPacket[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_RECEIVER_REPORT;
-        putUnalignedInt16BigEndian(rrPacket + RTCP_PACKET_LEN_OFFSET, (rrPacketLen / RTCP_PACKET_LEN_WORD_SIZE) - 1);
-        putUnalignedInt32BigEndian(rrPacket + 4, ssrc); // sender SSRC (our SSRC)
-        // Report block
-        putUnalignedInt32BigEndian(rrPacket + 8, pKvsRtpTransceiver->jitterBufferSsrc); // SSRC_1 (source)
-        rrPacket[12] = rrFraction;
-        rrPacket[13] = (rrCumulativeLost >> 16) & 0xFF;
-        rrPacket[14] = (rrCumulativeLost >> 8) & 0xFF;
-        rrPacket[15] = rrCumulativeLost & 0xFF;
-        putUnalignedInt32BigEndian(rrPacket + 16, rrExtMax);                                             // extended highest sequence number
-        putUnalignedInt32BigEndian(rrPacket + 20, (UINT32) (pKvsRtpTransceiver->pJitterBuffer->jitter)); // interarrival jitter
-        putUnalignedInt32BigEndian(rrPacket + 24, rrLastSRNtpMid);                                       // LSR
-
-        // DLSR: delay since last SR in 1/65536 sec units
-        if (rrLastSRReceivedTime != 0) {
-            UINT64 dlsrTime = currentTime - rrLastSRReceivedTime;
-            UINT32 dlsr = (UINT32) KVS_CONVERT_TIMESCALE(dlsrTime, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
-            putUnalignedInt32BigEndian(rrPacket + 28, dlsr);
-        }
-
-        DLOGV("receiver report ssrc: %u src: %u frac: %u lost: %d seq: %u", ssrc, pKvsRtpTransceiver->jitterBufferSsrc, rrFraction, rrCumulativeLost,
-              rrExtMax);
-        {
-            UINT32 rrAllocSize = rrPacketLen + SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4;
-            PBYTE rrRawPacket = (PBYTE) MEMALLOC(rrAllocSize);
-            CHK(rrRawPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
-            MEMCPY(rrRawPacket, rrPacket, rrPacketLen);
-
-            // PCAP: capture unencrypted outbound RTCP (Receiver Report)
-            if (pKvsPeerConnection->pPcapDump != NULL) {
-                pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rrRawPacket, rrPacketLen, TRUE, PCAP_PACKET_DIRECTION_SEND);
-            }
-
-            retStatus = encryptRtcpPacket(pKvsPeerConnection->pSrtpSession, rrRawPacket, (PINT32) &rrPacketLen);
-            if (STATUS_SUCCEEDED(retStatus)) {
-                retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rrRawPacket, rrPacketLen);
-            }
-            SAFE_MEMFREE(rrRawPacket);
-            CHK_STATUS(retStatus);
+        // Receiver Report — only if we are actually receiving media on this transceiver
+        reportLen = sizeof(reportBody);
+        CHK_STATUS(rtcpBuildReceiverReport(pKvsRtpTransceiver, currentTime, reportBody, &reportLen));
+        if (reportLen > 0) {
+            CHK_STATUS(sendBuiltRtcpReport(pKvsPeerConnection, reportBody, reportLen));
         }
     }
 
@@ -1032,7 +951,6 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
-    SAFE_MEMFREE(rawPacket);
 
     LEAVES();
     return retStatus;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -2,6 +2,139 @@
 
 #include "../Include_i.h"
 
+#define RTCP_SENDER_REPORT_LEN   (RTCP_PACKET_HEADER_LEN + 24)
+#define RTCP_RECEIVER_REPORT_LEN (RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN)
+
+STATUS rtcpBuildSenderReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer, PUINT32 pPacketLen)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT64 ntpTime, rtpTime;
+    UINT32 packetCount, octetCount, ssrc;
+
+    CHK(pKvsRtpTransceiver != NULL && pKvsRtpTransceiver->pJitterBuffer != NULL && pOutBuffer != NULL && pPacketLen != NULL, STATUS_NULL_ARG);
+    CHK(*pPacketLen >= RTCP_SENDER_REPORT_LEN, STATUS_BUFFER_TOO_SMALL);
+
+    // Only issue an SR if we have actually started sending media (see RFC 3550 §6.4).
+    // Signal "nothing to send" by setting *pPacketLen to 0.
+    if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0 ||
+        currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime < 2500 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND) {
+        *pPacketLen = 0;
+        CHK(FALSE, retStatus);
+    }
+
+    ssrc = pKvsRtpTransceiver->sender.ssrc;
+    ntpTime = convertTimestampToNTP(currentTime);
+    rtpTime = pKvsRtpTransceiver->sender.rtpTimeOffset +
+        CONVERT_TIMESTAMP_TO_RTP(pKvsRtpTransceiver->pJitterBuffer->clockRate, currentTime - pKvsRtpTransceiver->sender.firstFrameWallClockTime);
+
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    packetCount = pKvsRtpTransceiver->outboundStats.sent.packetsSent;
+    octetCount = pKvsRtpTransceiver->outboundStats.sent.bytesSent;
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+
+    DLOGV("sender report %u %" PRIu64 " %" PRIu64 " : %u packets %u bytes", ssrc, ntpTime, rtpTime, packetCount, octetCount);
+
+    pOutBuffer[0] = RTCP_PACKET_VERSION_VAL << 6;
+    pOutBuffer[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_SENDER_REPORT;
+    putUnalignedInt16BigEndian(pOutBuffer + RTCP_PACKET_LEN_OFFSET, (RTCP_SENDER_REPORT_LEN / RTCP_PACKET_LEN_WORD_SIZE) - 1);
+    putUnalignedInt32BigEndian(pOutBuffer + 4, ssrc);
+    putUnalignedInt64BigEndian(pOutBuffer + 8, ntpTime);
+    putUnalignedInt32BigEndian(pOutBuffer + 16, rtpTime);
+    putUnalignedInt32BigEndian(pOutBuffer + 20, packetCount);
+    putUnalignedInt32BigEndian(pOutBuffer + 24, octetCount);
+
+    *pPacketLen = RTCP_SENDER_REPORT_LEN;
+
+CleanUp:
+    LEAVES();
+    return retStatus;
+}
+
+STATUS rtcpBuildReceiverReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer, PUINT32 pPacketLen)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 rrExtMax, rrExpected, rrReceived, rrLost, rrExpectedInterval, rrReceivedInterval, rrLostInterval;
+    UINT8 rrFraction;
+    INT32 rrCumulativeLost;
+    UINT32 rrLastSRNtpMid;
+    UINT64 rrLastSRReceivedTime;
+    UINT32 ssrc;
+
+    CHK(pKvsRtpTransceiver != NULL && pKvsRtpTransceiver->pJitterBuffer != NULL && pOutBuffer != NULL && pPacketLen != NULL, STATUS_NULL_ARG);
+    CHK(*pPacketLen >= RTCP_RECEIVER_REPORT_LEN, STATUS_BUFFER_TOO_SMALL);
+
+    // Signal "nothing to send" by setting *pPacketLen to 0.
+    if (pKvsRtpTransceiver->jitterBufferSsrc == 0 || !pKvsRtpTransceiver->rrSeqInitialized) {
+        *pPacketLen = 0;
+        CHK(FALSE, retStatus);
+    }
+
+    ssrc = pKvsRtpTransceiver->sender.ssrc;
+
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    rrExtMax = pKvsRtpTransceiver->rrCycles + pKvsRtpTransceiver->rrMaxSeq;
+    rrExpected = rrExtMax - pKvsRtpTransceiver->rrBaseSeq + 1;
+    rrReceived = (UINT32) pKvsRtpTransceiver->inboundStats.received.packetsReceived;
+    rrLost = rrExpected - rrReceived;
+
+    rrExpectedInterval = rrExpected - pKvsRtpTransceiver->rrExpectedPrior;
+    pKvsRtpTransceiver->rrExpectedPrior = rrExpected;
+    rrReceivedInterval = rrReceived - pKvsRtpTransceiver->rrReceivedPrior;
+    pKvsRtpTransceiver->rrReceivedPrior = rrReceived;
+    rrLostInterval = rrExpectedInterval - rrReceivedInterval;
+
+    if (rrExpectedInterval == 0 || rrLostInterval == 0) {
+        rrFraction = 0;
+    } else {
+        rrFraction = (UINT8) ((rrLostInterval << 8) / rrExpectedInterval);
+    }
+
+    // Clamp cumulative lost to 24-bit signed range [-0x800000, 0x7FFFFF] per RFC 3550 §A.3.
+    if ((INT32) rrLost > 0x7FFFFF) {
+        rrCumulativeLost = 0x7FFFFF;
+    } else if ((INT32) rrLost < -0x800000) {
+        rrCumulativeLost = -0x800000;
+    } else {
+        rrCumulativeLost = (INT32) rrLost;
+    }
+    rrLastSRNtpMid = pKvsRtpTransceiver->lastSRNtpMid;
+    rrLastSRReceivedTime = pKvsRtpTransceiver->lastSRReceivedTime;
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+
+    MEMSET(pOutBuffer, 0, RTCP_RECEIVER_REPORT_LEN);
+    pOutBuffer[0] = (RTCP_PACKET_VERSION_VAL << 6) | 1; // V=2, RC=1
+    pOutBuffer[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_RECEIVER_REPORT;
+    putUnalignedInt16BigEndian(pOutBuffer + RTCP_PACKET_LEN_OFFSET, (RTCP_RECEIVER_REPORT_LEN / RTCP_PACKET_LEN_WORD_SIZE) - 1);
+    putUnalignedInt32BigEndian(pOutBuffer + 4, ssrc); // sender SSRC (our SSRC)
+    // Report block
+    putUnalignedInt32BigEndian(pOutBuffer + 8, pKvsRtpTransceiver->jitterBufferSsrc); // SSRC_1 (source)
+    pOutBuffer[12] = rrFraction;
+    pOutBuffer[13] = (rrCumulativeLost >> 16) & 0xFF;
+    pOutBuffer[14] = (rrCumulativeLost >> 8) & 0xFF;
+    pOutBuffer[15] = rrCumulativeLost & 0xFF;
+    putUnalignedInt32BigEndian(pOutBuffer + 16, rrExtMax);                                             // extended highest sequence number
+    putUnalignedInt32BigEndian(pOutBuffer + 20, (UINT32) (pKvsRtpTransceiver->pJitterBuffer->jitter)); // interarrival jitter
+    putUnalignedInt32BigEndian(pOutBuffer + 24, rrLastSRNtpMid);                                       // LSR
+
+    // DLSR: delay since last SR in 1/65536 sec units
+    if (rrLastSRReceivedTime != 0) {
+        UINT64 dlsrTime = currentTime - rrLastSRReceivedTime;
+        UINT32 dlsr = (UINT32) KVS_CONVERT_TIMESCALE(dlsrTime, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
+        putUnalignedInt32BigEndian(pOutBuffer + 28, dlsr);
+    }
+
+    DLOGV("receiver report ssrc: %u src: %u frac: %u lost: %d seq: %u", ssrc, pKvsRtpTransceiver->jitterBufferSsrc, rrFraction, rrCumulativeLost,
+          rrExtMax);
+
+    *pPacketLen = RTCP_RECEIVER_REPORT_LEN;
+
+CleanUp:
+    LEAVES();
+    return retStatus;
+}
+
 // TODO handle FIR packet https://tools.ietf.org/html/rfc2032#section-5.2.1
 static STATUS onRtcpFIRPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
 {

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -55,7 +55,8 @@ STATUS rtcpBuildReceiverReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 cur
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 rrExtMax, rrExpected, rrReceived, rrLost, rrExpectedInterval, rrReceivedInterval, rrLostInterval;
+    UINT32 rrExtMax, rrExpected, rrReceived, rrExpectedInterval, rrReceivedInterval;
+    INT32 rrLostInterval;
     UINT8 rrFraction;
     INT32 rrCumulativeLost;
     UINT32 rrLastSRNtpMid;
@@ -77,27 +78,27 @@ STATUS rtcpBuildReceiverReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 cur
     rrExtMax = pKvsRtpTransceiver->rrCycles + pKvsRtpTransceiver->rrMaxSeq;
     rrExpected = rrExtMax - pKvsRtpTransceiver->rrBaseSeq + 1;
     rrReceived = (UINT32) pKvsRtpTransceiver->inboundStats.received.packetsReceived;
-    rrLost = rrExpected - rrReceived;
 
     rrExpectedInterval = rrExpected - pKvsRtpTransceiver->rrExpectedPrior;
     pKvsRtpTransceiver->rrExpectedPrior = rrExpected;
     rrReceivedInterval = rrReceived - pKvsRtpTransceiver->rrReceivedPrior;
     pKvsRtpTransceiver->rrReceivedPrior = rrReceived;
-    rrLostInterval = rrExpectedInterval - rrReceivedInterval;
+    // RFC 3550 §A.3: compute lost_interval signed; duplicates/reorder make it <= 0.
+    rrLostInterval = (INT32) rrExpectedInterval - (INT32) rrReceivedInterval;
 
-    if (rrExpectedInterval == 0 || rrLostInterval == 0) {
+    if (rrExpectedInterval == 0 || rrLostInterval <= 0) {
         rrFraction = 0;
     } else {
-        rrFraction = (UINT8) ((rrLostInterval << 8) / rrExpectedInterval);
+        rrFraction = (UINT8) (((UINT32) rrLostInterval << 8) / rrExpectedInterval);
     }
 
-    // Clamp cumulative lost to 24-bit signed range [-0x800000, 0x7FFFFF] per RFC 3550 §A.3.
-    if ((INT32) rrLost > 0x7FFFFF) {
+    // Cumulative lost is a signed 24-bit value per RFC 3550 §6.4.1 (duplicates
+    // can make it negative). Clamp to the 24-bit signed range.
+    rrCumulativeLost = (INT32) rrExpected - (INT32) rrReceived;
+    if (rrCumulativeLost > 0x7FFFFF) {
         rrCumulativeLost = 0x7FFFFF;
-    } else if ((INT32) rrLost < -0x800000) {
+    } else if (rrCumulativeLost < -0x800000) {
         rrCumulativeLost = -0x800000;
-    } else {
-        rrCumulativeLost = (INT32) rrLost;
     }
     rrLastSRNtpMid = pKvsRtpTransceiver->lastSRNtpMid;
     rrLastSRReceivedTime = pKvsRtpTransceiver->lastSRReceivedTime;

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -16,6 +16,15 @@ STATUS updateTwccHashTable(PTwccManager, PINT64, PUINT64, PUINT64, PUINT64, PUIN
 STATUS sendRtcpPLI(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc);
 STATUS sendRtcpFIR(PKvsPeerConnection pKvsPeerConnection, UINT32 senderSsrc, UINT32 mediaSsrc, UINT8* pSeqNum);
 
+// Build unencrypted RTCP Sender Report into pOutBuffer; on success *pPacketLen holds bytes written.
+// Returns STATUS_SUCCESS if a report was written, STATUS_NOT_READY if the transceiver has not yet sent
+// any media (no SR is emitted in that case).
+STATUS rtcpBuildSenderReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer, PUINT32 pPacketLen);
+
+// Build unencrypted RTCP Receiver Report into pOutBuffer; on success *pPacketLen holds bytes written.
+// Returns STATUS_SUCCESS if a report was written, STATUS_NOT_READY if nothing has been received yet.
+STATUS rtcpBuildReceiverReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer, PUINT32 pPacketLen);
+
 // TWCC feedback generation (receiver side)
 STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager);
 STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2587,6 +2587,9 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
             << "Remote inbound video packetsReceived " << videoRemote.received.packetsReceived << " expected ~" << videoPacketsSent;
         EXPECT_EQ(videoRemote.received.packetsLost, 0) << "Remote inbound video packetsLost " << videoRemote.received.packetsLost;
         EXPECT_GE(videoRemote.received.jitter, 0.0) << "Remote inbound video jitter is negative";
+        // Localhost jitter should be sub-millisecond; a first-packet EWMA seed bug
+        // produces ~47 000 s from a UINT32-saturated wire value.
+        EXPECT_LT(videoRemote.received.jitter, 1.0) << "Remote inbound video jitter " << videoRemote.received.jitter << "s";
         EXPECT_EQ(videoRemote.fractionLost, 0.0) << "Remote inbound video fractionLost " << videoRemote.fractionLost;
 
         // Audio remote inbound
@@ -2602,6 +2605,7 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
             << "Remote inbound audio packetsReceived " << audioRemote.received.packetsReceived << " expected ~" << audioPacketsSent;
         EXPECT_EQ(audioRemote.received.packetsLost, 0) << "Remote inbound audio packetsLost " << audioRemote.received.packetsLost;
         EXPECT_GE(audioRemote.received.jitter, 0.0) << "Remote inbound audio jitter is negative";
+        EXPECT_LT(audioRemote.received.jitter, 1.0) << "Remote inbound audio jitter " << audioRemote.received.jitter << "s";
         EXPECT_EQ(audioRemote.fractionLost, 0.0) << "Remote inbound audio fractionLost " << audioRemote.fractionLost;
     }
 

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1074,6 +1074,138 @@ TEST_F(RtcpFunctionalityTest, remoteOutboundStatsFromSRWithRRBlocks)
     freePeerConnection(&pRtcPeerConnection);
 }
 
+// Helpers to decode fields written by rtcpBuildReceiverReport.
+// Byte layout after the 4-byte RTCP header + 4-byte sender SSRC:
+//   [8..11]  SSRC_1
+//   [12]     fraction lost
+//   [13..15] cumulative lost (signed 24-bit)
+//   [16..19] extended highest seq num
+//   [20..23] interarrival jitter
+//   [24..27] LSR
+//   [28..31] DLSR
+static UINT8 rrBlockFracLost(BYTE* buf)
+{
+    return buf[12];
+}
+static INT32 rrBlockCumLost(BYTE* buf)
+{
+    UINT32 u = ((UINT32) buf[13] << 16) | ((UINT32) buf[14] << 8) | buf[15];
+    return (u & 0x800000u) ? (INT32) (u | 0xFF000000u) : (INT32) u;
+}
+static UINT32 rrBlockJitter(BYTE* buf)
+{
+    return getUnalignedInt32BigEndian(buf + 20);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportReorderedDuplicate)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+    pT->jitterBufferSsrc = 0xabcd1234;
+
+    // Previous interval: 100 expected, 100 received.
+    pT->rrBaseSeq = 0;
+    pT->rrMaxSeq = 199; // rrExpected = 200
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 100;
+    pT->rrReceivedPrior = 100;
+    pT->rrSeqInitialized = TRUE;
+
+    // This interval: 100 expected, 101 received — one reordered duplicate.
+    pT->inboundStats.received.packetsReceived = 201;
+
+    BYTE buf[64];
+    UINT32 len = sizeof(buf);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, GETTIME(), buf, &len));
+    EXPECT_EQ(32u, len);
+    EXPECT_EQ(0u, rrBlockFracLost(buf)) << "underflow produced pseudo-random fraction";
+    INT32 cum = rrBlockCumLost(buf);
+    EXPECT_TRUE(cum == -1 || cum == 0) << "cum_lost " << cum << " not in {-1, 0}";
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, receiverReportFirstReportEmitsZeroJitter)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+    pT->jitterBufferSsrc = 0xabcd1234;
+
+    pT->rrBaseSeq = 0;
+    pT->rrMaxSeq = 9;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+    pT->inboundStats.received.packetsReceived = 10;
+    pT->pJitterBuffer->jitter = 0.0;
+
+    BYTE buf[64];
+    UINT32 len = sizeof(buf);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, GETTIME(), buf, &len));
+    EXPECT_EQ(32u, len);
+    EXPECT_EQ(0u, rrBlockFracLost(buf));
+    EXPECT_EQ(0, rrBlockCumLost(buf));
+    EXPECT_EQ(0u, rrBlockJitter(buf));
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+TEST_F(RtcpFunctionalityTest, jitterFirstPacketDoesNotSpike)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+
+    // Simulate the seeding path of sendPacketToRtpReceiver for the first packet.
+    // The pre-fix bug: delta = transit - 0 (huge), jitter seeded with |delta|/16.
+    // The fix: on !rrSeqInitialized, set transit=transit and jitter=0.
+    UINT64 now = GETTIME();
+    INT64 arrival = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, pT->pJitterBuffer->clockRate);
+    INT64 r_ts = 12345;
+    INT64 transit = arrival - r_ts;
+
+    // First packet — must behave as sendPacketToRtpReceiver does now.
+    EXPECT_FALSE(pT->rrSeqInitialized);
+    pT->rrBaseSeq = 100;
+    pT->rrMaxSeq = 100;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+    pT->pJitterBuffer->transit = (UINT64) transit;
+    pT->pJitterBuffer->jitter = 0.0;
+    pT->inboundStats.received.packetsReceived = 1;
+    pT->jitterBufferSsrc = 0xabcd1234;
+
+    BYTE buf[64];
+    UINT32 len = sizeof(buf);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, now, buf, &len));
+    EXPECT_EQ(0u, rrBlockJitter(buf)) << "first-packet jitter must be zero";
+
+    // Second packet ~20 ms later: small delta, EWMA stays bounded.
+    UINT64 later = now + 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    INT64 arrival2 = KVS_CONVERT_TIMESCALE(later, HUNDREDS_OF_NANOS_IN_A_SECOND, pT->pJitterBuffer->clockRate);
+    INT64 r_ts2 = r_ts + (pT->pJitterBuffer->clockRate * 20 / 1000); // 20 ms in RTP ticks
+    INT64 transit2 = arrival2 - r_ts2;
+    INT64 delta = transit2 - (INT64) pT->pJitterBuffer->transit;
+    pT->pJitterBuffer->transit = (UINT64) transit2;
+    pT->pJitterBuffer->jitter += (ABS(delta) - pT->pJitterBuffer->jitter) / 16.0;
+    pT->inboundStats.received.packetsReceived = 2;
+    pT->rrMaxSeq = 101;
+
+    len = sizeof(buf);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, later, buf, &len));
+    UINT32 jitter = rrBlockJitter(buf);
+    // Generous upper bound — ~100 ms worth of RTP ticks. The pre-fix bug
+    // produced values in the 10^9+ range.
+    EXPECT_LT(jitter, pT->pJitterBuffer->clockRate / 10u) << "jitter " << jitter << " exceeds 100 ms bound";
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
*What was changed?*

- Extracted `rtcpBuildSenderReport` / `rtcpBuildReceiverReport` into `Rtcp.c` (first commit on this branch) so the math sits next to the rest of the RTCP parsing/build logic, and `rtcpReportsCallback` is now ~30 lines of timer/srtp/send glue via a shared `sendBuiltRtcpReport` helper.
- Fixed two math bugs in the RR pipeline surfaced by pcap analysis of a real player session:
  - **First-packet jitter seed** in `sendPacketToRtpReceiver`: on the very first RTP packet `pJitterBuffer->transit` is zero, so `delta = transit - 0` is huge (~10^12 for 90 kHz video), seeding the EWMA with ~10^11 and decaying over hundreds of packets. Now captures `firstPacket = !rrSeqInitialized` before `rrInitSeq` flips it, seeds `transit` and zeroes `jitter` on the first packet per RFC 3550 §A.8, and uses an explicit `(INT64)` cast on the subtraction for subsequent packets.
  - **Unsigned `rrLostInterval` underflow** in `rtcpBuildReceiverReport`: when reorder/duplicates make `receivedInterval > expectedInterval`, the UINT32 subtraction wraps to a huge value, bypasses the `== 0` guard, and produces a pseudo-random fraction (a real report showed `frac_lost=87 / 34%` while `cum_lost=0`). Now uses signed `INT32 rrLostInterval` with a `<= 0` guard per RFC 3550 §A.3. `rrCumulativeLost` is also now computed directly as signed to drop the unsigned-to-signed cast trap.
- Added three new unit tests in `RtcpFunctionalityTest` that actually invoke `rtcpBuildReceiverReport` and decode the emitted wire bytes, rather than inlining the builder math into the assertion like the existing tests do.
- Tightened the existing end-to-end assertion in `PeerConnectionFunctionalityTest`: the old `EXPECT_GE(jitter, 0.0)` was too loose because the bug produces a positive value (~47 000 s from a UINT32-saturated wire field). Added `EXPECT_LT(jitter, 1.0)` on both video and audio.

*Why was it changed?*

Analysis of `dev_20260409T161932Z_Player_9dab4_last_4c0cd2c.pcap` (produced by `samples/pcapDump.c` on a real player session) showed the outgoing RRs carry values that don't pass RFC 3550 §6.4.1 / Appendix A.3 sanity checks — wild jitter values monotonically decaying from 10^9 down, and internally inconsistent `frac_lost` / `cum_lost` pairs. These fields feed remote bandwidth estimators and diagnostics, so bogus values can misguide congestion control on the peer and make debug traces untrustworthy. See `kinesis-docs/RTCP_RR_MATH_FIXES.md` for the full root-cause analysis.

The builder extraction in the first commit is prerequisite scaffolding: with SR/RR construction still inlined in `rtcpReportsCallback`, there was no way to unit-test the wire-format output directly — existing RR tests had drifted into copying the buggy math into the test body.

*How was it changed?*

- `src/source/PeerConnection/Rtcp.c`: two new pure builders (`rtcpBuildSenderReport`, `rtcpBuildReceiverReport`) that write unencrypted bytes into a caller-provided buffer and signal "nothing to send" via `*pPacketLen = 0`. RR builder now uses signed `INT32 rrLostInterval` and signed `rrCumulativeLost` computed directly.
- `src/source/PeerConnection/Rtcp.h`: forward declarations for the two builders.
- `src/source/PeerConnection/PeerConnection.c`: `rtcpReportsCallback` collapsed from ~160 lines to ~30 via a new static `sendBuiltRtcpReport` helper that owns the alloc → memcpy → pcap dump → encrypt → ice-send → free sequence. `sendPacketToRtpReceiver` now branches on `firstPacket` to seed the jitter EWMA correctly.
- `tst/RtcpFunctionalityTest.cpp`: three new tests — `receiverReportReorderedDuplicate`, `receiverReportFirstReportEmitsZeroJitter`, `jitterFirstPacketDoesNotSpike` — that drive the extracted builders and decode wire bytes via small `rrBlock*` helpers.
- `tst/PeerConnectionFunctionalityTest.cpp`: added `EXPECT_LT(jitter, 1.0)` upper bounds next to the existing `EXPECT_GE(jitter, 0.0)` for both video and audio remote inbound stats.

*What testing was done for the changes?*

- Full `RtcpFunctionalityTest` suite passes 30/30 (27 existing + 3 new) on `build-mac-clang-static-mbedtls`.
- Verified `kvsWebrtcClient` and `webrtc_client_test` build cleanly with no new warnings.
- Rebased on `origin/main` (already up to date, no conflicts) and re-ran tests.
- Note: `PeerConnectionFunctionalityTest.fullCycleVideoAudioDataChannel` fails on this branch, but a stash-and-rebuild on the baseline commit reproduces the same failure — it is a pre-existing issue unrelated to these changes, with `reportsReceived == 0` meaning no RR ever reached the offer in that test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.