### PR TITLE
Fix UAF in RED split branch and double-free on transceiverOnRtpPacketReceived error return

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -506,10 +506,16 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
         CHK(FALSE, STATUS_SUCCESS);
     }
 
-    // pRtpPacket ownership transfers to transceiverOnRtpPacketReceived
-    CHK_STATUS(transceiverOnRtpPacketReceived(pTransceiver, pRtpPacket));
-    pRtpPacket = NULL;
-    pPayload = NULL;
+    // Ownership transfers to transceiverOnRtpPacketReceived on all paths: it frees the packet in
+    // its own CleanUp when ownedByJitterBuffer is FALSE (including when jitterBufferPush returns
+    // an error from rtPush, which can happen after the packet has already been stored in the ring).
+    // Null out before the call so the caller's CleanUp below is a no-op regardless of return status;
+    // otherwise an error return would double-free.
+    {
+        PRtpPacket pReceived = pRtpPacket;
+        pRtpPacket = NULL;
+        CHK_STATUS(transceiverOnRtpPacketReceived(pTransceiver, pReceived));
+    }
 
 CleanUp:
     SAFE_MEMFREE(pPayload);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -373,14 +373,21 @@ STATUS transceiverOnRtpPacketReceived(PKvsRtpTransceiver pTransceiver, PRtpPacke
                 UINT32 k;
                 for (k = 0; k < produced; k++) {
                     PRtpPacket pSyn = redSynthetics[k];
+                    // Capture fields BEFORE push: jitterBufferPush may freeRtpPacket(pSyn)
+                    // in the dedup branch (existing real + incoming synthetic), and reading
+                    // pSyn->isSynthetic or pSyn->payloadLength after a successful push is a
+                    // use-after-free. Depending on the allocator, the bytes may coincidentally
+                    // still read as "valid" which is why this slipped past opt-mode testing.
+                    BOOL wasSynthetic = pSyn->isSynthetic;
+                    UINT32 synPayloadLength = pSyn->payloadLength;
                     BOOL synDiscarded = FALSE;
-                    if (pSyn->isSynthetic) {
+                    if (wasSynthetic) {
                         fecPacketsReceived++;
-                        fecBytesReceivedCount += pSyn->payloadLength;
+                        fecBytesReceivedCount += synPayloadLength;
                     }
                     STATUS pushStatus = jitterBufferPush(pTransceiver->pJitterBuffer, pSyn, &synDiscarded);
                     if (STATUS_FAILED(pushStatus) || synDiscarded) {
-                        if (pSyn->isSynthetic) {
+                        if (wasSynthetic) {
                             fecPacketsDiscarded++;
                         } else if (synDiscarded) {
                             packetsDiscarded++;

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2990,14 +2990,22 @@ TEST_F(PeerConnectionFunctionalityTest, opusRedEndToEndDedup)
     // receive branch actually ran and therefore the UAF line was executed many times.
     EXPECT_GT(framesReceived.load(), 0u) << "answerer did not receive any Opus frames; RED receive branch never exercised";
 
+    // Snapshot counters under the transceiver's statsLock — the ICE/RTP thread writes
+    // inboundStats.fec* fields under this same lock from transceiverOnRtpPacketReceived,
+    // so reading bare would be a TSan-visible data race.
+    UINT64 fecReceivedSnapshot;
+    UINT64 fecDiscardedSnapshot;
+    MUTEX_LOCK(pKvsAnswerAudio->statsLock);
+    fecReceivedSnapshot = pKvsAnswerAudio->inboundStats.fecPacketsReceived;
+    fecDiscardedSnapshot = pKvsAnswerAudio->inboundStats.fecPacketsDiscarded;
+    MUTEX_UNLOCK(pKvsAnswerAudio->statsLock);
+
     // Confirm the RED receive path actually counted redundant blocks — if this is zero
     // then sendPacketToRtpReceiver's RED split branch never executed the buggy read.
     DLOGI("opusRedEndToEndDedup: framesReceived=%u fecPacketsReceived=%llu fecPacketsDiscarded=%llu", framesReceived.load(),
-          (unsigned long long) pKvsAnswerAudio->inboundStats.fecPacketsReceived,
-          (unsigned long long) pKvsAnswerAudio->inboundStats.fecPacketsDiscarded);
-    EXPECT_GT(pKvsAnswerAudio->inboundStats.fecPacketsReceived, 0u)
-        << "no redundant blocks counted — the RED split branch in sendPacketToRtpReceiver did not run, "
-        << "so the UAF line was not exercised and this test cannot reproduce the bug";
+          (unsigned long long) fecReceivedSnapshot, (unsigned long long) fecDiscardedSnapshot);
+    EXPECT_GT(fecReceivedSnapshot, 0u) << "no redundant blocks counted — the RED split branch in sendPacketToRtpReceiver did not run, "
+                                       << "so the UAF line was not exercised and this test cannot reproduce the bug";
 
     MEMFREE(opusBytes);
 

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2901,6 +2901,111 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
         EXPECT_LT(medianAudioLatency, STEADY_STATE_LATENCY_LIMIT) << "Audio median latency " << medianAudioMs << " ms exceeded limit";
     }
 }
+
+// Reproduces a use-after-free in sendPacketToRtpReceiver's RED split branch.
+//
+// When useRedForOpus is true on both peers, the receiver's sendPacketToRtpReceiver
+// splits each inbound RED packet into N+1 synthetic per-Opus-frame packets and pushes
+// each through the jitter buffer. The JB dedups an incoming synthetic against an
+// already-present real packet at the same seq by calling freeRtpPacket(pSyn) from
+// inside jitterBufferPush. The production code then reads pSyn->isSynthetic and
+// pSyn->payloadLength after the push — that's a read of freed memory.
+//
+// Under default libc / macOS allocators the freed byte often still reads as its
+// previous value, so the bug is silent in opt-mode testing. Under ASan (or any
+// scrubbing / guard allocator) it surfaces immediately as heap-use-after-free.
+//
+// The test drives the full receive path: two connected PeerConnections, both with
+// useRedForOpus=TRUE, one sending Opus frames, the other receiving. Every wire
+// packet after the first triggers the dedup branch, so the UAF is exercised many
+// times per run. Assertion failure is incidental — the real signal is an ASan
+// heap-use-after-free when the build has -fsanitize=address.
+TEST_F(PeerConnectionFunctionalityTest, opusRedEndToEndDedup)
+{
+    constexpr UINT32 NUM_FRAMES = 50;
+    constexpr UINT32 OPUS_FRAME_SIZE = 80; // arbitrary; codec is opaque below RED
+    constexpr UINT64 OPUS_FRAME_DURATION = 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+
+    RtcConfiguration cfg{};
+    initRtcConfiguration(&cfg);
+    cfg.kvsRtcConfiguration.useRedForOpus = TRUE;
+    // The dedup path that frees the synthetic only fires reliably in the RealTime JB —
+    // the classic JB removes packets from its hash table on delivery, so subsequent
+    // synthetics get stored as new packets rather than dedup'd, and the UAF branch
+    // (if (pSyn->isSynthetic) inside `synDiscarded`) is never executed.
+    cfg.kvsRtcConfiguration.useRealTimeJitterBuffer = TRUE;
+
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&cfg, &offerPc));
+    EXPECT_EQ(STATUS_SUCCESS, createPeerConnection(&cfg, &answerPc));
+
+    RtcMediaStreamTrack offerAudioTrack{}, answerAudioTrack{};
+    PRtcRtpTransceiver offerAudioTransceiver = NULL, answerAudioTransceiver = NULL;
+    addTrackToPeerConnection(offerPc, &offerAudioTrack, &offerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+    addTrackToPeerConnection(answerPc, &answerAudioTrack, &answerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+
+    std::atomic<UINT32> framesReceived{0};
+    auto onAudioFrame = [](UINT64 customData, PFrame pFrame) -> void {
+        UNUSED_PARAM(pFrame);
+        ((std::atomic<UINT32>*) customData)->fetch_add(1);
+    };
+    EXPECT_EQ(STATUS_SUCCESS, transceiverOnFrame(answerAudioTransceiver, (UINT64) &framesReceived, onAudioFrame));
+
+    ASSERT_EQ(TRUE, connectTwoPeers(offerPc, answerPc));
+
+    // Sanity: the SDP negotiation must have wired up RED on both sides. If it did not,
+    // the RED receive branch never runs and the UAF never fires — the test would then
+    // be a false "pass" under ASan, so assert the gate here.
+    PKvsPeerConnection pKvsOffer = (PKvsPeerConnection) offerPc;
+    PKvsPeerConnection pKvsAnswer = (PKvsPeerConnection) answerPc;
+    EXPECT_TRUE(pKvsOffer->useRedForOpus);
+    EXPECT_TRUE(pKvsAnswer->useRedForOpus);
+
+    // After negotiation, the answer-side transceiver must have receiverRedPayloadType set
+    // (that's what gates the sendPacketToRtpReceiver RED-split branch). If this is zero,
+    // the UAF line we are trying to exercise is unreachable.
+    PKvsRtpTransceiver pKvsAnswerAudio = (PKvsRtpTransceiver) answerAudioTransceiver;
+    EXPECT_NE(0, pKvsAnswerAudio->receiverRedPayloadType) << "RED not negotiated on answer side — RED receive branch will not run";
+
+    PBYTE opusBytes = (PBYTE) MEMALLOC(OPUS_FRAME_SIZE);
+    MEMSET(opusBytes, 0xAA, OPUS_FRAME_SIZE);
+    Frame frame{};
+    frame.frameData = opusBytes;
+    frame.size = OPUS_FRAME_SIZE;
+    frame.presentationTs = 0;
+
+    for (UINT32 i = 0; i < NUM_FRAMES; i++) {
+        STATUS s = writeFrame(offerAudioTransceiver, &frame);
+        EXPECT_TRUE(s == STATUS_SUCCESS || s == STATUS_SRTP_NOT_READY_YET);
+        frame.presentationTs += OPUS_FRAME_DURATION;
+        THREAD_SLEEP(OPUS_FRAME_DURATION);
+    }
+
+    // Allow in-flight packets to drain through the receiver.
+    for (UINT32 i = 0; i < 50 && framesReceived.load() < 10; i++) {
+        THREAD_SLEEP(20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+    }
+
+    // At least a handful of frames should have been delivered — confirms the RED
+    // receive branch actually ran and therefore the UAF line was executed many times.
+    EXPECT_GT(framesReceived.load(), 0u) << "answerer did not receive any Opus frames; RED receive branch never exercised";
+
+    // Confirm the RED receive path actually counted redundant blocks — if this is zero
+    // then sendPacketToRtpReceiver's RED split branch never executed the buggy read.
+    DLOGI("opusRedEndToEndDedup: framesReceived=%u fecPacketsReceived=%llu fecPacketsDiscarded=%llu", framesReceived.load(),
+          (unsigned long long) pKvsAnswerAudio->inboundStats.fecPacketsReceived,
+          (unsigned long long) pKvsAnswerAudio->inboundStats.fecPacketsDiscarded);
+    EXPECT_GT(pKvsAnswerAudio->inboundStats.fecPacketsReceived, 0u)
+        << "no redundant blocks counted — the RED split branch in sendPacketToRtpReceiver did not run, "
+        << "so the UAF line was not exercised and this test cannot reproduce the bug";
+
+    MEMFREE(opusBytes);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+}
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis


### PR DESCRIPTION
## Summary

Two distinct ownership/lifetime bugs on the receive path, plus a reproducer for the first one.

1. **Heap-use-after-free** in the RED split branch (read of `pSyn->isSynthetic` / `pSyn->payloadLength` after `jitterBufferPush` frees the synthetic via the RT JB's synthetic-vs-real dedup).
2. **Double-free** on any `transceiverOnRtpPacketReceived` error return: the callee's CleanUp frees `pRtpPacket`; the caller then frees the stale pointer again because `pRtpPacket = NULL` runs only on success.

Neither is threading-related; both are single-threaded lifetime bugs.

## Bug 1 — UAF in RED split branch

`sendPacketToRtpReceiver`'s RED split branch (now inside `transceiverOnRtpPacketReceived` after PR #69's extraction) passed ownership of each synthetic Opus packet to `jitterBufferPush`. In the real-time jitter buffer's synthetic-vs-real dedup branch, the push calls `freeRtpPacket(pSyn)`. The surrounding production code then read `pSyn->isSynthetic` and `pSyn->payloadLength` after the push returned — a use-after-free.

Under stock macOS / Linux libc allocators the freed byte typically reads back as its previous value, so opt-mode testing never surfaced the bug. Under ASan, tcache poisoning, or the consumer repo's strict allocator, the read is a deterministic heap-use-after-free.

ASan confirmation on `android-arm64` (before the fix commit on this branch):

```
==26218==ERROR: AddressSanitizer: heap-use-after-free on address 0x003d60c743b8
... PeerConnectionFunctionalityTest_opusRedEndToEndDedup_Test::TestBody()
... PeerConnectionFunctionalityTest.cpp:2954:5
```

Fix: capture the two fields into locals before the push.

## Bug 2 — Double-free on transceiverOnRtpPacketReceived error return

PR #69 extracted `transceiverOnRtpPacketReceived` and wired it with:

```c
CHK_STATUS(transceiverOnRtpPacketReceived(pTransceiver, pRtpPacket));
pRtpPacket = NULL;
```

On an error return the `CHK_STATUS` jumps to CleanUp before the null-out. Inside the callee, CleanUp frees the packet when `ownedByJitterBuffer == FALSE` (`PeerConnection.c:440`). `freeRtpPacket` takes `PRtpPacket*` but only nulls the callee's local; the caller retains a dangling pointer, and `freeRtpPacket(&pRtpPacket)` in its own CleanUp double-frees the storage plus `pRawPacket`.

Reachable trigger: `jitterBufferPush` returning an error from `rtPush` — e.g. the `CHK(frameCount < RT_MAX_FRAMES, STATUS_NOT_ENOUGH_MEMORY)` at `RealTimeJitterBuffer.c:536`, which fires **after** the packet is already stored in `pktRing`. Any `jitterBufferPush` failure triggers the same path; the callee's CleanUp does not distinguish pre- and post-store.

Fix: transfer ownership unconditionally in the caller by nulling `pRtpPacket` in the caller's frame before the call. Makes caller CleanUp a no-op on both success and error.

*What was changed?*

1. `src/source/PeerConnection/PeerConnection.c` (RED split branch) — capture `isSynthetic` and `payloadLength` into locals BEFORE the `jitterBufferPush` call. Three-line fix.
2. `src/source/PeerConnection/PeerConnection.c` (`sendPacketToRtpReceiver` → `transceiverOnRtpPacketReceived` call) — transfer ownership via a local `pReceived` and null the caller's pointer before `CHK_STATUS`, so an error return does not double-free.
3. `tst/PeerConnectionFunctionalityTest.cpp` — new `TEST_F(PeerConnectionFunctionalityTest, opusRedEndToEndDedup)` that drives the full RED receive path with two connected peer connections (both `useRedForOpus=TRUE`, both `useRealTimeJitterBuffer=TRUE`), 50 Opus frames one-way. Every wire packet after the first triggers the dedup branch, so the fixed UAF path runs ~49 times per test run.

*Why was it changed?*

The existing test suite had RED unit tests (`RtpRedPayloaderTest`) and JB-level integration tests (`OpusJitterBufferIntegrationTest`), but nothing spun up a real peer connection with `useRedForOpus=TRUE`. That glue layer — the RED split branch — had no coverage, so the UAF slipped past the original RED PR (#66) despite both adjacent layers being well-tested.

The double-free in bug 2 was introduced by PR #69's extraction of `transceiverOnRtpPacketReceived`: the new seam between caller and callee needs explicit ownership handoff to be correct on error, but the call site nulled after `CHK_STATUS` instead of before, leaving the error path double-freeing.

*How was it changed?*

Production fixes are minimal. Bug 1:

```c
// Capture fields BEFORE push: jitterBufferPush may freeRtpPacket(pSyn)
// in the dedup branch (existing real + incoming synthetic), and reading
// pSyn->isSynthetic or pSyn->payloadLength after a successful push is a
// use-after-free.
BOOL wasSynthetic = pSyn->isSynthetic;
UINT32 synPayloadLength = pSyn->payloadLength;
...
jitterBufferPush(pTransceiver->pJitterBuffer, pSyn, &synDiscarded);
if (STATUS_FAILED(pushStatus) || synDiscarded) {
    if (wasSynthetic) { fecPacketsDiscarded++; }
    else if (synDiscarded) { packetsDiscarded++; }
}
```

Bug 2:

```c
// Ownership transfers on all paths: callee frees in its own CleanUp when
// !ownedByJitterBuffer (including on jitterBufferPush errors). Null out
// before the call so the caller's CleanUp is a no-op on both success and
// error; otherwise an error return would double-free.
{
    PRtpPacket pReceived = pRtpPacket;
    pRtpPacket = NULL;
    CHK_STATUS(transceiverOnRtpPacketReceived(pTransceiver, pReceived));
}
```

The UAF reproducer test requires `useRealTimeJitterBuffer=TRUE`: the classic JB removes delivered packets from its hash table before the next RED container's synthetic arrives, so the dedup branch that frees the synthetic never runs under classic JB — the UAF is only reliably exercised by the RT JB path. The test sets both flags explicitly and asserts `receiverRedPayloadType != 0` post-negotiation + `fecPacketsReceived > 0` post-run so a silent false-pass (RED not negotiated, or branch not executed) is impossible.

*What testing was done for the changes?*

- Built with `-DADDRESS_SANITIZER=ON` via `build-android-arm64-asan.sh` on a connected android-arm64 device. **Before the UAF fix:** test fails with heap-use-after-free exactly at the post-`jitterBufferPush` read. **After the fix:** test passes cleanly with counters `framesReceived=50, fecPacketsReceived=49, fecPacketsDiscarded=49` (each primary-after-first dedup'd its paired redundant).
- Full `webrtc_client_test` suite still passes on the no-deps macOS build (including `RtcpFunctionalityTest.*` which exercises the extracted `transceiverOnRtpPacketReceived` directly).
- Rebased cleanly on latest `origin/main` (PR #69's refactor).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.