### PR TITLE
Fix remote-inbound RTT stats: only count RRs with valid LSR

### DIFF
--- a/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
+++ b/src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h
@@ -451,7 +451,7 @@ typedef struct {
     RtcReceivedRtpStreamStats received; //!< Inherited from RTCReceivedRtpStreamStats (packetsReceived, packetsLost, jitter)
     DOMString localId;                  //!< Used to look up RTCOutboundRtpStreamStats for the SSRC
     UINT64 roundTripTime;               //!< Estimated round trip time (milliseconds) for this SSRC based on the RTCP timestamps
-    UINT64 totalRoundTripTime;          //!< The cumulative sum of all round trip time measurements in seconds since the beginning of the session
+    UINT64 totalRoundTripTime;          //!< The cumulative sum of all round trip time measurements (milliseconds) since the beginning of the session
     DOUBLE fractionLost;                //!< The fraction packet loss reported for this SSRC
     UINT64 reportsReceived;             //!< Total number of RTCP RR blocks received for this SSRC
     UINT64 roundTripTimeMeasurements;   //!< Total number of RTCP RR blocks received for this SSRC that contain a valid round trip time

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -278,9 +278,12 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
     if (fractionLost > -1.0) {
         pTransceiver->remoteInboundStats.fractionLost = fractionLost;
     }
-    pTransceiver->remoteInboundStats.roundTripTimeMeasurements++;
-    pTransceiver->remoteInboundStats.totalRoundTripTime += rttPropDelayMsec;
-    pTransceiver->remoteInboundStats.roundTripTime = rttPropDelayMsec;
+    // Skip the first RR after session start (LSR=DLSR=0) so it doesn't bias the RTT average toward zero.
+    if (lastSR != 0) {
+        pTransceiver->remoteInboundStats.roundTripTimeMeasurements++;
+        pTransceiver->remoteInboundStats.totalRoundTripTime += rttPropDelayMsec;
+        pTransceiver->remoteInboundStats.roundTripTime = rttPropDelayMsec;
+    }
     // Sign-extend 24-bit cumulativeLost to INT64
     pTransceiver->remoteInboundStats.received.packetsLost =
         (cumulativeLost & 0x800000u) ? (INT64) (cumulativeLost | 0xFF000000u) : (INT64) cumulativeLost;


### PR DESCRIPTION
*What was changed?*

`onRtcpReceiverReport` now only bumps `roundTripTimeMeasurements`, `totalRoundTripTime` and `roundTripTime` on `RtcRemoteInboundRtpStreamStats` when the incoming RR carries a non-zero `lastSR`. The doxygen comment for `totalRoundTripTime` in `Stats.h` is also corrected from "seconds" to "milliseconds" to match the actual unit written by the code.

*Why was it changed?*

The first Receiver Report after session start carries `LSR=DLSR=0` because the peer has not yet received a Sender Report from us. Prior to this fix the stats code unconditionally incremented `roundTripTimeMeasurements` and added `0` to `totalRoundTripTime` for those early reports, biasing the computed average RTT toward zero for the duration of the session. In a live session we observed the first two RRs always arriving with `lsr:0 dlsr:0`, each adding a spurious "measurement" of 0 ms.

Separately, the header claimed `totalRoundTripTime` was in seconds while the implementation accumulates a value produced by `KVS_CONVERT_TIMESCALE(..., 1000)` (milliseconds), so consumers could not rely on the documented unit.

*How was it changed?*

- `src/source/PeerConnection/Rtcp.c`: move the three RTT-stat writes inside the existing `if (lastSR != 0)` block that already guards `rttPropDelay` computation. `reportsReceived` and `fractionLost` keep their original unconditional semantics.
- `src/include/com/amazonaws/kinesis/video/webrtcclient/Stats.h`: update the comment on `RtcRemoteInboundRtpStreamStats.totalRoundTripTime` to state "milliseconds".

*What testing was done for the changes?*

Verified on a live WHEP peer connection to Chrome: before the change the log showed 54 RRs with `lsr:0 dlsr:0` each incrementing the measurement counter; after the change only RRs whose `lastSR != 0` (those that produced a computed `rttPropDelay` value, ≈1 ms in localhost) contribute to the stat. No other stats or code paths are affected; format verified via `./scripts/clang-format.sh -f` on both changed files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.