### PR TITLE
Fix negative cum_lost in RRs when initial packets arrive reordered

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -300,21 +300,141 @@ static VOID rrUpdateSeq(PKvsRtpTransceiver pTransceiver, UINT16 seq)
     // else duplicate or reordered packet — ignore for max tracking
 }
 
+STATUS transceiverOnRtpPacketReceived(PKvsRtpTransceiver pTransceiver, PRtpPacket pRtpPacket)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    BOOL ownedByJitterBuffer = FALSE, discarded = FALSE;
+    UINT64 packetsReceived = 0, lastPacketReceivedTimestamp = 0, headerBytesReceived = 0, bytesReceived = 0, packetsDiscarded = 0;
+    UINT64 fecPacketsReceived = 0, fecBytesReceivedCount = 0, fecPacketsDiscarded = 0;
+    INT64 arrival, r_ts, transit, delta;
+    UINT64 now;
+
+    CHK(pTransceiver != NULL && pTransceiver->pJitterBuffer != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
+
+    now = pRtpPacket->receivedTime;
+
+    {
+        BOOL firstPacket = !pTransceiver->rrSeqInitialized;
+        packetsReceived++;
+
+        if (firstPacket) {
+            rrInitSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
+        } else {
+            rrUpdateSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
+        }
+
+        // https://tools.ietf.org/html/rfc3550#section-6.4.1
+        // https://tools.ietf.org/html/rfc3550#appendix-A.8
+        // interarrival jitter
+        // arrival, the current time in the same units.
+        // r_ts, the timestamp from   the incoming packet
+        arrival = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, pTransceiver->pJitterBuffer->clockRate);
+        r_ts = pRtpPacket->header.timestamp;
+        transit = arrival - r_ts;
+        if (firstPacket) {
+            // RFC 3550 §A.8: seed transit on first packet, skip the D(i-1,i) update.
+            pTransceiver->pJitterBuffer->transit = (UINT64) transit;
+            pTransceiver->pJitterBuffer->jitter = 0.0;
+        } else {
+            delta = transit - (INT64) pTransceiver->pJitterBuffer->transit;
+            pTransceiver->pJitterBuffer->transit = (UINT64) transit;
+            pTransceiver->pJitterBuffer->jitter += (ABS(delta) - pTransceiver->pJitterBuffer->jitter) / 16.0;
+        }
+
+        headerBytesReceived += RTP_HEADER_LEN(pRtpPacket);
+        bytesReceived += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);
+
+        // RFC 2198 RED split branch. When the inbound packet carries the negotiated RED PT,
+        // expand it into up to (redundancy+1) synthetic packets and feed each through the
+        // jitter buffer. Primary packet keeps the real seqnum/ts; redundant blocks get
+        // synthesized seqnums (seq - distance) and ts (ts - offset) and are tagged
+        // isSynthetic=TRUE so the jitter buffer's dedup can prefer real packets.
+        if (pTransceiver->receiverRedPayloadType != 0 && pRtpPacket->header.payloadType == pTransceiver->receiverRedPayloadType) {
+            PRtpPacket redSynthetics[RED_MAX_BLOCKS] = {};
+            UINT32 produced = 0;
+            UINT32 fecBytes = 0;
+            STATUS splitStatus =
+                splitRedRtpPacket(pRtpPacket, pTransceiver->receiverOpusPayloadType, redSynthetics, RED_MAX_BLOCKS, &produced, &fecBytes);
+            if (STATUS_SUCCEEDED(splitStatus) && produced > 0) {
+                UINT32 k;
+                for (k = 0; k < produced; k++) {
+                    PRtpPacket pSyn = redSynthetics[k];
+                    BOOL synDiscarded = FALSE;
+                    if (pSyn->isSynthetic) {
+                        fecPacketsReceived++;
+                        fecBytesReceivedCount += pSyn->payloadLength;
+                    }
+                    STATUS pushStatus = jitterBufferPush(pTransceiver->pJitterBuffer, pSyn, &synDiscarded);
+                    if (STATUS_FAILED(pushStatus) || synDiscarded) {
+                        if (pSyn->isSynthetic) {
+                            fecPacketsDiscarded++;
+                        } else if (synDiscarded) {
+                            packetsDiscarded++;
+                        }
+                        // jitterBufferPush consumes the packet regardless; if it failed, it still owns the pointer.
+                    }
+                }
+                // Outer RED packet is fully consumed; free it now.
+                freeRtpPacket(&pRtpPacket);
+                pRtpPacket = NULL;
+            } else {
+                // Malformed RED — drop the outer packet.
+                DLOGW("Discarded malformed RED packet (status 0x%08x)", splitStatus);
+                freeRtpPacket(&pRtpPacket);
+                pRtpPacket = NULL;
+                packetsDiscarded++;
+            }
+            lastPacketReceivedTimestamp = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
+            ownedByJitterBuffer = TRUE;
+            CHK(FALSE, STATUS_SUCCESS);
+        }
+
+        CHK_STATUS(jitterBufferPush(pTransceiver->pJitterBuffer, pRtpPacket, &discarded));
+        if (discarded) {
+            packetsDiscarded++;
+        }
+        lastPacketReceivedTimestamp = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
+        ownedByJitterBuffer = TRUE;
+    }
+
+CleanUp:
+    if (packetsReceived > 0) {
+        MUTEX_LOCK(pTransceiver->statsLock);
+        pTransceiver->inboundStats.received.packetsReceived += packetsReceived;
+        pTransceiver->inboundStats.lastPacketReceivedTimestamp = lastPacketReceivedTimestamp;
+        pTransceiver->inboundStats.headerBytesReceived += headerBytesReceived;
+        pTransceiver->inboundStats.bytesReceived += bytesReceived;
+        pTransceiver->inboundStats.received.jitter = pTransceiver->pJitterBuffer->jitter / pTransceiver->pJitterBuffer->clockRate;
+        pTransceiver->inboundStats.received.packetsDiscarded += packetsDiscarded;
+        pTransceiver->inboundStats.fecPacketsReceived += fecPacketsReceived;
+        pTransceiver->inboundStats.fecBytesReceived += fecBytesReceivedCount;
+        pTransceiver->inboundStats.fecPacketsDiscarded += fecPacketsDiscarded;
+        if (pTransceiver->rrSeqInitialized) {
+            UINT32 extMax = pTransceiver->rrCycles + pTransceiver->rrMaxSeq;
+            UINT32 expected = extMax - pTransceiver->rrBaseSeq + 1;
+            pTransceiver->inboundStats.received.packetsLost = (INT64) expected - (INT64) pTransceiver->inboundStats.received.packetsReceived;
+        }
+        MUTEX_UNLOCK(pTransceiver->statsLock);
+    }
+    if (!ownedByJitterBuffer) {
+        freeRtpPacket(&pRtpPacket);
+    }
+    CHK_LOG_ERR(retStatus);
+
+    LEAVES();
+    return retStatus;
+}
+
 STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuffer, UINT32 bufferLen)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
-    PDoubleListNode pCurNode = NULL;
-    PKvsRtpTransceiver pTransceiver;
-    UINT64 item, now;
+    PKvsRtpTransceiver pTransceiver = NULL;
+    UINT64 now;
     UINT32 ssrc;
     PRtpPacket pRtpPacket = NULL;
     PBYTE pPayload = NULL;
-    BOOL ownedByJitterBuffer = FALSE, discarded = FALSE;
-    UINT64 packetsReceived = 0, packetsFailedDecryption = 0, lastPacketReceivedTimestamp = 0, headerBytesReceived = 0, bytesReceived = 0,
-           packetsDiscarded = 0;
-    UINT64 fecPacketsReceived = 0, fecBytesReceivedCount = 0, fecPacketsDiscarded = 0;
-    INT64 arrival, r_ts, transit, delta;
 
     CHK(pKvsPeerConnection != NULL && pBuffer != NULL, STATUS_NULL_ARG);
     CHK(bufferLen >= MIN_HEADER_LENGTH, STATUS_INVALID_ARG);
@@ -345,7 +465,6 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
     // Now decrypt
     if (STATUS_FAILED(retStatus = decryptSrtpPacket(pKvsPeerConnection->pSrtpSession, pBuffer, (PINT32) &bufferLen))) {
         DLOGW("decryptSrtpPacket failed with 0x%08x", retStatus);
-        packetsFailedDecryption++;
         CHK(FALSE, STATUS_SUCCESS);
     }
 
@@ -362,126 +481,19 @@ STATUS sendPacketToRtpReceiver(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuf
 
     ssrc = pRtpPacket->header.ssrc;
 
-    // Find matching transceiver for this SSRC
-    CHK_STATUS(doubleListGetHeadNode(pKvsPeerConnection->pTransceivers, &pCurNode));
-    while (pCurNode != NULL) {
-        CHK_STATUS(doubleListGetNodeData(pCurNode, &item));
-        pTransceiver = (PKvsRtpTransceiver) item;
-
-        if (pTransceiver->jitterBufferSsrc == ssrc) {
-            BOOL firstPacket = !pTransceiver->rrSeqInitialized;
-            packetsReceived++;
-
-            if (firstPacket) {
-                rrInitSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
-            } else {
-                rrUpdateSeq(pTransceiver, pRtpPacket->header.sequenceNumber);
-            }
-
-            // https://tools.ietf.org/html/rfc3550#section-6.4.1
-            // https://tools.ietf.org/html/rfc3550#appendix-A.8
-            // interarrival jitter
-            // arrival, the current time in the same units.
-            // r_ts, the timestamp from   the incoming packet
-            arrival = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, pTransceiver->pJitterBuffer->clockRate);
-            r_ts = pRtpPacket->header.timestamp;
-            transit = arrival - r_ts;
-            if (firstPacket) {
-                // RFC 3550 §A.8: seed transit on first packet, skip the D(i-1,i) update.
-                pTransceiver->pJitterBuffer->transit = (UINT64) transit;
-                pTransceiver->pJitterBuffer->jitter = 0.0;
-            } else {
-                delta = transit - (INT64) pTransceiver->pJitterBuffer->transit;
-                pTransceiver->pJitterBuffer->transit = (UINT64) transit;
-                pTransceiver->pJitterBuffer->jitter += (ABS(delta) - pTransceiver->pJitterBuffer->jitter) / 16.0;
-            }
-
-            headerBytesReceived += RTP_HEADER_LEN(pRtpPacket);
-            bytesReceived += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);
-
-            // RFC 2198 RED split branch. When the inbound packet carries the negotiated RED PT,
-            // expand it into up to (redundancy+1) synthetic packets and feed each through the
-            // jitter buffer. Primary packet keeps the real seqnum/ts; redundant blocks get
-            // synthesized seqnums (seq - distance) and ts (ts - offset) and are tagged
-            // isSynthetic=TRUE so the jitter buffer's dedup can prefer real packets.
-            if (pTransceiver->receiverRedPayloadType != 0 && pRtpPacket->header.payloadType == pTransceiver->receiverRedPayloadType) {
-                PRtpPacket redSynthetics[RED_MAX_BLOCKS] = {};
-                UINT32 produced = 0;
-                UINT32 fecBytes = 0;
-                STATUS splitStatus =
-                    splitRedRtpPacket(pRtpPacket, pTransceiver->receiverOpusPayloadType, redSynthetics, RED_MAX_BLOCKS, &produced, &fecBytes);
-                if (STATUS_SUCCEEDED(splitStatus) && produced > 0) {
-                    UINT32 k;
-                    for (k = 0; k < produced; k++) {
-                        PRtpPacket pSyn = redSynthetics[k];
-                        BOOL synDiscarded = FALSE;
-                        if (pSyn->isSynthetic) {
-                            fecPacketsReceived++;
-                            fecBytesReceivedCount += pSyn->payloadLength;
-                        }
-                        STATUS pushStatus = jitterBufferPush(pTransceiver->pJitterBuffer, pSyn, &synDiscarded);
-                        if (STATUS_FAILED(pushStatus) || synDiscarded) {
-                            if (pSyn->isSynthetic) {
-                                fecPacketsDiscarded++;
-                            } else if (synDiscarded) {
-                                packetsDiscarded++;
-                            }
-                            // jitterBufferPush consumes the packet regardless; if it failed, it still owns the pointer.
-                        }
-                    }
-                    // Outer RED packet is fully consumed; free it now.
-                    freeRtpPacket(&pRtpPacket);
-                    pRtpPacket = NULL;
-                } else {
-                    // Malformed RED — drop the outer packet.
-                    DLOGW("Discarded malformed RED packet (status 0x%08x)", splitStatus);
-                    freeRtpPacket(&pRtpPacket);
-                    pRtpPacket = NULL;
-                    packetsDiscarded++;
-                }
-                lastPacketReceivedTimestamp = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
-                ownedByJitterBuffer = TRUE;
-                CHK(FALSE, STATUS_SUCCESS);
-            }
-
-            CHK_STATUS(jitterBufferPush(pTransceiver->pJitterBuffer, pRtpPacket, &discarded));
-            if (discarded) {
-                packetsDiscarded++;
-            }
-            lastPacketReceivedTimestamp = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
-            ownedByJitterBuffer = TRUE;
-            CHK(FALSE, STATUS_SUCCESS);
-        }
-        pCurNode = pCurNode->pNext;
+    if (STATUS_FAILED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, ssrc))) {
+        DLOGW("No transceiver to handle inbound ssrc %u", ssrc);
+        CHK(FALSE, STATUS_SUCCESS);
     }
 
-    DLOGW("No transceiver to handle inbound ssrc %u", ssrc);
+    // pRtpPacket ownership transfers to transceiverOnRtpPacketReceived
+    CHK_STATUS(transceiverOnRtpPacketReceived(pTransceiver, pRtpPacket));
+    pRtpPacket = NULL;
+    pPayload = NULL;
 
 CleanUp:
-    if (packetsReceived > 0) {
-        MUTEX_LOCK(pTransceiver->statsLock);
-        pTransceiver->inboundStats.received.packetsReceived += packetsReceived;
-        pTransceiver->inboundStats.packetsFailedDecryption += packetsFailedDecryption;
-        pTransceiver->inboundStats.lastPacketReceivedTimestamp = lastPacketReceivedTimestamp;
-        pTransceiver->inboundStats.headerBytesReceived += headerBytesReceived;
-        pTransceiver->inboundStats.bytesReceived += bytesReceived;
-        pTransceiver->inboundStats.received.jitter = pTransceiver->pJitterBuffer->jitter / pTransceiver->pJitterBuffer->clockRate;
-        pTransceiver->inboundStats.received.packetsDiscarded += packetsDiscarded;
-        pTransceiver->inboundStats.fecPacketsReceived += fecPacketsReceived;
-        pTransceiver->inboundStats.fecBytesReceived += fecBytesReceivedCount;
-        pTransceiver->inboundStats.fecPacketsDiscarded += fecPacketsDiscarded;
-        if (pTransceiver->rrSeqInitialized) {
-            UINT32 extMax = pTransceiver->rrCycles + pTransceiver->rrMaxSeq;
-            UINT32 expected = extMax - pTransceiver->rrBaseSeq + 1;
-            pTransceiver->inboundStats.received.packetsLost = (INT64) expected - (INT64) pTransceiver->inboundStats.received.packetsReceived;
-        }
-        MUTEX_UNLOCK(pTransceiver->statsLock);
-    }
-    if (!ownedByJitterBuffer) {
-        SAFE_MEMFREE(pPayload);
-        freeRtpPacket(&pRtpPacket);
-        CHK_LOG_ERR(retStatus);
-    }
+    SAFE_MEMFREE(pPayload);
+    freeRtpPacket(&pRtpPacket);
     CHK_LOG_ERR(retStatus);
 
     LEAVES();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -296,8 +296,21 @@ static VOID rrUpdateSeq(PKvsRtpTransceiver pTransceiver, UINT16 seq)
         } else {
             pTransceiver->rrBadSeq = ((UINT32) seq + 1) & (RTP_SEQ_MOD - 1);
         }
+    } else {
+        // Reorder: packet is 1..MAX_MISORDER before rrMaxSeq in extended-seq
+        // space. If its extended seq is less than rrBaseSeq, the remote started
+        // earlier than rrInitSeq captured (e.g. seq=10,11 reach us before seq
+        // 0..9 due to jitter). Extend rrBaseSeq down so
+        // "expected = extMax - baseSeq + 1" covers every received packet and
+        // cum_lost stays non-negative. Comparing in UINT32 extended space
+        // rejects late stragglers from prior cycles (their extPacket wraps above
+        // any plausible rrBaseSeq).
+        UINT32 backward = (UINT16) (pTransceiver->rrMaxSeq - seq);
+        UINT32 extPacket = pTransceiver->rrCycles + pTransceiver->rrMaxSeq - backward;
+        if (extPacket < pTransceiver->rrBaseSeq) {
+            pTransceiver->rrBaseSeq = extPacket;
+        }
     }
-    // else duplicate or reordered packet — ignore for max tracking
 }
 
 STATUS transceiverOnRtpPacketReceived(PKvsRtpTransceiver pTransceiver, PRtpPacket pRtpPacket)

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -140,6 +140,7 @@ STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPack
 
 STATUS hasTransceiverWithSsrc(PKvsPeerConnection pKvsPeerConnection, UINT32 ssrc);
 STATUS findTransceiverBySsrc(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTransceiver* ppTransceiver, UINT32 ssrc);
+STATUS transceiverOnRtpPacketReceived(PKvsRtpTransceiver, PRtpPacket);
 
 STATUS setUpRollingBufferConfigInternal(PKvsRtpTransceiver, PRtcMediaStreamTrack, DOUBLE, DOUBLE);
 STATUS freeRollingBufferConfig(PRollingBufferConfig);

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1126,6 +1126,46 @@ TEST_F(RtcpFunctionalityTest, receiverReportReorderedDuplicate)
     freePeerConnection(&pRtcPeerConnection);
 }
 
+// Reproduces negative cumulative lost when initial packets arrive out of order.
+// Scenario from pcap: remote starts at seq=0, but seq=10,11 arrive first, then
+// seq=0..9 arrive late. rrInitSeq(10) sets rrBaseSeq=10, and the 10 late packets
+// (seq 0-9) each increment packetsReceived but never lower rrBaseSeq, so
+// expected permanently undercounts by 10.
+TEST_F(RtcpFunctionalityTest, receiverReportNegativeLossOnReorderedStart)
+{
+    initTransceiver(1000);
+    auto* pT = pKvsRtpTransceiver;
+    pT->jitterBufferSsrc = 0xabcd1234;
+
+    // Simulate state after: rrInitSeq(10), rrUpdateSeq for seq 11, then
+    // seq 0-9 (all fall into reorder/dup else branch — rrMaxSeq stays),
+    // then seq 12..99 (normal forward).
+    // Final rrMaxSeq = 99, rrBaseSeq = 10 (never adjusted down).
+    pT->rrBaseSeq = 10;
+    pT->rrMaxSeq = 99;
+    pT->rrCycles = 0;
+    pT->rrBadSeq = RTP_SEQ_MOD + 1;
+    pT->rrExpectedPrior = 0;
+    pT->rrReceivedPrior = 0;
+    pT->rrSeqInitialized = TRUE;
+
+    // All 100 packets (seq 0..99) were received — no actual loss.
+    pT->inboundStats.received.packetsReceived = 100;
+
+    BYTE buf[64];
+    UINT32 len = sizeof(buf);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, GETTIME(), buf, &len));
+    EXPECT_EQ(32u, len);
+
+    // expected = 99 - 10 + 1 = 90, received = 100 → cumLost = -10
+    // BUG: should be 0 since no packets were actually lost.
+    INT32 cum = rrBlockCumLost(buf);
+    EXPECT_EQ(0, cum) << "negative cum_lost " << cum
+                       << " indicates rrBaseSeq was not adjusted for late-arriving earlier packets";
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
 TEST_F(RtcpFunctionalityTest, receiverReportFirstReportEmitsZeroJitter)
 {
     initTransceiver(1000);

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1126,42 +1126,55 @@ TEST_F(RtcpFunctionalityTest, receiverReportReorderedDuplicate)
     freePeerConnection(&pRtcPeerConnection);
 }
 
-// Reproduces negative cumulative lost when initial packets arrive out of order.
-// Scenario from pcap: remote starts at seq=0, but seq=10,11 arrive first, then
-// seq=0..9 arrive late. rrInitSeq(10) sets rrBaseSeq=10, and the 10 late packets
-// (seq 0-9) each increment packetsReceived but never lower rrBaseSeq, so
-// expected permanently undercounts by 10.
-TEST_F(RtcpFunctionalityTest, receiverReportNegativeLossOnReorderedStart)
+// Black-box reproduction of the negative-cum_lost bug via the real receive path.
+// Builds raw RTP packets in the exact arrival order observed in the user's pcap
+// (seq=10,11, then 0..9 late, then 12..99 in order) and feeds each through
+// transceiverOnRtpPacketReceived, which exercises rrInitSeq/rrUpdateSeq and the
+// packetsReceived counter. Then builds an RR and asserts cum_lost == 0.
+TEST_F(RtcpFunctionalityTest, receiverReportReorderedStartViaPacketReceive)
 {
     initTransceiver(1000);
     auto* pT = pKvsRtpTransceiver;
-    pT->jitterBufferSsrc = 0xabcd1234;
+    const UINT32 ssrc = 0xabcd1234;
+    pT->jitterBufferSsrc = ssrc;
 
-    // Simulate state after: rrInitSeq(10), rrUpdateSeq for seq 11, then
-    // seq 0-9 (all fall into reorder/dup else branch — rrMaxSeq stays),
-    // then seq 12..99 (normal forward).
-    // Final rrMaxSeq = 99, rrBaseSeq = 10 (never adjusted down).
-    pT->rrBaseSeq = 10;
-    pT->rrMaxSeq = 99;
-    pT->rrCycles = 0;
-    pT->rrBadSeq = RTP_SEQ_MOD + 1;
-    pT->rrExpectedPrior = 0;
-    pT->rrReceivedPrior = 0;
-    pT->rrSeqInitialized = TRUE;
+    std::vector<UINT16> arrivalOrder{10, 11};
+    for (UINT16 s = 0; s <= 9; s++) {
+        arrivalOrder.push_back(s);
+    }
+    for (UINT16 s = 12; s <= 99; s++) {
+        arrivalOrder.push_back(s);
+    }
+    ASSERT_EQ(100u, arrivalOrder.size());
 
-    // All 100 packets (seq 0..99) were received — no actual loss.
-    pT->inboundStats.received.packetsReceived = 100;
+    const UINT64 now = GETTIME();
+    const UINT32 clockRate = pT->pJitterBuffer->clockRate;
+    const UINT32 baseTs = 100000;
+
+    for (UINT16 seq : arrivalOrder) {
+        TestRtpPacket params;
+        params.seqNum = seq;
+        params.ssrc = ssrc;
+        params.timestamp = baseTs + (UINT32) seq * (clockRate / 1000);
+        PRtpPacket pPkt = nullptr;
+        ASSERT_EQ(STATUS_SUCCESS, createTestRtpPacket(params, &pPkt));
+        pPkt->receivedTime = now;
+        ASSERT_EQ(STATUS_SUCCESS, transceiverOnRtpPacketReceived(pT, pPkt));
+    }
+
+    EXPECT_EQ(0u, pT->rrBaseSeq);
+    EXPECT_EQ(99u, pT->rrMaxSeq);
+    EXPECT_EQ(0u, pT->rrCycles);
+    EXPECT_EQ(100u, pT->inboundStats.received.packetsReceived);
 
     BYTE buf[64];
     UINT32 len = sizeof(buf);
     EXPECT_EQ(STATUS_SUCCESS, rtcpBuildReceiverReport(pT, GETTIME(), buf, &len));
     EXPECT_EQ(32u, len);
-
-    // expected = 99 - 10 + 1 = 90, received = 100 → cumLost = -10
-    // BUG: should be 0 since no packets were actually lost.
+    EXPECT_EQ(0u, rrBlockFracLost(buf));
     INT32 cum = rrBlockCumLost(buf);
-    EXPECT_EQ(0, cum) << "negative cum_lost " << cum
-                       << " indicates rrBaseSeq was not adjusted for late-arriving earlier packets";
+    EXPECT_EQ(0, cum) << "end-to-end negative cum_lost " << cum
+                       << " from reordered session start";
 
     freePeerConnection(&pRtcPeerConnection);
 }

--- a/tst/WebRTCClientTestFixture.cpp
+++ b/tst/WebRTCClientTestFixture.cpp
@@ -17,21 +17,48 @@ UINT64 gTotalWebRtcClientMemoryUsage = 0;
 //
 MUTEX gTotalWebRtcClientMemoryMutex;
 
-STATUS createRtpPacketWithSeqNum(UINT16 seqNum, PRtpPacket* ppRtpPacket)
+STATUS createTestRtpPacket(const TestRtpPacket& params, PRtpPacket* ppRtpPacket)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    BYTE payload[10];
-    PRtpPacket pRtpPacket = NULL;
+    PRtpPacket pTmp = NULL;
+    PRtpPacket pFinal = NULL;
+    PBYTE pRaw = NULL;
+    UINT32 rawLen = 0;
+    // Local payload — copied into pRaw by createBytesFromRtpPacket; after the
+    // re-parse below the final packet's `payload` points inside its own pRaw.
+    std::vector<BYTE> payload(params.payloadLength, 0);
 
-    CHK_STATUS(createRtpPacket(2, FALSE, FALSE, 0, FALSE, 96, seqNum, 100, 0x1234ABCD, NULL, 0, 0, NULL, payload, 10, &pRtpPacket));
-    *ppRtpPacket = pRtpPacket;
+    CHK(ppRtpPacket != NULL, STATUS_NULL_ARG);
 
-    CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, NULL, &pRtpPacket->rawPacketLength));
-    CHK(NULL != (pRtpPacket->pRawPacket = (PBYTE) MEMALLOC(pRtpPacket->rawPacketLength)), STATUS_NOT_ENOUGH_MEMORY);
-    CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, pRtpPacket->pRawPacket, &pRtpPacket->rawPacketLength));
+    CHK_STATUS(createRtpPacket(2, FALSE, FALSE, 0, params.marker, params.payloadType, params.seqNum, params.timestamp, params.ssrc, NULL, 0, 0, NULL,
+                               payload.data(), (UINT32) payload.size(), &pTmp));
+    CHK_STATUS(createBytesFromRtpPacket(pTmp, NULL, &rawLen));
+    CHK(NULL != (pRaw = (PBYTE) MEMALLOC(rawLen)), STATUS_NOT_ENOUGH_MEMORY);
+    CHK_STATUS(createBytesFromRtpPacket(pTmp, pRaw, &rawLen));
+
+    CHK_STATUS(createRtpPacketFromBytes(pRaw, rawLen, &pFinal));
+    pRaw = NULL; // ownership transferred to pFinal
+
+    *ppRtpPacket = pFinal;
+    pFinal = NULL;
 
 CleanUp:
+    if (pTmp != NULL) {
+        freeRtpPacket(&pTmp);
+    }
+    SAFE_MEMFREE(pRaw);
+    if (pFinal != NULL) {
+        freeRtpPacket(&pFinal);
+    }
     return retStatus;
+}
+
+STATUS createRtpPacketWithSeqNum(UINT16 seqNum, PRtpPacket* ppRtpPacket)
+{
+    TestRtpPacket params;
+    params.seqNum = seqNum;
+    params.timestamp = 100;
+    return createTestRtpPacket(params, ppRtpPacket);
 }
 
 WebRtcClientTestBase::WebRtcClientTestBase()

--- a/tst/WebRTCClientTestFixture.h
+++ b/tst/WebRTCClientTestFixture.h
@@ -42,6 +42,21 @@ typedef struct {
 
 STATUS createRtpPacketWithSeqNum(UINT16 seqNum, PRtpPacket* ppRtpPacket);
 
+struct TestRtpPacket {
+    UINT16 seqNum = 0;
+    UINT32 timestamp = 0;
+    UINT32 ssrc = 0x1234ABCD;
+    UINT8 payloadType = 96;
+    BOOL marker = FALSE;
+    UINT32 payloadLength = 10; // arbitrary non-zero default; zeroed bytes
+};
+
+// Builds an RTP packet from the given parameters and re-parses it via
+// createRtpPacketFromBytes, so the returned packet's `payload` pointer lives
+// inside its own pRawPacket (no stack dangles). Caller owns the returned
+// packet and must free it (or transfer ownership to e.g. jitterBufferPush).
+STATUS createTestRtpPacket(const TestRtpPacket& params, PRtpPacket* ppRtpPacket);
+
 // Shared TestFrame.flags values. FULL means onFrameReady delivered every byte
 // of the frame; PARTIAL means onFrameDropped fired but some packets were
 // still salvageable through fillPartialFrameData; DROPPED means nothing was


### PR DESCRIPTION
*What was changed?*

`rrUpdateSeq` now extends `rrBaseSeq` downward when a reordered packet's extended seq falls before the current base. A new `transceiverOnRtpPacketReceived` entry point is exercised by a black-box test that feeds a real arrival sequence (seq=10,11 before seq=0..9, then 12..99) and asserts `cum_lost == 0`. Adds a `TestRtpPacket` fixture helper so tests can build header+payload-stable packets with arbitrary ssrc/timestamp/PT.

*Why was it changed?*

A user-supplied pcap showed every RR emitted by the SDK reporting `cum_lost = -10` (0xFFFFF6) for the entire 32-second session. Root cause: when `rrInitSeq` captured a first seq (10) and earlier packets (0..9) arrived later due to jitter, the RFC 3550 §A.1 reorder branch ignored them for max tracking, but `packetsReceived++` still ran. `rrBaseSeq` stayed at 10 forever, so `expected = extMax - baseSeq + 1` undercounted by 10 and `cum_lost = expected - received` went permanently negative. Browser WebRTC stats surfaced this as nonsensical negative `packetsLost`.

*How was it changed?*

In the reorder branch of `rrUpdateSeq`, compute `extPacket = cycles + rrMaxSeq - (UINT16)(rrMaxSeq - seq)` — since the reorder condition guarantees the packet is 1..MAX_MISORDER before `rrMaxSeq` in extended space, this is its extended seq. If `extPacket < rrBaseSeq` (UINT32 comparison), lower `rrBaseSeq` to `extPacket`. The UINT32 comparison rejects three edge cases automatically:

- Late stragglers from prior cycles: `extPacket` lands far above any plausible `rrBaseSeq`, no update.
- Pathological mid-session reorder where seq is close to `rrBaseSeq` in UINT16 circular distance but actually in a later cycle: `extPacket` is huge (cycles+rrMaxSeq-backward), no update.
- Session start near seq=0 with stray very-high seq: `extPacket` underflows to `0xFFFFFFxx`, not less than `rrBaseSeq`, no update.

Wrap-straddling start (remote began near seq=65535, reordered late packet arrives after the cycle flipped) is now handled correctly.

*What testing was done for the changes?*

- New test `RtcpFunctionalityTest.receiverReportReorderedStartViaPacketReceive` builds raw RTP packets in the pcap's exact arrival order and pushes them through `transceiverOnRtpPacketReceived`; asserts `rrBaseSeq=0`, `rrMaxSeq=99`, `packetsReceived=100`, and `cum_lost=0`. Fails without the fix with `rrBaseSeq=10`, `cum=-10`.
- Full `webrtc_client_test` with the `*JitterBuffer*:*Rtp*:*Rtcp*` filter: 240 passed, 1 skipped (unrelated parameterized skip), 0 failures.
- Deleted the prior state-poking `receiverReportNegativeLossOnReorderedStart` — it simulated a bug-state that can no longer arise, so keeping it would only have tested defensive clamping we deliberately didn't add.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.