### PR TITLE
Full ICE-lite implementation

### DIFF
--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -65,17 +65,20 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/bbbH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/girH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/h265SampleFrames" DESTINATION .)
 
-# Symlink the source html/ directory into the build output so edits to
-# index.html / client.js are picked up live — just refresh the browser, no
-# rebuild or reconfigure needed. We remove any stale copy/directory first so
-# this works cleanly on incremental builds that previously used file(COPY).
-add_custom_target(samples_html ALL
-    COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/html"
-    COMMAND ${CMAKE_COMMAND} -E create_symlink
-            "${CMAKE_CURRENT_SOURCE_DIR}/html"
-            "${CMAKE_CURRENT_BINARY_DIR}/html"
-    COMMENT "Linking samples/html → build"
-    VERBATIM)
+# Expose html/ to the WHEP/WHIP servers. On Unix we symlink the source tree
+# into the build dir so edits to index.html / client.js are picked up live —
+# just refresh the browser, no rebuild or reconfigure needed. On Windows (or
+# anywhere symlinks are unavailable) we fall back to a configure-time copy.
+# Done at configure time so we don't need an add_custom_target — cmake -E rm
+# is only available from CMake 3.17 and breaks the GCC 4.4 / CMake 3.16 CI.
+if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/html" AND NOT IS_SYMLINK "${CMAKE_CURRENT_BINARY_DIR}/html")
+    file(REMOVE_RECURSE "${CMAKE_CURRENT_BINARY_DIR}/html")
+endif()
+if(UNIX)
+    file(CREATE_LINK "${CMAKE_CURRENT_SOURCE_DIR}/html" "${CMAKE_CURRENT_BINARY_DIR}/html" SYMBOLIC)
+else()
+    file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/html" DESTINATION .)
+endif()
 
 if (ENABLE_SIGNALING)
 add_executable(
@@ -106,7 +109,6 @@ add_executable(
         whepServer.cpp)
 target_link_libraries(whepServer kvsWebrtcClient ${EXTRA_DEPS} kvspicUtils)
 set_target_properties(whepServer PROPERTIES CXX_STANDARD 17)
-add_dependencies(whepServer samples_html)
 
 # WHIP Server (C++ HTTP-based WebRTC ingestion per RFC 9725)
 add_executable(
@@ -115,7 +117,6 @@ add_executable(
         whipServer.cpp)
 target_link_libraries(whipServer kvsWebrtcClient ${EXTRA_DEPS} kvspicUtils)
 set_target_properties(whipServer PROPERTIES CXX_STANDARD 17)
-add_dependencies(whipServer samples_html)
 
 add_executable(
         discoverNatBehavior

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -64,8 +64,17 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/h264SampleFrames" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/bbbH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/girH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/h265SampleFrames" DESTINATION .)
-# html assets served by the WHEP/WHIP servers
-file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/html" DESTINATION .)
+
+# Mirror the html/ directory into the build output on every build so edits to
+# index.html / client.js show up without re-running CMake. file(COPY ...) only
+# runs at configure time. The whepServer / whipServer targets below depend on
+# this, so building either one re-syncs the html assets.
+add_custom_target(samples_html ALL
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+            "${CMAKE_CURRENT_SOURCE_DIR}/html"
+            "${CMAKE_CURRENT_BINARY_DIR}/html"
+    COMMENT "Syncing samples/html → build"
+    VERBATIM)
 
 if (ENABLE_SIGNALING)
 add_executable(
@@ -96,6 +105,7 @@ add_executable(
         whepServer.cpp)
 target_link_libraries(whepServer kvsWebrtcClient ${EXTRA_DEPS} kvspicUtils)
 set_target_properties(whepServer PROPERTIES CXX_STANDARD 17)
+add_dependencies(whepServer samples_html)
 
 # WHIP Server (C++ HTTP-based WebRTC ingestion per RFC 9725)
 add_executable(
@@ -104,6 +114,7 @@ add_executable(
         whipServer.cpp)
 target_link_libraries(whipServer kvsWebrtcClient ${EXTRA_DEPS} kvspicUtils)
 set_target_properties(whipServer PROPERTIES CXX_STANDARD 17)
+add_dependencies(whipServer samples_html)
 
 add_executable(
         discoverNatBehavior

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -65,15 +65,16 @@ file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/bbbH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/girH264" DESTINATION .)
 file(COPY "${CMAKE_CURRENT_SOURCE_DIR}/h265SampleFrames" DESTINATION .)
 
-# Mirror the html/ directory into the build output on every build so edits to
-# index.html / client.js show up without re-running CMake. file(COPY ...) only
-# runs at configure time. The whepServer / whipServer targets below depend on
-# this, so building either one re-syncs the html assets.
+# Symlink the source html/ directory into the build output so edits to
+# index.html / client.js are picked up live — just refresh the browser, no
+# rebuild or reconfigure needed. We remove any stale copy/directory first so
+# this works cleanly on incremental builds that previously used file(COPY).
 add_custom_target(samples_html ALL
-    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    COMMAND ${CMAKE_COMMAND} -E rm -rf "${CMAKE_CURRENT_BINARY_DIR}/html"
+    COMMAND ${CMAKE_COMMAND} -E create_symlink
             "${CMAKE_CURRENT_SOURCE_DIR}/html"
             "${CMAKE_CURRENT_BINARY_DIR}/html"
-    COMMENT "Syncing samples/html → build"
+    COMMENT "Linking samples/html → build"
     VERBATIM)
 
 if (ENABLE_SIGNALING)

--- a/samples/html/client.js
+++ b/samples/html/client.js
@@ -117,7 +117,32 @@ function negotiate() {
     });
 }
 
+// Measure wall-clock time from "Start" click to the first frame the browser renders to the <video> element.
+// Uses requestVideoFrameCallback (Chromium/Safari, Firefox >=131) when available — it fires exactly when a
+// decoded frame is ready for the compositor. Falls back to the 'playing' event for older browsers, which fires
+// after playback has begun (i.e. at least one frame is already visible).
+function armFirstFrameTimer(startPerfNow) {
+    const videoEl = document.getElementById('video');
+    const ttffEl = document.getElementById('ttff');
+    let reported = false;
+    const report = () => {
+        if (reported) return;
+        reported = true;
+        const deltaMs = performance.now() - startPerfNow;
+        ttffEl.textContent = deltaMs.toFixed(0) + ' ms';
+    };
+    if (typeof videoEl.requestVideoFrameCallback === 'function') {
+        videoEl.requestVideoFrameCallback(() => report());
+    } else {
+        videoEl.addEventListener('playing', report, {once: true});
+    }
+}
+
 async function start() {
+    const startPerfNow = performance.now();
+    document.getElementById('ttff').textContent = 'waiting…';
+    armFirstFrameTimer(startPerfNow);
+
     let config = {
         sdpSemantics: 'unified-plan'
     };

--- a/samples/html/client.js
+++ b/samples/html/client.js
@@ -57,9 +57,17 @@ async function reportFecStats() {
 function negotiate() {
     pc.addTransceiver('video', {direction: 'recvonly'});
     pc.addTransceiver('audio', {direction: 'recvonly'});
+    const assumeIceLite = document.getElementById('assume-ice-lite').checked;
     return pc.createOffer().then((offer) => {
         return pc.setLocalDescription(offer);
     }).then(() => {
+        // When assuming an ICE-lite server, skip the gather wait and post the bare offer immediately (no
+        // a=candidate lines). The server will still emit its own host candidates in the answer; our probes
+        // against them will reach it, and a lite peer learns us via peer-reflexive from the incoming binding
+        // request — no trickle channel needed.
+        if (assumeIceLite) {
+            return;
+        }
         // wait for ICE gathering to complete
         return new Promise((resolve) => {
             if (pc.iceGatheringState === 'complete') {

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -30,6 +30,9 @@
     Signaling state: <span id="signaling-state"></span>
 </p>
 <p>
+    Time to first frame: <span id="ttff">—</span>
+</p>
+<p>
     Audio RED negotiated: <span id="audio-red-status">—</span>
 </p>
 <p>

--- a/samples/html/index.html
+++ b/samples/html/index.html
@@ -52,6 +52,10 @@
     <input id="use-stun" type="checkbox"/>
     <label for="use-stun">Use STUN server</label>
 </div>
+<div class="option">
+    <input id="assume-ice-lite" type="checkbox"/>
+    <label for="assume-ice-lite">Assume ICE-lite server (send offer without candidates)</label>
+</div>
 <button id="start" onclick="start()">Start</button>
 <button id="stop" style="display: none" onclick="stop()">Stop</button>
 

--- a/samples/whepServer.cpp
+++ b/samples/whepServer.cpp
@@ -35,6 +35,7 @@ struct WhepSession {
     std::thread audioThread;
     char stunServer[256];
     bool enableAudio;
+    bool iceLiteMode;
 };
 
 static WhepSession g_session;
@@ -491,7 +492,7 @@ static void setupRoutes(httplib::Server& svr, WhepSession* session)
 }
 
 // Initialize session
-static void initSession(WhepSession* session, const char* stunServer, bool enableAudio)
+static void initSession(WhepSession* session, const char* stunServer, bool enableAudio, bool iceLiteMode)
 {
     MEMSET(session, 0, SIZEOF(WhepSession));
 
@@ -500,6 +501,7 @@ static void initSession(WhepSession* session, const char* stunServer, bool enabl
     session->rtcConfig.kvsRtcConfiguration.iceCandidateNominationTimeout = 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
     session->rtcConfig.kvsRtcConfiguration.iceConnectionCheckTimeout = 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
     session->rtcConfig.kvsRtcConfiguration.useRedForOpus = TRUE;
+    session->rtcConfig.kvsRtcConfiguration.iceLiteMode = iceLiteMode ? TRUE : FALSE;
     if (STRLEN(stunServer) > 0) {
         STRNCPY(session->rtcConfig.iceServers[0].urls, stunServer, MAX_ICE_CONFIG_URI_LEN);
         STRNCPY(session->stunServer, stunServer, SIZEOF(session->stunServer) - 1);
@@ -507,6 +509,7 @@ static void initSession(WhepSession* session, const char* stunServer, bool enabl
 
     // Audio config
     session->enableAudio = enableAudio;
+    session->iceLiteMode = iceLiteMode;
 
     // Initialize atomics
     session->iceGatheringDone.store(false);
@@ -549,6 +552,7 @@ int main(int argc, char* argv[])
     // const char* stunServer = "stun:stun.l.google.com:19302";
     const char* stunServer = "";
     bool enableAudio = false;
+    bool iceLiteMode = false;
 
     // Parse command line arguments
     for (int i = 1; i < argc; i++) {
@@ -558,11 +562,14 @@ int main(int argc, char* argv[])
             stunServer = argv[++i];
         } else if (strcmp(argv[i], "--audio") == 0) {
             enableAudio = true;
+        } else if (strcmp(argv[i], "--ice-lite") == 0) {
+            iceLiteMode = true;
         } else if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
-            printf("Usage: %s [--port PORT] [--stun STUN_URL] [--audio]\n", argv[0]);
+            printf("Usage: %s [--port PORT] [--stun STUN_URL] [--audio] [--ice-lite]\n", argv[0]);
             printf("  --port PORT     HTTP server port (default: 8080)\n");
-            printf("  --stun STUN_URL STUN server URL (default: stun:stun.l.google.com:19302)\n");
+            printf("  --stun STUN_URL STUN server URL (default: none)\n");
             printf("  --audio         Enable audio streaming (default: disabled)\n");
+            printf("  --ice-lite      Run as an ICE-lite agent (host-only, never probes).\n");
             return 0;
         }
     }
@@ -577,7 +584,7 @@ int main(int argc, char* argv[])
     }
 
     // Initialize session
-    initSession(&g_session, stunServer, enableAudio);
+    initSession(&g_session, stunServer, enableAudio, iceLiteMode);
 
     // Create HTTP server
     httplib::Server svr;
@@ -588,8 +595,9 @@ int main(int argc, char* argv[])
 
     // Start listening
     printf("[WHEP] WHEP Server listening on http://0.0.0.0:%d\n", port);
-    printf("[WHEP] Using STUN server: %s\n", stunServer);
+    printf("[WHEP] Using STUN server: %s\n", STRLEN(stunServer) > 0 ? stunServer : "(none)");
     printf("[WHEP] Audio streaming: %s\n", enableAudio ? "enabled" : "disabled");
+    printf("[WHEP] ICE-lite mode: %s\n", iceLiteMode ? "enabled" : "disabled");
     printf("[WHEP] Open browser to http://localhost:%d and click Start\n", port);
 
     svr.listen("0.0.0.0", port);

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -436,6 +436,13 @@ extern "C" {
  */
 
 /**
+ * Buffer size for an IPv4 or IPv6 address string, including null terminator.
+ * For IPv6: 0000:0000:0000:0000:0000:0000:0000:0000 = 39
+ * For IPv4-mapped IPv6: 0000:0000:0000:0000:0000:ffff:192.168.100.228 = 45
+ */
+#define KVS_IP_ADDRESS_STRING_BUFFER_LEN 46
+
+/**
  * Maximum allowed channel name length
  */
 #define MAX_CHANNEL_NAME_LEN 256
@@ -1306,6 +1313,15 @@ typedef struct {
     BOOL iceLiteMode; //!< When TRUE, agent operates as ICE-lite (RFC 8445 §2.5).
                       //!< Only host candidates are gathered, no connectivity checks are initiated.
                       //!< The agent always assumes the controlled role.
+                      //!< To deploy an ICE-lite server behind 1:1 NAT or a load balancer, set announcedIpAddress
+                      //!< to the externally reachable IP — lite agents do not gather srflx/relay and otherwise
+                      //!< have no way to learn their public address.
+
+    CHAR announcedIpAddress[KVS_IP_ADDRESS_STRING_BUFFER_LEN]; //!< When non-empty, host candidates emit this address in SDP instead of the real
+                                                               //!< bind address. Sockets still listen on the locally-gathered interface IPs.
+                                                               //!< Accepts an IPv4 or IPv6 literal. Primary use: deploying an ICE-lite server
+                                                               //!< behind 1:1 NAT / a load balancer where the public IP is not assigned to any
+                                                               //!< local interface. Leave empty (default) to emit real interface IPs.
 
 #ifdef ENABLE_STATS_CALCULATION_CONTROL
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined

--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Include.h
@@ -1303,6 +1303,10 @@ typedef struct {
     UINT8 redForOpusRedundancy; //!< Number of prior Opus frames carried as redundancy in each RED packet. Clamped to 1..9.
                                 //!< If 0, defaults to 1 (Chrome/libwebrtc default). Ignored when useRedForOpus is FALSE.
 
+    BOOL iceLiteMode; //!< When TRUE, agent operates as ICE-lite (RFC 8445 §2.5).
+                      //!< Only host candidates are gathered, no connectivity checks are initiated.
+                      //!< The agent always assumes the controlled role.
+
 #ifdef ENABLE_STATS_CALCULATION_CONTROL
     BOOL enableIceStats; //!< Control whether ICE agent stats are to be calculated. ENABLE_STATS_CALCULATION_CONTROL compiler flag must be defined
                          //!< to use this member, else stats are enabled by default.

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -529,6 +529,25 @@ STATUS iceAgentInitHostCandidate(PIceAgent pIceAgent)
     PSocketConnection pSocketConnection = NULL;
     BOOL locked = FALSE;
 
+    // Parse announcedIpAddress once (if configured). Failing to parse is fatal — silently falling back to the bind IP
+    // would produce candidates the user did not expect.
+    KvsIpAddress announcedIpAddr;
+    BOOL hasAnnouncedIp = FALSE;
+    MEMSET(&announcedIpAddr, 0x00, SIZEOF(KvsIpAddress));
+    if (pIceAgent->kvsRtcConfiguration.announcedIpAddress[0] != '\0') {
+        PCHAR announcedStr = pIceAgent->kvsRtcConfiguration.announcedIpAddress;
+        if (inet_pton(AF_INET, announcedStr, announcedIpAddr.address) == 1) {
+            announcedIpAddr.family = KVS_IP_FAMILY_TYPE_IPV4;
+            hasAnnouncedIp = TRUE;
+        } else if (inet_pton(AF_INET6, announcedStr, announcedIpAddr.address) == 1) {
+            announcedIpAddr.family = KVS_IP_FAMILY_TYPE_IPV6;
+            hasAnnouncedIp = TRUE;
+        } else {
+            DLOGE("Invalid announcedIpAddress '%s' — must be an IPv4 or IPv6 literal", announcedStr);
+            CHK(FALSE, STATUS_INVALID_ARG);
+        }
+    }
+
     for (i = 0; i < pIceAgent->localNetworkInterfaceCount; ++i) {
         pIpAddress = &pIceAgent->localNetworkInterfaces[i];
 
@@ -553,6 +572,13 @@ STATUS iceAgentInitHostCandidate(PIceAgent pIceAgent)
             pTmpIceCandidate->foundation = pIceAgent->foundationCounter++;
             pTmpIceCandidate->pSocketConnection = pSocketConnection;
             pTmpIceCandidate->priority = computeCandidatePriority(pTmpIceCandidate);
+
+            // Presentation-only override for SDP emission; port is taken from the bound socket (pIpAddress->port).
+            if (hasAnnouncedIp && pIpAddress->family == announcedIpAddr.family) {
+                pTmpIceCandidate->hasAnnouncedAddress = TRUE;
+                pTmpIceCandidate->announcedIpAddress = announcedIpAddr;
+                pTmpIceCandidate->announcedIpAddress.port = pIpAddress->port;
+            }
 
             /* Another thread could be calling iceAgentAddRemoteCandidate which triggers createIceCandidatePairs.
              * createIceCandidatePairs will read through localCandidates, since we are mutating localCandidates here,
@@ -1708,8 +1734,7 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     }
     /* stop scheduling if there is a nominated candidate pair (in cases where the pair does not have relay, which is set via stopGathering flag), no
      * more pending candidate and relay candidates are added or if timeout is reached. */
-    if (ATOMIC_LOAD_BOOL(&pIceAgent->stopGathering) ||
-        (pIceAgent->isLiteAgent && totalCandidateCount > 0 && pendingCandidateCount == 0) ||
+    if (ATOMIC_LOAD_BOOL(&pIceAgent->stopGathering) || (pIceAgent->isLiteAgent && totalCandidateCount > 0 && pendingCandidateCount == 0) ||
         (totalCandidateCount > 0 && pendingCandidateCount == 0 && ATOMIC_LOAD_BOOL(&pIceAgent->addedRelayCandidate)) ||
         currentTime >= pIceAgent->candidateGatheringEndTime) {
         DLOGI("Candidate gathering completed.");
@@ -2573,27 +2598,30 @@ STATUS iceCandidateSerialize(PIceCandidate pIceCandidate, PCHAR pOutputData, PUI
 {
     STATUS retStatus = STATUS_SUCCESS;
     INT32 amountWritten = 0;
+    PKvsIpAddress pIpAddress = NULL;
 
     CHK(pIceCandidate != NULL && pOutputLength != NULL, STATUS_NULL_ARG);
 
+    // Emit the announced IP instead of the real bind address when configured (presentation-only override).
+    pIpAddress = pIceCandidate->hasAnnouncedAddress ? &pIceCandidate->announcedIpAddress : &pIceCandidate->ipAddress;
+
     // TODO FIXME real source of randomness
-    if (IS_IPV4_ADDR(&(pIceCandidate->ipAddress))) {
-        amountWritten = SNPRINTF(pOutputData, pOutputData == NULL ? 0 : *pOutputLength,
-                                 "%u 1 udp %u %d.%d.%d.%d %d typ %s raddr 0.0.0.0 rport 0 generation 0 network-cost 999", pIceCandidate->foundation,
-                                 pIceCandidate->priority, pIceCandidate->ipAddress.address[0], pIceCandidate->ipAddress.address[1],
-                                 pIceCandidate->ipAddress.address[2], pIceCandidate->ipAddress.address[3],
-                                 (UINT16) getInt16(pIceCandidate->ipAddress.port), iceAgentGetCandidateTypeStr(pIceCandidate->iceCandidateType));
+    if (IS_IPV4_ADDR(pIpAddress)) {
+        amountWritten =
+            SNPRINTF(pOutputData, pOutputData == NULL ? 0 : *pOutputLength,
+                     "%u 1 udp %u %d.%d.%d.%d %d typ %s raddr 0.0.0.0 rport 0 generation 0 network-cost 999", pIceCandidate->foundation,
+                     pIceCandidate->priority, pIpAddress->address[0], pIpAddress->address[1], pIpAddress->address[2], pIpAddress->address[3],
+                     (UINT16) getInt16(pIpAddress->port), iceAgentGetCandidateTypeStr(pIceCandidate->iceCandidateType));
     } else {
-        amountWritten = SNPRINTF(pOutputData, pOutputData == NULL ? 0 : *pOutputLength,
-                                 "%u 1 udp %u %02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X "
-                                 "%d typ %s raddr ::/0 rport 0 generation 0 network-cost 999",
-                                 pIceCandidate->foundation, pIceCandidate->priority, pIceCandidate->ipAddress.address[0],
-                                 pIceCandidate->ipAddress.address[1], pIceCandidate->ipAddress.address[2], pIceCandidate->ipAddress.address[3],
-                                 pIceCandidate->ipAddress.address[4], pIceCandidate->ipAddress.address[5], pIceCandidate->ipAddress.address[6],
-                                 pIceCandidate->ipAddress.address[7], pIceCandidate->ipAddress.address[8], pIceCandidate->ipAddress.address[9],
-                                 pIceCandidate->ipAddress.address[10], pIceCandidate->ipAddress.address[11], pIceCandidate->ipAddress.address[12],
-                                 pIceCandidate->ipAddress.address[13], pIceCandidate->ipAddress.address[14], pIceCandidate->ipAddress.address[15],
-                                 (UINT16) getInt16(pIceCandidate->ipAddress.port), iceAgentGetCandidateTypeStr(pIceCandidate->iceCandidateType));
+        amountWritten =
+            SNPRINTF(pOutputData, pOutputData == NULL ? 0 : *pOutputLength,
+                     "%u 1 udp %u %02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X:%02X%02X "
+                     "%d typ %s raddr ::/0 rport 0 generation 0 network-cost 999",
+                     pIceCandidate->foundation, pIceCandidate->priority, pIpAddress->address[0], pIpAddress->address[1], pIpAddress->address[2],
+                     pIpAddress->address[3], pIpAddress->address[4], pIpAddress->address[5], pIpAddress->address[6], pIpAddress->address[7],
+                     pIpAddress->address[8], pIpAddress->address[9], pIpAddress->address[10], pIpAddress->address[11], pIpAddress->address[12],
+                     pIpAddress->address[13], pIpAddress->address[14], pIpAddress->address[15], (UINT16) getInt16(pIpAddress->port),
+                     iceAgentGetCandidateTypeStr(pIceCandidate->iceCandidateType));
     }
 
     CHK_WARN(amountWritten > 0, STATUS_INTERNAL_ERROR, "SNPRINTF failed");
@@ -2641,6 +2669,26 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
             connectivityCheckRequestsReceived++;
             CHK_STATUS(deserializeStunPacket(pBuffer, bufferLen, (PBYTE) pIceAgent->localPassword,
                                              (UINT32) STRLEN(pIceAgent->localPassword) * SIZEOF(CHAR), &pStunPacket));
+
+            // RFC 8445 §7.3.1.1: a lite agent is always controlled. If the remote peer signals ICE-CONTROLLED, that is a
+            // role conflict — reply with a 487 Binding Error Response and do not process the request further.
+            if (pIceAgent->isLiteAgent) {
+                PStunAttributeHeader pIceControlledAttr = NULL;
+                CHK_STATUS(getStunAttribute(pStunPacket, STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED, &pIceControlledAttr));
+                if (pIceControlledAttr != NULL) {
+                    DLOGW("ICE-lite: received Binding Request with ICE-CONTROLLED from remote; replying 487 Role Conflict");
+                    CHK_STATUS(createStunPacket(STUN_PACKET_TYPE_BINDING_RESPONSE_ERROR, pStunPacket->header.transactionId, &pStunResponse));
+                    CHK_STATUS(appendStunErrorCodeAttribute(pStunResponse, (PCHAR) "Role Conflict", 487));
+                    CHK_STATUS(findCandidateWithSocketConnection(pSocketConnection, pIceAgent->localCandidates, &pIceCandidate));
+                    if (pIceCandidate != NULL) {
+                        iceAgentSendStunPacket(pStunResponse, (PBYTE) pIceAgent->localPassword,
+                                               (UINT32) STRLEN(pIceAgent->localPassword) * SIZEOF(CHAR), pIceAgent, pIceCandidate, pSrcAddr);
+                    }
+                    // stop processing; CleanUp will free pStunPacket and pStunResponse
+                    CHK(FALSE, retStatus);
+                }
+            }
+
             CHK_STATUS(createStunPacket(STUN_PACKET_TYPE_BINDING_RESPONSE_SUCCESS, pStunPacket->header.transactionId, &pStunResponse));
             CHK_STATUS(appendStunAddressAttribute(pStunResponse, STUN_ATTRIBUTE_TYPE_XOR_MAPPED_ADDRESS, pSrcAddr));
             CHK_STATUS(appendStunIceControllAttribute(

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -849,23 +849,31 @@ STATUS iceAgentShutdown(PIceAgent pIceAgent)
     UINT64 turnShutdownTimeout;
     PTurnConnection turnConnections[KVS_ICE_MAX_RELAY_CANDIDATE_COUNT];
     UINT32 turnConnectionCount = 0;
+    UINT32 stateTimerTask = MAX_UINT32, keepAliveTask = MAX_UINT32, gatheringTask = MAX_UINT32;
 
     CHK(pIceAgent != NULL, STATUS_NULL_ARG);
     CHK(!ATOMIC_EXCHANGE_BOOL(&pIceAgent->shutdown, TRUE), retStatus);
 
-    if (pIceAgent->iceAgentStateTimerTask != MAX_UINT32) {
-        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceAgentStateTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
-    }
+    // Capture and clear the timer-task handles under the lock to synchronize with timer callbacks that may be
+    // self-cancelling (writing MAX_UINT32 under the same lock). Cancel outside the lock to avoid blocking on a
+    // running callback that is itself waiting for this lock.
+    MUTEX_LOCK(pIceAgent->lock);
+    stateTimerTask = pIceAgent->iceAgentStateTimerTask;
+    pIceAgent->iceAgentStateTimerTask = MAX_UINT32;
+    keepAliveTask = pIceAgent->keepAliveTimerTask;
+    pIceAgent->keepAliveTimerTask = MAX_UINT32;
+    gatheringTask = pIceAgent->iceCandidateGatheringTimerTask;
+    pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
+    MUTEX_UNLOCK(pIceAgent->lock);
 
-    if (pIceAgent->keepAliveTimerTask != MAX_UINT32) {
-        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->keepAliveTimerTask, (UINT64) pIceAgent));
-        pIceAgent->keepAliveTimerTask = MAX_UINT32;
+    if (stateTimerTask != MAX_UINT32) {
+        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, stateTimerTask, (UINT64) pIceAgent));
     }
-
-    if (pIceAgent->iceCandidateGatheringTimerTask != MAX_UINT32) {
-        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, pIceAgent->iceCandidateGatheringTimerTask, (UINT64) pIceAgent));
-        pIceAgent->iceCandidateGatheringTimerTask = MAX_UINT32;
+    if (keepAliveTask != MAX_UINT32) {
+        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, keepAliveTask, (UINT64) pIceAgent));
+    }
+    if (gatheringTask != MAX_UINT32) {
+        CHK_STATUS(timerQueueCancelTimer(pIceAgent->timerQueueHandle, gatheringTask, (UINT64) pIceAgent));
     }
 
     MUTEX_LOCK(pIceAgent->lock);

--- a/src/source/Ice/IceAgent.c
+++ b/src/source/Ice/IceAgent.c
@@ -53,6 +53,8 @@ STATUS createIceAgent(PCHAR username, PCHAR password, PIceAgentCallbacks pIceAge
     pIceAgent->tieBreaker = (UINT64) RAND();
     pIceAgent->iceTransportPolicy = pRtcConfiguration->iceTransportPolicy;
     pIceAgent->kvsRtcConfiguration = pRtcConfiguration->kvsRtcConfiguration;
+    pIceAgent->isLiteAgent = pRtcConfiguration->kvsRtcConfiguration.iceLiteMode;
+    pIceAgent->remoteIsLiteAgent = FALSE;
     CHK_STATUS(iceAgentValidateKvsRtcConfig(&pIceAgent->kvsRtcConfiguration));
 
     if (pIceAgentCallbacks != NULL) {
@@ -661,12 +663,18 @@ STATUS iceAgentStartGathering(PIceAgent pIceAgent)
                                 pIceAgent->iceAgentProfileDiagnostics.localCandidateGatheringTime, "Host candidate gathering from local interfaces");
         PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentInitHostCandidate(pIceAgent)), pIceAgent->iceAgentProfileDiagnostics.hostCandidateSetUpTime,
                                 "Host candidates setup time");
-        PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentInitSrflxCandidate(pIceAgent)), pIceAgent->iceAgentProfileDiagnostics.srflxCandidateSetUpTime,
-                                "Srflx candidates setup time");
+        // ICE-lite agents only gather host candidates — skip srflx
+        if (!pIceAgent->isLiteAgent) {
+            PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentInitSrflxCandidate(pIceAgent)), pIceAgent->iceAgentProfileDiagnostics.srflxCandidateSetUpTime,
+                                    "Srflx candidates setup time");
+        }
     }
 
-    PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentInitRelayCandidates(pIceAgent)), pIceAgent->iceAgentProfileDiagnostics.relayCandidateSetUpTime,
-                            "Relay candidates setup time");
+    // ICE-lite agents do not use relay candidates
+    if (!pIceAgent->isLiteAgent) {
+        PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentInitRelayCandidates(pIceAgent)), pIceAgent->iceAgentProfileDiagnostics.relayCandidateSetUpTime,
+                                "Relay candidates setup time");
+    }
 
     // start listening for incoming data
     CHK_STATUS(connectionListenerStart(pIceAgent->pConnectionListener));
@@ -1701,6 +1709,7 @@ STATUS iceAgentGatherCandidateTimerCallback(UINT32 timerId, UINT64 currentTime, 
     /* stop scheduling if there is a nominated candidate pair (in cases where the pair does not have relay, which is set via stopGathering flag), no
      * more pending candidate and relay candidates are added or if timeout is reached. */
     if (ATOMIC_LOAD_BOOL(&pIceAgent->stopGathering) ||
+        (pIceAgent->isLiteAgent && totalCandidateCount > 0 && pendingCandidateCount == 0) ||
         (totalCandidateCount > 0 && pendingCandidateCount == 0 && ATOMIC_LOAD_BOOL(&pIceAgent->addedRelayCandidate)) ||
         currentTime >= pIceAgent->candidateGatheringEndTime) {
         DLOGI("Candidate gathering completed.");
@@ -2109,15 +2118,18 @@ STATUS iceAgentCheckConnectionStateSetup(PIceAgent pIceAgent)
         pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_WAITING;
     }
 
-    if (pIceAgent->pBindingRequest != NULL) {
-        CHK_STATUS(freeStunPacket(&pIceAgent->pBindingRequest));
+    // ICE-lite agents do not send binding requests — they only respond to incoming ones
+    if (!pIceAgent->isLiteAgent) {
+        if (pIceAgent->pBindingRequest != NULL) {
+            CHK_STATUS(freeStunPacket(&pIceAgent->pBindingRequest));
+        }
+        CHK_STATUS(createStunPacket(STUN_PACKET_TYPE_BINDING_REQUEST, NULL, &pIceAgent->pBindingRequest));
+        CHK_STATUS(appendStunUsernameAttribute(pIceAgent->pBindingRequest, pIceAgent->combinedUserName));
+        CHK_STATUS(appendStunPriorityAttribute(pIceAgent->pBindingRequest, 0));
+        CHK_STATUS(appendStunIceControllAttribute(pIceAgent->pBindingRequest,
+                                                  pIceAgent->isControlling ? STUN_ATTRIBUTE_TYPE_ICE_CONTROLLING : STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
+                                                  pIceAgent->tieBreaker));
     }
-    CHK_STATUS(createStunPacket(STUN_PACKET_TYPE_BINDING_REQUEST, NULL, &pIceAgent->pBindingRequest));
-    CHK_STATUS(appendStunUsernameAttribute(pIceAgent->pBindingRequest, pIceAgent->combinedUserName));
-    CHK_STATUS(appendStunPriorityAttribute(pIceAgent->pBindingRequest, 0));
-    CHK_STATUS(appendStunIceControllAttribute(pIceAgent->pBindingRequest,
-                                              pIceAgent->isControlling ? STUN_ATTRIBUTE_TYPE_ICE_CONTROLLING : STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED,
-                                              pIceAgent->tieBreaker));
 
     pIceAgent->stateEndTime = GETTIME() + pIceAgent->kvsRtcConfiguration.iceConnectionCheckTimeout;
 
@@ -2661,10 +2673,16 @@ STATUS handleStunPacket(PIceAgent pIceAgent, PBYTE pBuffer, UINT32 bufferLen, PS
                 }
             }
 
-            // schedule a connectivity check for the pair
-            if (pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_FROZEN || pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_WAITING ||
-                pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS) {
-                CHK_STATUS(stackQueueEnqueue(pIceAgent->triggeredCheckQueue, (UINT64) pIceCandidatePair));
+            if (pIceAgent->isLiteAgent) {
+                // ICE-lite: successful binding request/response exchange means the pair is valid.
+                // Mark SUCCEEDED directly since we do not initiate outbound checks.
+                pIceCandidatePair->state = ICE_CANDIDATE_PAIR_STATE_SUCCEEDED;
+            } else {
+                // schedule a connectivity check for the pair
+                if (pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_FROZEN || pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_WAITING ||
+                    pIceCandidatePair->state == ICE_CANDIDATE_PAIR_STATE_IN_PROGRESS) {
+                    CHK_STATUS(stackQueueEnqueue(pIceAgent->triggeredCheckQueue, (UINT64) pIceCandidatePair));
+                }
             }
 
             if (pIceCandidatePair == pIceAgent->pDataSendingIceCandidatePair) {

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -171,6 +171,11 @@ typedef struct {
     BOOL reported;
     CHAR id[ICE_CANDIDATE_ID_LEN + 1];
     KVS_SOCKET_PROTOCOL remoteProtocol;
+
+    /* When TRUE, iceCandidateSerialize emits announcedIpAddress in SDP instead of ipAddress.
+     * The socket still binds on ipAddress; this is a presentation-only override. */
+    BOOL hasAnnouncedAddress;
+    KvsIpAddress announcedIpAddress;
 } IceCandidate, *PIceCandidate;
 
 typedef struct {

--- a/src/source/Ice/IceAgent.h
+++ b/src/source/Ice/IceAgent.h
@@ -271,6 +271,9 @@ struct __IceAgent {
     ICE_TRANSPORT_POLICY iceTransportPolicy;
     KvsRtcConfiguration kvsRtcConfiguration;
 
+    BOOL isLiteAgent;       // TRUE if local agent is ICE-lite (RFC 8445 §2.5)
+    BOOL remoteIsLiteAgent; // TRUE if remote peer signaled a=ice-lite
+
     // Pre-allocated stun packets
     PStunPacket pBindingIndication;
     PStunPacket pBindingRequest;

--- a/src/source/Ice/IceAgentStateMachine.c
+++ b/src/source/Ice/IceAgentStateMachine.c
@@ -511,6 +511,8 @@ STATUS fromReadyIceAgentState(UINT64 customData, PUINT64 pState)
     // move to failed state if any error happened.
     CHK_STATUS(pIceAgent->iceAgentStatus);
 
+    // For ICE-lite agents, this also serves as the RFC 7675 consent-freshness signal: any inbound packet (STUN or media)
+    // updates lastDataReceivedTime, and silence past iceDisconnectionTimeout flips state to DISCONNECTED.
     CHK_STATUS(iceAgentStateMachineCheckDisconnection(pIceAgent, &state));
 
     // return early if changing to disconnected state

--- a/src/source/Ice/IceAgentStateMachine.c
+++ b/src/source/Ice/IceAgentStateMachine.c
@@ -292,7 +292,10 @@ STATUS executeCheckConnectionIceAgentState(UINT64 customData, UINT64 time)
         pIceAgent->iceAgentState = ICE_AGENT_STATE_CHECK_CONNECTION;
     }
 
-    CHK_STATUS(iceAgentCheckCandidatePairConnection(pIceAgent));
+    // ICE-lite agents do not initiate connectivity checks; they only respond to incoming binding requests
+    if (!pIceAgent->isLiteAgent) {
+        CHK_STATUS(iceAgentCheckCandidatePairConnection(pIceAgent));
+    }
 
 CleanUp:
     CHK_LOG_ERR(retStatus);
@@ -465,7 +468,9 @@ STATUS executeNominatingIceAgentState(UINT64 customData, UINT64 time)
         pIceAgent->iceAgentState = ICE_AGENT_STATE_NOMINATING;
     }
 
-    if (pIceAgent->isControlling) {
+    if (pIceAgent->isLiteAgent) {
+        // ICE-lite: wait for the full agent's USE_CANDIDATE binding request (handled in handleStunPacket)
+    } else if (pIceAgent->isControlling) {
         PROFILE_CALL_WITH_T_OBJ(CHK_STATUS(iceAgentSendCandidateNomination(pIceAgent)),
                                 pIceAgent->iceAgentProfileDiagnostics.iceCandidatePairNominationTime, "ICE candidate pair nomination");
     } else {

--- a/src/source/Ice/Network.h
+++ b/src/source/Ice/Network.h
@@ -12,10 +12,7 @@ extern "C" {
 
 #define MAX_LOCAL_NETWORK_INTERFACE_COUNT 128
 
-// string buffer size for ipv4 and ipv6. Null terminator included.
-// for ipv6: 0000:0000:0000:0000:0000:0000:0000:0000 = 39
-// for ipv4 mapped ipv6: 0000:0000:0000:0000:0000:ffff:192.168.100.228 = 45
-#define KVS_IP_ADDRESS_STRING_BUFFER_LEN 46
+// KVS_IP_ADDRESS_STRING_BUFFER_LEN is defined in the public Include.h (used by announcedIpAddress).
 
 // 000.000.000.000
 #define KVS_MAX_IPV4_ADDRESS_STRING_LEN 15

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1942,8 +1942,8 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     }
 
     // This starts the state machine timer callback that transitions states periodically
-    CHK_STATUS(iceAgentStartAgent(pKvsPeerConnection->pIceAgent, pKvsPeerConnection->remoteIceUfrag, pKvsPeerConnection->remoteIcePwd,
-                                  isControlling));
+    CHK_STATUS(
+        iceAgentStartAgent(pKvsPeerConnection->pIceAgent, pKvsPeerConnection->remoteIceUfrag, pKvsPeerConnection->remoteIcePwd, isControlling));
 
     if (!pKvsPeerConnection->isOffer) {
         CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pKvsPeerConnection->pRedTable,

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1825,6 +1825,7 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     PCHAR remoteIceUfrag = NULL, remoteIcePwd = NULL;
     UINT32 i, j;
     PSessionDescription pSessionDescription;
+    BOOL isControlling;
 
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pPeerConnection;
 
@@ -1860,6 +1861,8 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
         } else if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "ice-options") == 0 &&
                    STRSTR(pSessionDescription->sdpAttributes[i].attributeValue, "trickle") != NULL) {
             NULLABLE_SET_VALUE(pKvsPeerConnection->canTrickleIce, TRUE);
+        } else if (STRCMP(pSessionDescription->sdpAttributes[i].attributeName, "ice-lite") == 0) {
+            pKvsPeerConnection->remoteIsIceLite = TRUE;
         }
     }
 
@@ -1923,9 +1926,24 @@ STATUS setRemoteDescription(PRtcPeerConnection pPeerConnection, PRtcSessionDescr
     STRNCPY(pKvsPeerConnection->remoteIceUfrag, remoteIceUfrag, MAX_ICE_UFRAG_LEN);
     STRNCPY(pKvsPeerConnection->remoteIcePwd, remoteIcePwd, MAX_ICE_PWD_LEN);
 
+    // Propagate remote ICE-lite flag to the ICE agent
+    pKvsPeerConnection->pIceAgent->remoteIsLiteAgent = pKvsPeerConnection->remoteIsIceLite;
+
+    // ICE role determination per RFC 8445:
+    // - Local lite + remote full → local is always controlled (isControlling = FALSE)
+    // - Local full + remote lite → local is always controlling (isControlling = TRUE)
+    // - Both full or both lite → offerer is controlling
+    if (pKvsPeerConnection->pIceAgent->isLiteAgent && !pKvsPeerConnection->remoteIsIceLite) {
+        isControlling = FALSE;
+    } else if (!pKvsPeerConnection->pIceAgent->isLiteAgent && pKvsPeerConnection->remoteIsIceLite) {
+        isControlling = TRUE;
+    } else {
+        isControlling = pKvsPeerConnection->isOffer;
+    }
+
     // This starts the state machine timer callback that transitions states periodically
     CHK_STATUS(iceAgentStartAgent(pKvsPeerConnection->pIceAgent, pKvsPeerConnection->remoteIceUfrag, pKvsPeerConnection->remoteIcePwd,
-                                  pKvsPeerConnection->isOffer));
+                                  isControlling));
 
     if (!pKvsPeerConnection->isOffer) {
         CHK_STATUS(setPayloadTypesFromOffer(pKvsPeerConnection->pCodecTable, pKvsPeerConnection->pRtxTable, pKvsPeerConnection->pRedTable,

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -170,6 +170,8 @@ typedef struct {
 
     NullableBool canTrickleIce;
 
+    BOOL remoteIsIceLite; // TRUE if remote peer advertised a=ice-lite in SDP
+
     // congestion control (sender side)
     // https://tools.ietf.org/html/draft-holmer-rmcat-transport-wide-cc-extensions-01
     UINT16 twccExtId;

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -1026,6 +1026,12 @@ STATUS populateSessionDescription(PKvsPeerConnection pKvsPeerConnection, PSessio
         pLocalSessionDescription->sessionAttributesCount++;
     }
 
+    if (pKvsPeerConnection->pIceAgent->isLiteAgent) {
+        STRCPY(pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeName, "ice-lite");
+        pLocalSessionDescription->sdpAttributes[pLocalSessionDescription->sessionAttributesCount].attributeValue[0] = '\0';
+        pLocalSessionDescription->sessionAttributesCount++;
+    }
+
     // check all session attribute lines to see if a line with BUNDLE is present. If it is present, copy its content and break
     if (!pKvsPeerConnection->isOffer) {
         for (i = 0; i < pRemoteSessionDescription->sessionAttributesCount; i++) {

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -312,7 +312,6 @@ TEST_F(IceFunctionalityTest, IceAgentIceAgentAddIceServerUnitTest)
     EXPECT_EQ(STATUS_SUCCESS, parseIceServer(&iceServer, (PCHAR) "turn:54.202.170.151:443?randomstuff", (PCHAR) "username", (PCHAR) "password"));
     EXPECT_EQ(iceServer.transport, KVS_SOCKET_PROTOCOL_NONE);
 
-
     //
     // Dual-stack checks.
     //
@@ -320,12 +319,12 @@ TEST_F(IceFunctionalityTest, IceAgentIceAgentAddIceServerUnitTest)
     // Clear the iceServer struct.
     MEMSET(&iceServer, 0x00, SIZEOF(IceServer));
 
-    // Set the env var to enable dual-stack mode.
-    #ifdef _WIN32
-        _putenv_s(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "ON");
-    #else
-        setenv(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "ON", 1);
-    #endif
+// Set the env var to enable dual-stack mode.
+#ifdef _WIN32
+    _putenv_s(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "ON");
+#else
+    setenv(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "ON", 1);
+#endif
 
     std::string test_ipv4_addr = "35-90-63-38";
     std::string test_ipv6_addr = "2001-0db8-85a3-0000-0000-8a2e-0370-7334";
@@ -349,9 +348,11 @@ TEST_F(IceFunctionalityTest, IceAgentIceAgentAddIceServerUnitTest)
 
     // Failing cases: both IPv4 and IPv6 addresses should be present in hostname, else will
     // fallback to getAddrInfo and fail.
-    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, parseIceServer(&iceServer, (PCHAR) ("turn:" + test_ipv4_addr).c_str(), (PCHAR) "username", (PCHAR) "password"));
-    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED, parseIceServer(&iceServer, (PCHAR) ("turn:" + test_ipv6_addr).c_str(), (PCHAR) "username", (PCHAR) "password"));
-    
+    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED,
+              parseIceServer(&iceServer, (PCHAR) ("turn:" + test_ipv4_addr).c_str(), (PCHAR) "username", (PCHAR) "password"));
+    EXPECT_EQ(STATUS_RESOLVE_HOSTNAME_FAILED,
+              parseIceServer(&iceServer, (PCHAR) ("turn:" + test_ipv6_addr).c_str(), (PCHAR) "username", (PCHAR) "password"));
+
     // Clear the iceServer struct again incase of partial population from previous calls.
     MEMSET(&iceServer, 0x00, SIZEOF(IceServer));
 
@@ -377,13 +378,12 @@ TEST_F(IceFunctionalityTest, IceAgentIceAgentAddIceServerUnitTest)
     getIpAddrStr(&iceServer.ipAddresses.ipv6Address, (PCHAR) parsed_ipv6_addr, SIZEOF(parsed_ipv6_addr));
     EXPECT_STREQ(parsed_ipv6_addr, colon_delim_test_ipv6_addr.c_str());
 
-    // Cleanup the env var.
-    #ifdef _WIN32
-        _putenv_s(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "");
-    #else
-        unsetenv(USE_DUAL_STACK_ENDPOINTS_ENV_VAR);
-    #endif   
-
+// Cleanup the env var.
+#ifdef _WIN32
+    _putenv_s(USE_DUAL_STACK_ENDPOINTS_ENV_VAR, "");
+#else
+    unsetenv(USE_DUAL_STACK_ENDPOINTS_ENV_VAR);
+#endif
 }
 
 TEST_F(IceFunctionalityTest, IceAgentAddRemoteCandidateUnitTest)
@@ -772,8 +772,7 @@ TEST_F(IceFunctionalityTest, getLocalhostIpAddressesBasicTest)
         EXPECT_TRUE(ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV4 || ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV6);
         EXPECT_EQ((UINT16) 0, ipAddresses[i].port);
         EXPECT_EQ(STATUS_SUCCESS, getIpAddrStr(&ipAddresses[i], ipAddrStr, SIZEOF(ipAddrStr)));
-        DLOGD("Found interface %u: %s (%s)", i, ipAddrStr,
-              ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV4 ? "IPv4" : "IPv6");
+        DLOGD("Found interface %u: %s (%s)", i, ipAddrStr, ipAddresses[i].family == KVS_IP_FAMILY_TYPE_IPV4 ? "IPv4" : "IPv6");
     }
 }
 
@@ -895,6 +894,237 @@ TEST_F(IceFunctionalityTest, iceLiteAgentFlagDefaultFalse)
 
     EXPECT_FALSE(pIceAgent->isLiteAgent);
     EXPECT_FALSE(pIceAgent->remoteIsLiteAgent);
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
+TEST_F(IceFunctionalityTest, iceLiteAgentRespondsWith487OnIceControlled)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    PStunPacket pRequest = NULL;
+    BYTE txnId[STUN_TRANSACTION_ID_LEN] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12};
+    BYTE serialized[1024] = {0};
+    UINT32 serializedLen = SIZEOF(serialized);
+    KvsIpAddress srcAddr;
+    KvsIpAddress destAddr;
+    UINT32 beforeRemoteCount = 0, afterRemoteCount = 0;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+    MEMSET(&srcAddr, 0x00, SIZEOF(KvsIpAddress));
+    MEMSET(&destAddr, 0x00, SIZEOF(KvsIpAddress));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    // Gather host candidates so we have a local candidate + bound socket to receive on.
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentStartGathering(pIceAgent));
+    THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    PIceCandidate pLocalCandidate = NULL;
+    PDoubleListNode pNode = NULL;
+    ASSERT_EQ(STATUS_SUCCESS, doubleListGetHeadNode(pIceAgent->localCandidates, &pNode));
+    ASSERT_TRUE(pNode != NULL);
+    pLocalCandidate = (PIceCandidate) pNode->data;
+    ASSERT_TRUE(pLocalCandidate != NULL);
+
+    // Build a STUN Binding Request with ICE-CONTROLLED (the protocol-violating case for a lite agent).
+    constexpr UINT32 USERNAME_BUF_LEN = MAX_ICE_CONFIG_USER_NAME_LEN + 1;
+    CHAR combinedUsername[USERNAME_BUF_LEN];
+    SNPRINTF(combinedUsername, USERNAME_BUF_LEN, "%s:fakepeer", pIceAgent->localUsername);
+    EXPECT_EQ(STATUS_SUCCESS, createStunPacket(STUN_PACKET_TYPE_BINDING_REQUEST, txnId, &pRequest));
+    EXPECT_EQ(STATUS_SUCCESS, appendStunUsernameAttribute(pRequest, combinedUsername));
+    EXPECT_EQ(STATUS_SUCCESS, appendStunPriorityAttribute(pRequest, 1000));
+    EXPECT_EQ(STATUS_SUCCESS, appendStunIceControllAttribute(pRequest, STUN_ATTRIBUTE_TYPE_ICE_CONTROLLED, 0xdeadbeefcafef00dULL));
+    // Two-call pattern: first ask for required size, then serialize.
+    serializedLen = 0;
+    EXPECT_EQ(
+        STATUS_SUCCESS,
+        serializeStunPacket(pRequest, (PBYTE) pIceAgent->localPassword, (UINT32) STRLEN(pIceAgent->localPassword), TRUE, TRUE, NULL, &serializedLen));
+    ASSERT_LE(serializedLen, (UINT32) SIZEOF(serialized));
+    EXPECT_EQ(STATUS_SUCCESS,
+              serializeStunPacket(pRequest, (PBYTE) pIceAgent->localPassword, (UINT32) STRLEN(pIceAgent->localPassword), TRUE, TRUE, serialized,
+                                  &serializedLen));
+
+    // Use an arbitrary "remote" src address that is not yet known — if the guard is absent, this would be added as a
+    // peer-reflexive remote candidate.
+    srcAddr.family = KVS_IP_FAMILY_TYPE_IPV4;
+    srcAddr.address[0] = 203;
+    srcAddr.address[1] = 0;
+    srcAddr.address[2] = 113;
+    srcAddr.address[3] = 77;
+    srcAddr.port = htons(54321);
+
+    EXPECT_EQ(STATUS_SUCCESS, doubleListGetNodeCount(pIceAgent->remoteCandidates, &beforeRemoteCount));
+
+    // handleStunPacket should short-circuit — no peer-reflexive candidate added.
+    EXPECT_EQ(STATUS_SUCCESS, handleStunPacket(pIceAgent, serialized, serializedLen, pLocalCandidate->pSocketConnection, &srcAddr, &destAddr));
+
+    EXPECT_EQ(STATUS_SUCCESS, doubleListGetNodeCount(pIceAgent->remoteCandidates, &afterRemoteCount));
+    EXPECT_EQ(beforeRemoteCount, afterRemoteCount);
+
+    freeStunPacket(&pRequest);
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
+TEST_F(IceFunctionalityTest, iceLiteAgentDisconnectsOnSilence)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    UINT64 nextState = 0;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+    configuration.kvsRtcConfiguration.iceDisconnectionTimeout = 1 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    // Simulate a lite agent that has reached READY and then the remote stopped sending everything.
+    // The consent-freshness signal is any inbound packet (STUN or media); 2s without inbound must flip to DISCONNECTED.
+    pIceAgent->iceAgentState = ICE_AGENT_STATE_READY;
+    pIceAgent->lastDataReceivedTime = GETTIME() - 2 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+
+    nextState = ICE_AGENT_STATE_READY;
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentStateMachineCheckDisconnection(pIceAgent, &nextState));
+    EXPECT_EQ((UINT64) ICE_AGENT_STATE_DISCONNECTED, nextState);
+
+    // And recovery: if inbound arrives within the grace period, the machinery flips back to the current state.
+    pIceAgent->detectedDisconnection = TRUE;
+    pIceAgent->disconnectionGracePeriodEndTime = GETTIME() + 10 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    pIceAgent->lastDataReceivedTime = GETTIME();
+    nextState = ICE_AGENT_STATE_DISCONNECTED;
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentStateMachineCheckDisconnection(pIceAgent, &nextState));
+    EXPECT_FALSE(pIceAgent->detectedDisconnection);
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
+TEST_F(IceFunctionalityTest, announcedIpAddressRewritesHostCandidate)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+    CHAR candidateStr[512] = {0};
+    UINT32 candidateStrLen = SIZEOF(candidateStr);
+    BYTE expected[4] = {203, 0, 113, 10};
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+    STRNCPY(configuration.kvsRtcConfiguration.announcedIpAddress, "203.0.113.10", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentStartGathering(pIceAgent));
+    THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    // Every IPv4 host candidate must carry the announced address and emit it in SDP; the bind IP is preserved separately.
+    PDoubleListNode pNode = NULL;
+    UINT32 v4Checked = 0;
+    EXPECT_EQ(STATUS_SUCCESS, doubleListGetHeadNode(pIceAgent->localCandidates, &pNode));
+    while (pNode != NULL) {
+        PIceCandidate pCandidate = (PIceCandidate) pNode->data;
+        pNode = pNode->pNext;
+        if (pCandidate->iceCandidateType != ICE_CANDIDATE_TYPE_HOST || !IS_IPV4_ADDR(&pCandidate->ipAddress)) {
+            continue;
+        }
+        EXPECT_TRUE(pCandidate->hasAnnouncedAddress);
+        EXPECT_EQ(0, MEMCMP(pCandidate->announcedIpAddress.address, expected, 4));
+        // Ensure the real bind IP is NOT the announced one (we're not actually on 203.0.113.10).
+        EXPECT_NE(0, MEMCMP(pCandidate->ipAddress.address, expected, 4));
+        // Port preserved from bind socket.
+        EXPECT_EQ(pCandidate->ipAddress.port, pCandidate->announcedIpAddress.port);
+
+        candidateStrLen = SIZEOF(candidateStr);
+        MEMSET(candidateStr, 0, SIZEOF(candidateStr));
+        EXPECT_EQ(STATUS_SUCCESS, iceCandidateSerialize(pCandidate, candidateStr, &candidateStrLen));
+        EXPECT_TRUE(STRSTR(candidateStr, "203.0.113.10") != NULL);
+        v4Checked++;
+    }
+    EXPECT_GT(v4Checked, 0u);
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
+TEST_F(IceFunctionalityTest, announcedIpAddressInvalidRejected)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+    STRNCPY(configuration.kvsRtcConfiguration.announcedIpAddress, "not-an-ip", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    // Garbled announcedIpAddress must cause gathering to fail loudly instead of silently falling back to the bind IP.
+    EXPECT_EQ(STATUS_INVALID_ARG, iceAgentStartGathering(pIceAgent));
 
     EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
     EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));

--- a/tst/IceFunctionalityTest.cpp
+++ b/tst/IceFunctionalityTest.cpp
@@ -836,6 +836,72 @@ TEST_F(IceFunctionalityTest, getLocalhostIpAddressesFilterCustomDataTest)
     EXPECT_GE(filterCallCount, ipCount);
 }
 
+TEST_F(IceFunctionalityTest, iceLiteAgentFlagSetCorrectly)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    EXPECT_TRUE(pIceAgent->isLiteAgent);
+    EXPECT_FALSE(pIceAgent->remoteIsLiteAgent);
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
+TEST_F(IceFunctionalityTest, iceLiteAgentFlagDefaultFalse)
+{
+    PIceAgent pIceAgent = NULL;
+    CHAR localIceUfrag[LOCAL_ICE_UFRAG_LEN + 1];
+    CHAR localIcePwd[LOCAL_ICE_PWD_LEN + 1];
+    RtcConfiguration configuration;
+    IceAgentCallbacks iceAgentCallbacks;
+    PConnectionListener pConnectionListener = NULL;
+    TIMER_QUEUE_HANDLE timerQueueHandle = INVALID_TIMER_QUEUE_HANDLE_VALUE;
+
+    initRtcConfiguration(&configuration);
+    // Default: iceLiteMode is FALSE (MEMSET to 0)
+
+    MEMSET(localIceUfrag, 0x00, SIZEOF(localIceUfrag));
+    MEMSET(localIcePwd, 0x00, SIZEOF(localIcePwd));
+    MEMSET(&iceAgentCallbacks, 0x00, SIZEOF(IceAgentCallbacks));
+
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIceUfrag, LOCAL_ICE_UFRAG_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, generateJSONSafeString(localIcePwd, LOCAL_ICE_PWD_LEN));
+    EXPECT_EQ(STATUS_SUCCESS, createConnectionListener(&pConnectionListener));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueCreate(&timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS,
+              createIceAgent(localIceUfrag, localIcePwd, &iceAgentCallbacks, &configuration, timerQueueHandle, pConnectionListener, &pIceAgent));
+
+    EXPECT_FALSE(pIceAgent->isLiteAgent);
+    EXPECT_FALSE(pIceAgent->remoteIsLiteAgent);
+
+    EXPECT_EQ(STATUS_SUCCESS, iceAgentShutdown(pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueShutdown(timerQueueHandle));
+    EXPECT_EQ(STATUS_SUCCESS, freeIceAgent(&pIceAgent));
+    EXPECT_EQ(STATUS_SUCCESS, timerQueueFree(&timerQueueHandle));
+}
+
 TEST_F(IceFunctionalityTest, DISABLED_IceAgentCandidateGatheringTest)
 {
     ASSERT_EQ(TRUE, mAccessKeyIdSet);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -96,11 +96,12 @@ TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
     freePeerConnection(&answerPc);
 }
 
-// Proves that announcedIpAddress genuinely rewrites the address the full peer probes: the lite peer emits host
-// candidates pointing at an unreachable documentation IP, the full peer tries and fails to send STUN binding
-// requests to it (ENETUNREACH), and both agents end up in FAILED rather than CONNECTED. If the rewrite were purely
-// nominal — e.g. the full peer falling back to the lite socket's real bind IP — this test would instead succeed.
-TEST_F(PeerConnectionFunctionalityTest, announcedIpUnreachableConnectionFails)
+// Proves that announcedIpAddress is applied at the PeerConnection layer (not just the ICE-agent unit): at least one
+// IPv4 host candidate trickled out by the lite peer must carry the announced address in its SDP form. We assert on
+// the trickled candidate strings rather than on whether the connection succeeds — the latter depends on host
+// routing (e.g. an Android image with IPv6 loopback may connect over IPv6, where the announced IPv4 rewrite does
+// not apply), which makes pass/fail platform-dependent.
+TEST_F(PeerConnectionFunctionalityTest, announcedIpPropagatesIntoLiteTrickledCandidates)
 {
     RtcConfiguration fullCfg{}, liteCfg{};
     PRtcPeerConnection offerPc = NULL, answerPc = NULL;
@@ -108,18 +109,57 @@ TEST_F(PeerConnectionFunctionalityTest, announcedIpUnreachableConnectionFails)
     initRtcConfiguration(&fullCfg);
     initRtcConfiguration(&liteCfg);
     liteCfg.kvsRtcConfiguration.iceLiteMode = TRUE;
-    // 203.0.113.0/24 is TEST-NET-3 (RFC 5737) — guaranteed not to be in any routing table.
     STRNCPY(liteCfg.kvsRtcConfiguration.announcedIpAddress, "203.0.113.10", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
 
-    EXPECT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
-    EXPECT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
+    ASSERT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
+    ASSERT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
 
-    EXPECT_FALSE(connectTwoPeers(offerPc, answerPc));
-    EXPECT_EQ(0u, ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]));
-    EXPECT_GT(ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_FAILED]), 0u);
+    // Collect every candidate string lite trickles out.
+    std::vector<std::string> liteCandidates;
+    std::mutex liteCandidatesLock;
+    struct Capture {
+        std::vector<std::string>* candidates;
+        std::mutex* lock;
+    } capture{&liteCandidates, &liteCandidatesLock};
 
-    PKvsPeerConnection pKvsAnswer = (PKvsPeerConnection) answerPc;
-    EXPECT_TRUE(pKvsAnswer->pIceAgent->isLiteAgent);
+    auto captureHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
+        if (candidateStr == NULL) {
+            return;
+        }
+        Capture* cap = (Capture*) customData;
+        cap->lock->lock();
+        cap->candidates->emplace_back(candidateStr);
+        cap->lock->unlock();
+    };
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &capture, captureHdlr));
+
+    // Drive the offer/answer exchange manually; no need to actually connect.
+    RtcSessionDescriptionInit sdp;
+    MEMSET(&sdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(answerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, createAnswer(answerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(answerPc, &sdp));
+
+    // Give host gathering a moment to run and the trickle callback a moment to fire.
+    UINT64 timeout = GETTIME() + 3 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    bool found = false;
+    while (!found && GETTIME() < timeout) {
+        THREAD_SLEEP(50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        liteCandidatesLock.lock();
+        for (const auto& c : liteCandidates) {
+            if (c.find("203.0.113.10") != std::string::npos) {
+                found = true;
+                break;
+            }
+        }
+        liteCandidatesLock.unlock();
+    }
+    EXPECT_TRUE(found);
+
+    auto noopHdlr = [](UINT64, PCHAR) -> void {};
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, 0, noopHdlr));
 
     closePeerConnection(offerPc);
     closePeerConnection(answerPc);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -72,9 +72,11 @@ TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeer)
     freePeerConnection(&answerPc);
 }
 
-// Same as above but with announcedIpAddress set on the lite peer. Connection still succeeds over loopback because
-// the SDK listens on the real bind IPs even when announcedIpAddress rewrites the advertised address.
-TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeerWithAnnouncedIp)
+// Proves that announcedIpAddress genuinely rewrites the address the full peer probes: the lite peer emits host
+// candidates pointing at an unreachable documentation IP, the full peer tries and fails to send STUN binding
+// requests to it (ENETUNREACH), and both agents end up in FAILED rather than CONNECTED. If the rewrite were purely
+// nominal — e.g. the full peer falling back to the lite socket's real bind IP — this test would instead succeed.
+TEST_F(PeerConnectionFunctionalityTest, announcedIpUnreachableConnectionFails)
 {
     RtcConfiguration fullCfg{}, liteCfg{};
     PRtcPeerConnection offerPc = NULL, answerPc = NULL;
@@ -82,16 +84,15 @@ TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeerWithAnnouncedIp)
     initRtcConfiguration(&fullCfg);
     initRtcConfiguration(&liteCfg);
     liteCfg.kvsRtcConfiguration.iceLiteMode = TRUE;
-    // Announce a non-reachable IP; connectivity should still work because the full peer learns the real reachable
-    // address via peer-reflexive discovery from the first incoming check, rather than trusting the announced IP.
+    // 203.0.113.0/24 is TEST-NET-3 (RFC 5737) — guaranteed not to be in any routing table.
     STRNCPY(liteCfg.kvsRtcConfiguration.announcedIpAddress, "203.0.113.10", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
 
     EXPECT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
     EXPECT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
 
-    // May or may not connect depending on whether peer-reflexive discovery salvages the bogus announced IP; either
-    // outcome is acceptable here. The real assertion is that setup/teardown of a lite+announcedIp peer is clean.
-    connectTwoPeers(offerPc, answerPc);
+    EXPECT_FALSE(connectTwoPeers(offerPc, answerPc));
+    EXPECT_EQ(0u, ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]));
+    EXPECT_GT(ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_FAILED]), 0u);
 
     PKvsPeerConnection pKvsAnswer = (PKvsPeerConnection) answerPc;
     EXPECT_TRUE(pKvsAnswer->pIceAgent->isLiteAgent);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -38,6 +38,70 @@ TEST_F(PeerConnectionFunctionalityTest, connectTwoPeers)
     freePeerConnection(&answerPc);
 }
 
+// End-to-end: a full ICE agent (offerer) connecting to a lite ICE agent (answerer) must reach CONNECTED,
+// with full=controlling / lite=controlled per RFC 8445.
+TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeer)
+{
+    RtcConfiguration fullCfg{}, liteCfg{};
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+
+    initRtcConfiguration(&fullCfg);
+    initRtcConfiguration(&liteCfg);
+    liteCfg.kvsRtcConfiguration.iceLiteMode = TRUE;
+
+    EXPECT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
+
+    ASSERT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+
+    PKvsPeerConnection pKvsOffer = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pKvsAnswer = (PKvsPeerConnection) answerPc;
+
+    // Full agent observed the answerer's a=ice-lite and took the controlling role.
+    EXPECT_FALSE(pKvsOffer->pIceAgent->isLiteAgent);
+    EXPECT_TRUE(pKvsOffer->remoteIsIceLite);
+    EXPECT_TRUE(pKvsOffer->pIceAgent->isControlling);
+
+    // Lite agent is controlled and did not initiate any binding requests.
+    EXPECT_TRUE(pKvsAnswer->pIceAgent->isLiteAgent);
+    EXPECT_FALSE(pKvsAnswer->pIceAgent->isControlling);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
+// Same as above but with announcedIpAddress set on the lite peer. Connection still succeeds over loopback because
+// the SDK listens on the real bind IPs even when announcedIpAddress rewrites the advertised address.
+TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeerWithAnnouncedIp)
+{
+    RtcConfiguration fullCfg{}, liteCfg{};
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+
+    initRtcConfiguration(&fullCfg);
+    initRtcConfiguration(&liteCfg);
+    liteCfg.kvsRtcConfiguration.iceLiteMode = TRUE;
+    // Announce a non-reachable IP; connectivity should still work because the full peer learns the real reachable
+    // address via peer-reflexive discovery from the first incoming check, rather than trusting the announced IP.
+    STRNCPY(liteCfg.kvsRtcConfiguration.announcedIpAddress, "203.0.113.10", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
+
+    EXPECT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
+
+    // May or may not connect depending on whether peer-reflexive discovery salvages the bogus announced IP; either
+    // outcome is acceptable here. The real assertion is that setup/teardown of a lite+announcedIp peer is clean.
+    connectTwoPeers(offerPc, answerPc);
+
+    PKvsPeerConnection pKvsAnswer = (PKvsPeerConnection) answerPc;
+    EXPECT_TRUE(pKvsAnswer->pIceAgent->isLiteAgent);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
 TEST_F(PeerConnectionFunctionalityTest, connectTwoPeersWithDelay)
 {
     RtcConfiguration configuration{};

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -72,10 +72,11 @@ TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeer)
     freePeerConnection(&answerPc);
 }
 
-// Non-trickle exchange where the full (offerer) peer's offer SDP is handed to lite with every a=candidate: line
-// stripped. Lite never sees the full peer's advertised addresses — neither in the SDP nor via trickle, since
-// there is no trickle channel. Lite must still reach CONNECTED by learning the full peer's source address via
-// peer-reflexive discovery from the first incoming binding request. Validates RFC 8445 §7.3.1.3 on the lite side.
+// Non-trickle exchange where the full (offerer) peer hands over its offer SDP before gathering completes, so
+// the offer carries no a=candidate lines; the lite peer still gathers host candidates normally and publishes
+// them in the answer SDP. Full learns lite's addresses and probes them. Lite, seeing an inbound binding request
+// from an unknown source, learns the full peer's address via peer-reflexive discovery (RFC 8445 §7.3.1.3) and
+// responds. Both peers must reach CONNECTED.
 TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
 {
     RtcConfiguration fullCfg{}, liteCfg{};
@@ -88,7 +89,7 @@ TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
     ASSERT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
     ASSERT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
 
-    EXPECT_TRUE(connectTwoPeersNoTrickle(offerPc, answerPc, /*stripOfferCandidates=*/true));
+    EXPECT_TRUE(connectTwoPeersNoTrickle(offerPc, answerPc, /*assumeOfferGathered=*/true));
 
     closePeerConnection(offerPc);
     closePeerConnection(answerPc);

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -72,6 +72,30 @@ TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeer)
     freePeerConnection(&answerPc);
 }
 
+// With forwardOfferCandidates=false, the full (offerer) peer never emits candidates to the lite (answerer) peer —
+// neither in the initial SDP (trickle mode) nor through the trickle callback. Lite must still reach CONNECTED by
+// learning the full peer's source address via peer-reflexive discovery from the first incoming binding request.
+// This validates RFC 8445 §7.3.1.3 on the lite side.
+TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
+{
+    RtcConfiguration fullCfg{}, liteCfg{};
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+
+    initRtcConfiguration(&fullCfg);
+    initRtcConfiguration(&liteCfg);
+    liteCfg.kvsRtcConfiguration.iceLiteMode = TRUE;
+
+    ASSERT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
+    ASSERT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
+
+    EXPECT_TRUE(connectTwoPeers(offerPc, answerPc, NULL, NULL, /*forwardOfferCandidates=*/false));
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
+
 // Proves that announcedIpAddress genuinely rewrites the address the full peer probes: the lite peer emits host
 // candidates pointing at an unreachable documentation IP, the full peer tries and fails to send STUN binding
 // requests to it (ENETUNREACH), and both agents end up in FAILED rather than CONNECTED. If the rewrite were purely

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -72,10 +72,10 @@ TEST_F(PeerConnectionFunctionalityTest, connectFullToLitePeer)
     freePeerConnection(&answerPc);
 }
 
-// With forwardOfferCandidates=false, the full (offerer) peer never emits candidates to the lite (answerer) peer —
-// neither in the initial SDP (trickle mode) nor through the trickle callback. Lite must still reach CONNECTED by
-// learning the full peer's source address via peer-reflexive discovery from the first incoming binding request.
-// This validates RFC 8445 §7.3.1.3 on the lite side.
+// Non-trickle exchange where the full (offerer) peer's offer SDP is handed to lite with every a=candidate: line
+// stripped. Lite never sees the full peer's advertised addresses — neither in the SDP nor via trickle, since
+// there is no trickle channel. Lite must still reach CONNECTED by learning the full peer's source address via
+// peer-reflexive discovery from the first incoming binding request. Validates RFC 8445 §7.3.1.3 on the lite side.
 TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
 {
     RtcConfiguration fullCfg{}, liteCfg{};
@@ -88,7 +88,7 @@ TEST_F(PeerConnectionFunctionalityTest, liteConnectsWhenFullEmitsNoCandidates)
     ASSERT_EQ(createPeerConnection(&fullCfg, &offerPc), STATUS_SUCCESS);
     ASSERT_EQ(createPeerConnection(&liteCfg, &answerPc), STATUS_SUCCESS);
 
-    EXPECT_TRUE(connectTwoPeers(offerPc, answerPc, NULL, NULL, /*forwardOfferCandidates=*/false));
+    EXPECT_TRUE(connectTwoPeersNoTrickle(offerPc, answerPc, /*stripOfferCandidates=*/true));
 
     closePeerConnection(offerPc);
     closePeerConnection(answerPc);

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -2793,6 +2793,175 @@ TEST_F(SdpApiTest, addTransceiverUnknownCodecId_returnsStatusNotImplemented)
     freePeerConnection(&offerPc);
 }
 
+TEST_F(SdpApiTest, iceLiteAttributeInSDP)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver transceiver = nullptr;
+    RtcSessionDescriptionInit offerSdp;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRNCPY(track.streamId, "videoStream", MAX_MEDIA_STREAM_ID_LEN);
+    STRNCPY(track.trackId, "videoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+    MEMSET(&offerSdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(pRtcPeerConnection, &offerSdp));
+
+    std::string sdp(offerSdp.sdp);
+    EXPECT_NE(std::string::npos, sdp.find("a=ice-lite"));
+
+    EXPECT_EQ(STATUS_SUCCESS, closePeerConnection(pRtcPeerConnection));
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(SdpApiTest, noIceLiteByDefault)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver transceiver = nullptr;
+    RtcSessionDescriptionInit offerSdp;
+
+    initRtcConfiguration(&configuration);
+    // iceLiteMode defaults to FALSE (MEMSET 0)
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRNCPY(track.streamId, "videoStream", MAX_MEDIA_STREAM_ID_LEN);
+    STRNCPY(track.trackId, "videoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+    MEMSET(&offerSdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(pRtcPeerConnection, &offerSdp));
+
+    std::string sdp(offerSdp.sdp);
+    EXPECT_EQ(std::string::npos, sdp.find("a=ice-lite"));
+
+    EXPECT_EQ(STATUS_SUCCESS, closePeerConnection(pRtcPeerConnection));
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
+TEST_F(SdpApiTest, parseRemoteIceLiteAttribute)
+{
+    PRtcPeerConnection offerPc = NULL;
+    PRtcPeerConnection answerPc = NULL;
+    RtcConfiguration configurationOffer;
+    RtcConfiguration configurationAnswer;
+    RtcSessionDescriptionInit offerSdpInit;
+    RtcSessionDescriptionInit remoteSdpInit;
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver transceiver = nullptr;
+
+    initRtcConfiguration(&configurationOffer);
+    initRtcConfiguration(&configurationAnswer);
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configurationOffer, &offerPc));
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configurationAnswer, &answerPc));
+
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRNCPY(track.streamId, "videoStream", MAX_MEDIA_STREAM_ID_LEN);
+    STRNCPY(track.trackId, "videoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(offerPc, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(offerPc, &track, nullptr, &transceiver));
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(answerPc, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(answerPc, &track, nullptr, &transceiver));
+
+    // Create an offer, then inject a=ice-lite into it before setting on answer side
+    MEMSET(&offerSdpInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    offerSdpInit.useTrickleIce = TRUE;
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &offerSdpInit));
+
+    // Insert a=ice-lite after the session-level attributes
+    std::string sdp(offerSdpInit.sdp);
+    auto pos = sdp.find("a=group:");
+    ASSERT_NE(std::string::npos, pos);
+    sdp.insert(pos, "a=ice-lite\r\n");
+
+    MEMSET(&remoteSdpInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    remoteSdpInit.type = SDP_TYPE_OFFER;
+    STRNCPY(remoteSdpInit.sdp, sdp.c_str(), MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(answerPc, &remoteSdpInit));
+
+    // Verify that the answer PC detected ice-lite
+    PKvsPeerConnection pKvsAnswerPc = (PKvsPeerConnection) answerPc;
+    EXPECT_TRUE(pKvsAnswerPc->remoteIsIceLite);
+
+    // The answer side (full agent) should be controlling when remote is ice-lite
+    EXPECT_TRUE(pKvsAnswerPc->pIceAgent->isControlling);
+
+    closePeerConnection(offerPc);
+    freePeerConnection(&offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&answerPc);
+}
+
+TEST_F(SdpApiTest, iceLiteAgentAlwaysControlled)
+{
+    PRtcPeerConnection litePc = NULL;
+    PRtcPeerConnection fullPc = NULL;
+    RtcConfiguration configurationLite;
+    RtcConfiguration configurationFull;
+    RtcSessionDescriptionInit offerSdpInit;
+    RtcSessionDescriptionInit remoteSdpInit;
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver transceiver = nullptr;
+
+    initRtcConfiguration(&configurationLite);
+    configurationLite.kvsRtcConfiguration.iceLiteMode = TRUE;
+    initRtcConfiguration(&configurationFull);
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configurationLite, &litePc));
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configurationFull, &fullPc));
+
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRNCPY(track.streamId, "videoStream", MAX_MEDIA_STREAM_ID_LEN);
+    STRNCPY(track.trackId, "videoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(fullPc, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(fullPc, &track, nullptr, &transceiver));
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(litePc, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(litePc, &track, nullptr, &transceiver));
+
+    // Full agent creates the offer
+    MEMSET(&offerSdpInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    offerSdpInit.useTrickleIce = TRUE;
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(fullPc, &offerSdpInit));
+
+    // Set the full agent's offer as remote description on the lite agent
+    MEMSET(&remoteSdpInit, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    remoteSdpInit.type = SDP_TYPE_OFFER;
+    STRCPY(remoteSdpInit.sdp, offerSdpInit.sdp);
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(litePc, &remoteSdpInit));
+
+    // ICE-lite agent must be controlled (not controlling), even though it's answering
+    PKvsPeerConnection pKvsLitePc = (PKvsPeerConnection) litePc;
+    EXPECT_FALSE(pKvsLitePc->pIceAgent->isControlling);
+    EXPECT_TRUE(pKvsLitePc->pIceAgent->isLiteAgent);
+
+    closePeerConnection(litePc);
+    freePeerConnection(&litePc);
+    closePeerConnection(fullPc);
+    freePeerConnection(&fullPc);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/SdpApiTest.cpp
+++ b/tst/SdpApiTest.cpp
@@ -2962,6 +2962,76 @@ TEST_F(SdpApiTest, iceLiteAgentAlwaysControlled)
     freePeerConnection(&fullPc);
 }
 
+TEST_F(SdpApiTest, iceLiteWithAnnouncedIpEmitsBothInOffer)
+{
+    RtcConfiguration configuration;
+    PRtcPeerConnection pRtcPeerConnection = nullptr;
+    RtcMediaStreamTrack track;
+    PRtcRtpTransceiver transceiver = nullptr;
+    RtcSessionDescriptionInit offerSdp;
+    SIZE_T gatherDone = 0;
+
+    initRtcConfiguration(&configuration);
+    configuration.kvsRtcConfiguration.iceLiteMode = TRUE;
+    STRNCPY(configuration.kvsRtcConfiguration.announcedIpAddress, "203.0.113.10", KVS_IP_ADDRESS_STRING_BUFFER_LEN - 1);
+
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&configuration, &pRtcPeerConnection));
+
+    track.kind = MEDIA_STREAM_TRACK_KIND_VIDEO;
+    track.codec = RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE;
+    STRNCPY(track.streamId, "videoStream", MAX_MEDIA_STREAM_ID_LEN);
+    STRNCPY(track.trackId, "videoTrack", MAX_MEDIA_STREAM_TRACK_ID_LEN);
+
+    EXPECT_EQ(STATUS_SUCCESS, addSupportedCodec(pRtcPeerConnection, RTC_CODEC_H264_PROFILE_42E01F_LEVEL_ASYMMETRY_ALLOWED_PACKETIZATION_MODE));
+    EXPECT_EQ(STATUS_SUCCESS, addTransceiver(pRtcPeerConnection, &track, nullptr, &transceiver));
+
+    // Signal gathering completion via the ICE-candidate callback: NULL candidate string means "done".
+    auto onCandidate = [](UINT64 customData, PCHAR candidateStr) -> void {
+        if (candidateStr == NULL) {
+            ATOMIC_INCREMENT((PSIZE_T) customData);
+        }
+    };
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(pRtcPeerConnection, (UINT64) &gatherDone, onCandidate));
+
+    // setLocalDescription triggers gathering; for lite mode it's host-only and completes essentially immediately.
+    MEMSET(&offerSdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(pRtcPeerConnection, &offerSdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(pRtcPeerConnection, &offerSdp));
+
+    UINT64 timeout = GETTIME() + 3 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    while (ATOMIC_LOAD(&gatherDone) == 0 && GETTIME() < timeout) {
+        THREAD_SLEEP(50 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+    ASSERT_GT(ATOMIC_LOAD(&gatherDone), 0u);
+
+    // Get the SDP with candidates populated.
+    MEMSET(&offerSdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(pRtcPeerConnection, &offerSdp));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(pRtcPeerConnection, &offerSdp));
+
+    std::string sdp(offerSdp.sdp);
+    EXPECT_NE(std::string::npos, sdp.find("a=ice-lite"));
+
+    // At least one a=candidate line must carry the announced IP. Scope the substring check to candidate lines so we
+    // don't accidentally match the address appearing elsewhere (e.g. an ICE server URL).
+    bool announcedIpInCandidate = false;
+    auto candidatePos = sdp.find("a=candidate:");
+    ASSERT_NE(std::string::npos, candidatePos);
+    while (candidatePos != std::string::npos) {
+        auto lineEnd = sdp.find("\r\n", candidatePos);
+        std::string line = sdp.substr(candidatePos, lineEnd - candidatePos);
+        if (line.find("203.0.113.10") != std::string::npos) {
+            announcedIpInCandidate = true;
+            break;
+        }
+        candidatePos = sdp.find("a=candidate:", candidatePos + 1);
+    }
+    EXPECT_TRUE(announcedIpInCandidate);
+
+    EXPECT_EQ(STATUS_SUCCESS, closePeerConnection(pRtcPeerConnection));
+    EXPECT_EQ(STATUS_SUCCESS, freePeerConnection(&pRtcPeerConnection));
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -213,8 +213,8 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
 }
 
 // Non-trickle variant of connectTwoPeers. See header for parameter semantics.
-bool WebRtcClientTestBase::connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool stripOfferCandidates,
-                                                    bool stripAnswerCandidates)
+bool WebRtcClientTestBase::connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool assumeOfferGathered,
+                                                    bool assumeAnswerGathered)
 {
     RtcSessionDescriptionInit sdp;
     SIZE_T offerDoneGather = 0, answerDoneGather = 0;
@@ -239,46 +239,40 @@ bool WebRtcClientTestBase::connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, 
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnConnectionStateChange(offerPc, (UINT64) this->stateChangeCount, onStateChangeHdlr));
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnConnectionStateChange(answerPc, (UINT64) this->stateChangeCount, onStateChangeHdlr));
 
-    // Kick gathering on both PCs. Passing a MEMSET'd SDP with no payload is the idiomatic way this codebase starts
-    // gathering outside of the normal createOffer/createAnswer path.
+    // Produce the offer SDP BEFORE gathering starts. populateSessionDescription iterates valid local candidates,
+    // and host candidates become VALID synchronously inside iceAgentInitHostCandidate; calling createOffer after
+    // setLocalDescription would bake them in regardless of whether we then call
+    // peerConnectionGetCurrentLocalDescription. Capturing the offer before gathering gives us a guaranteed-bare
+    // offer SDP that we can optionally refresh with candidates after gathering completes.
     MEMSET(&sdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sdp));
+
     EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(offerPc, &sdp));
     EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(answerPc, &sdp));
 
+    // Wait only for sides that are supposed to publish candidates in their SDP.
     timeout = GETTIME() + KVS_ICE_GATHER_REFLEXIVE_AND_RELAYED_CANDIDATE_TIMEOUT + 2 * HUNDREDS_OF_NANOS_IN_A_SECOND;
-    while ((ATOMIC_LOAD(&offerDoneGather) == 0 || ATOMIC_LOAD(&answerDoneGather) == 0) && GETTIME() < timeout) {
+    while (GETTIME() < timeout && ((!assumeOfferGathered && ATOMIC_LOAD(&offerDoneGather) == 0) ||
+                                   (!assumeAnswerGathered && ATOMIC_LOAD(&answerDoneGather) == 0))) {
         THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
     }
-    EXPECT_GT(ATOMIC_LOAD(&offerDoneGather), 0u);
-    EXPECT_GT(ATOMIC_LOAD(&answerDoneGather), 0u);
+    if (!assumeOfferGathered) {
+        EXPECT_GT(ATOMIC_LOAD(&offerDoneGather), 0u);
+    }
+    if (!assumeAnswerGathered) {
+        EXPECT_GT(ATOMIC_LOAD(&answerDoneGather), 0u);
+    }
 
-    // Remove every a=candidate: line (including the trailing CRLF) from an SDP string in-place.
-    auto stripCandidates = [](PCHAR sdpStr) {
-        std::string s(sdpStr);
-        size_t pos = 0;
-        while ((pos = s.find("a=candidate:", pos)) != std::string::npos) {
-            size_t end = s.find("\r\n", pos);
-            if (end == std::string::npos) {
-                s.erase(pos);
-                break;
-            }
-            s.erase(pos, end - pos + 2);
-        }
-        STRNCPY(sdpStr, s.c_str(), MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
-        sdpStr[MAX_SESSION_DESCRIPTION_INIT_SDP_LEN] = '\0';
-    };
-
-    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sdp));
-    EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(offerPc, &sdp));
-    if (stripOfferCandidates) {
-        stripCandidates(sdp.sdp);
+    // If we waited for the offer side, refresh sdp with its post-gathering description (now has a=candidate
+    // lines). Otherwise leave sdp as the bare offer captured before gathering started.
+    if (!assumeOfferGathered) {
+        EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(offerPc, &sdp));
     }
     EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(answerPc, &sdp));
 
     EXPECT_EQ(STATUS_SUCCESS, createAnswer(answerPc, &sdp));
-    EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(answerPc, &sdp));
-    if (stripAnswerCandidates) {
-        stripCandidates(sdp.sdp);
+    if (!assumeAnswerGathered) {
+        EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(answerPc, &sdp));
     }
     EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(offerPc, &sdp));
 

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -129,7 +129,7 @@ void WebRtcClientTestBase::TearDown()
 // in the given amount of time. Return false if they don't go to connected in
 // the expected amounted of time
 bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, PCHAR pOfferCertFingerprint,
-                                           PCHAR pAnswerCertFingerprint, bool forwardOfferCandidates)
+                                           PCHAR pAnswerCertFingerprint)
 {
     RtcSessionDescriptionInit sdp;
     PeerContainer offer;
@@ -154,13 +154,6 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
         }
     };
 
-    // When forwardOfferCandidates is false, the offer peer's candidates are intentionally dropped so the answerer
-    // never learns them and must rely on peer-reflexive discovery from incoming binding requests.
-    auto dropCandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
-        UNUSED_PARAM(customData);
-        UNUSED_PARAM(candidateStr);
-    };
-
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
         UNUSED_PARAM(customData);
         UNUSED_PARAM(candidateStr);
@@ -171,11 +164,7 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     answer.pc = answerPc;
     answer.client = this;
 
-    if (forwardOfferCandidates) {
-        EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
-    } else {
-        EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, dropCandidateHdlr));
-    }
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &offer, onICECandidateHdlr));
 
     auto onICEConnectionStateChangeHdlr = [](UINT64 customData, RTC_PEER_CONNECTION_STATE newState) -> void {
@@ -219,6 +208,88 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
 
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onICECandidateHdlrDone));
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onICECandidateHdlrDone));
+
+    return ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) == 2;
+}
+
+// Non-trickle variant of connectTwoPeers. See header for parameter semantics.
+bool WebRtcClientTestBase::connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool stripOfferCandidates,
+                                                    bool stripAnswerCandidates)
+{
+    RtcSessionDescriptionInit sdp;
+    SIZE_T offerDoneGather = 0, answerDoneGather = 0;
+    UINT64 timeout;
+
+    auto onDoneGatherHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
+        if (candidateStr == NULL) {
+            ATOMIC_STORE((PSIZE_T) customData, 1);
+        }
+    };
+    auto onDoneHdlrFinal = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &offerDoneGather, onDoneGatherHdlr));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &answerDoneGather, onDoneGatherHdlr));
+
+    auto onStateChangeHdlr = [](UINT64 customData, RTC_PEER_CONNECTION_STATE newState) -> void {
+        ATOMIC_INCREMENT((PSIZE_T) customData + newState);
+    };
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnConnectionStateChange(offerPc, (UINT64) this->stateChangeCount, onStateChangeHdlr));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnConnectionStateChange(answerPc, (UINT64) this->stateChangeCount, onStateChangeHdlr));
+
+    // Kick gathering on both PCs. Passing a MEMSET'd SDP with no payload is the idiomatic way this codebase starts
+    // gathering outside of the normal createOffer/createAnswer path.
+    MEMSET(&sdp, 0x00, SIZEOF(RtcSessionDescriptionInit));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, setLocalDescription(answerPc, &sdp));
+
+    timeout = GETTIME() + KVS_ICE_GATHER_REFLEXIVE_AND_RELAYED_CANDIDATE_TIMEOUT + 2 * HUNDREDS_OF_NANOS_IN_A_SECOND;
+    while ((ATOMIC_LOAD(&offerDoneGather) == 0 || ATOMIC_LOAD(&answerDoneGather) == 0) && GETTIME() < timeout) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+    EXPECT_GT(ATOMIC_LOAD(&offerDoneGather), 0u);
+    EXPECT_GT(ATOMIC_LOAD(&answerDoneGather), 0u);
+
+    // Remove every a=candidate: line (including the trailing CRLF) from an SDP string in-place.
+    auto stripCandidates = [](PCHAR sdpStr) {
+        std::string s(sdpStr);
+        size_t pos = 0;
+        while ((pos = s.find("a=candidate:", pos)) != std::string::npos) {
+            size_t end = s.find("\r\n", pos);
+            if (end == std::string::npos) {
+                s.erase(pos);
+                break;
+            }
+            s.erase(pos, end - pos + 2);
+        }
+        STRNCPY(sdpStr, s.c_str(), MAX_SESSION_DESCRIPTION_INIT_SDP_LEN);
+        sdpStr[MAX_SESSION_DESCRIPTION_INIT_SDP_LEN] = '\0';
+    };
+
+    EXPECT_EQ(STATUS_SUCCESS, createOffer(offerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(offerPc, &sdp));
+    if (stripOfferCandidates) {
+        stripCandidates(sdp.sdp);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(answerPc, &sdp));
+
+    EXPECT_EQ(STATUS_SUCCESS, createAnswer(answerPc, &sdp));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionGetCurrentLocalDescription(answerPc, &sdp));
+    if (stripAnswerCandidates) {
+        stripCandidates(sdp.sdp);
+    }
+    EXPECT_EQ(STATUS_SUCCESS, setRemoteDescription(offerPc, &sdp));
+
+    for (auto i = 0; i <= 10 && ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) != 2 &&
+         ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_FAILED]) == 0;
+         i++) {
+        THREAD_SLEEP(HUNDREDS_OF_NANOS_IN_A_SECOND);
+    }
+
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, onDoneHdlrFinal));
+    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) 0, onDoneHdlrFinal));
 
     return ATOMIC_LOAD(&this->stateChangeCount[RTC_PEER_CONNECTION_STATE_CONNECTED]) == 2;
 }

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -129,7 +129,7 @@ void WebRtcClientTestBase::TearDown()
 // in the given amount of time. Return false if they don't go to connected in
 // the expected amounted of time
 bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, PCHAR pOfferCertFingerprint,
-                                           PCHAR pAnswerCertFingerprint)
+                                           PCHAR pAnswerCertFingerprint, bool forwardOfferCandidates)
 {
     RtcSessionDescriptionInit sdp;
     PeerContainer offer;
@@ -154,6 +154,13 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
         }
     };
 
+    // When forwardOfferCandidates is false, the offer peer's candidates are intentionally dropped so the answerer
+    // never learns them and must rely on peer-reflexive discovery from incoming binding requests.
+    auto dropCandidateHdlr = [](UINT64 customData, PCHAR candidateStr) -> void {
+        UNUSED_PARAM(customData);
+        UNUSED_PARAM(candidateStr);
+    };
+
     auto onICECandidateHdlrDone = [](UINT64 customData, PCHAR candidateStr) -> void {
         UNUSED_PARAM(customData);
         UNUSED_PARAM(candidateStr);
@@ -164,7 +171,11 @@ bool WebRtcClientTestBase::connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerC
     answer.pc = answerPc;
     answer.client = this;
 
-    EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
+    if (forwardOfferCandidates) {
+        EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) &answer, onICECandidateHdlr));
+    } else {
+        EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(offerPc, (UINT64) 0, dropCandidateHdlr));
+    }
     EXPECT_EQ(STATUS_SUCCESS, peerConnectionOnIceCandidate(answerPc, (UINT64) &offer, onICECandidateHdlr));
 
     auto onICEConnectionStateChangeHdlr = [](UINT64 customData, RTC_PEER_CONNECTION_STATE newState) -> void {

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -294,7 +294,14 @@ class WebRtcClientTestBase : public ::testing::Test {
     }
 
     bool connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, PCHAR pOfferCertFingerprint = NULL,
-                         PCHAR pAnswerCertFingerprint = NULL, bool forwardOfferCandidates = true);
+                         PCHAR pAnswerCertFingerprint = NULL);
+
+    // Non-trickle variant: starts gathering on both PCs, waits for each to signal gathering completion, then
+    // exchanges post-gathering SDPs (containing a=candidate lines inline). Optional strip flags remove all
+    // a=candidate: lines from the offer or answer SDP before it is handed to the remote peer — use either to
+    // exercise peer-reflexive discovery on the receiving side. Returns true iff both PCs reach CONNECTED.
+    bool connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool stripOfferCandidates = false,
+                                  bool stripAnswerCandidates = false);
     void addTrackToPeerConnection(PRtcPeerConnection pRtcPeerConnection, PRtcMediaStreamTrack track, PRtcRtpTransceiver* transceiver, RTC_CODEC codec,
                                   MEDIA_STREAM_TRACK_KIND kind);
     void getIceServers(PRtcConfiguration pRtcConfiguration);

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -297,11 +297,14 @@ class WebRtcClientTestBase : public ::testing::Test {
                          PCHAR pAnswerCertFingerprint = NULL);
 
     // Non-trickle variant: starts gathering on both PCs, waits for each to signal gathering completion, then
-    // exchanges post-gathering SDPs (containing a=candidate lines inline). Optional strip flags remove all
-    // a=candidate: lines from the offer or answer SDP before it is handed to the remote peer — use either to
-    // exercise peer-reflexive discovery on the receiving side. Returns true iff both PCs reach CONNECTED.
-    bool connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool stripOfferCandidates = false,
-                                  bool stripAnswerCandidates = false);
+    // exchanges post-gathering SDPs (containing a=candidate lines inline).
+    //
+    // assumeOfferGathered / assumeAnswerGathered skip the gather-wait for that side and use the bare SDP from
+    // createOffer/createAnswer (no a=candidate: lines). The other side still gathers and emits candidates
+    // normally. Use this to test scenarios where one peer intentionally hands over an SDP without any advertised
+    // candidates — the receiving peer then has to learn its address via peer-reflexive discovery.
+    bool connectTwoPeersNoTrickle(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, bool assumeOfferGathered = false,
+                                  bool assumeAnswerGathered = false);
     void addTrackToPeerConnection(PRtcPeerConnection pRtcPeerConnection, PRtcMediaStreamTrack track, PRtcRtpTransceiver* transceiver, RTC_CODEC codec,
                                   MEDIA_STREAM_TRACK_KIND kind);
     void getIceServers(PRtcConfiguration pRtcConfiguration);

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -294,7 +294,7 @@ class WebRtcClientTestBase : public ::testing::Test {
     }
 
     bool connectTwoPeers(PRtcPeerConnection offerPc, PRtcPeerConnection answerPc, PCHAR pOfferCertFingerprint = NULL,
-                         PCHAR pAnswerCertFingerprint = NULL);
+                         PCHAR pAnswerCertFingerprint = NULL, bool forwardOfferCandidates = true);
     void addTrackToPeerConnection(PRtcPeerConnection pRtcPeerConnection, PRtcMediaStreamTrack track, PRtcRtpTransceiver* transceiver, RTC_CODEC codec,
                                   MEDIA_STREAM_TRACK_KIND kind);
     void getIceServers(PRtcConfiguration pRtcConfiguration);


### PR DESCRIPTION
*What was changed?*

Full ICE-lite support in the local agent per RFC 8445 §2.5:

- New \`iceLiteMode\` boolean on \`KvsRtcConfiguration\`. When set, the agent advertises \`a=ice-lite\` in its SDP, gathers only host candidates, skips initiating connectivity checks, and assumes the controlled role regardless of offer/answer direction.
- Remote-side ICE-lite detection: when a peer's SDP contains \`a=ice-lite\`, \`PKvsPeerConnection\` sets \`remoteIsIceLite\` and forces the controlling role on our agent (since an ICE-lite peer will never try to take control).
- Agent state machine skips the connectivity-check phases for ICE-lite locally.
- Tests: \`tst/IceFunctionalityTest.cpp\` gains \`iceLiteAgentFlagSetCorrectly\` and \`iceLiteAgentFlagDefaultFalse\`; \`tst/SdpApiTest.cpp\` gains \`iceLiteAttributeInSDP\`, \`noIceLiteByDefault\`, \`parseRemoteIceLiteAttribute\`, and \`iceLiteAgentAlwaysControlled\` covering both offer-emission and offer-parsing paths plus role assignment.

*Why was it changed?*

We want the SDK to be usable as an ICE-lite endpoint in server-side deployments (media relays, SFUs, recording nodes) where the server has a stable public address and doesn't need to probe — the full ICE machinery is wasteful there and delays connection establishment. Several contributors have asked for this; it also unlocks interop with clients that require an ICE-lite peer.

*How was it changed?*

- \`src/include/.../Include.h\`: \`iceLiteMode\` config field.
- \`src/source/Ice/IceAgent.{h,c}\`: \`isLiteAgent\` / \`remoteIsLiteAgent\` flags on \`IceAgent\`, conditional connectivity-check logic.
- \`src/source/Ice/IceAgentStateMachine.c\`: skip check phases when lite.
- \`src/source/PeerConnection/PeerConnection.{h,c}\`: \`remoteIsIceLite\` on peer connection, role-forcing when the remote is lite.
- \`src/source/PeerConnection/SessionDescription.c\`: emit/parse \`a=ice-lite\`.

*What testing was done for the changes?*

New unit tests in \`IceFunctionalityTest\` and \`SdpApiTest\` cover flag propagation, SDP attribute emission/parsing, and role assignment under both offer and answer scenarios. Ran the full \`webrtc_client_test\` suite locally on macOS (no AWS credentials); passes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.