### PR TITLE
Add RFC 3611 RTCP XR (RRTR + DLRR) support for non-sender RTT

### DIFF
--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1036,6 +1036,13 @@ STATUS rtcpReportsCallback(UINT32 timerId, UINT64 currentTime, UINT64 customData
         if (reportLen > 0) {
             CHK_STATUS(sendBuiltRtcpReport(pKvsPeerConnection, reportBody, reportLen));
         }
+
+        // RFC 3611 XR DLRR — answer any pending RRTR from the remote peer.
+        reportLen = sizeof(reportBody);
+        CHK_STATUS(rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, currentTime, reportBody, &reportLen));
+        if (reportLen > 0) {
+            CHK_STATUS(sendBuiltRtcpReport(pKvsPeerConnection, reportBody, reportLen));
+        }
     }
 
     delay = 100 + (RAND() % 200);
@@ -1335,6 +1342,9 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     pKvsPeerConnection->twccReceiverLock = MUTEX_CREATE(TRUE);
     CHK_STATUS(createTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
     pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32; // Invalid timer ID
+
+    // RFC 3611 RRTR -> DLRR state.
+    pKvsPeerConnection->rtcpXrLock = MUTEX_CREATE(TRUE);
 #ifdef ENABLE_NATIVE_SCTP
     pKvsPeerConnection->sctpTimerCallbackId = MAX_UINT32;
 #endif
@@ -1521,6 +1531,11 @@ STATUS freePeerConnection(PRtcPeerConnection* ppPeerConnection)
     if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->twccReceiverLock)) {
         MUTEX_FREE(pKvsPeerConnection->twccReceiverLock);
         pKvsPeerConnection->twccReceiverLock = INVALID_MUTEX_VALUE;
+    }
+
+    if (IS_VALID_MUTEX_VALUE(pKvsPeerConnection->rtcpXrLock)) {
+        MUTEX_FREE(pKvsPeerConnection->rtcpXrLock);
+        pKvsPeerConnection->rtcpXrLock = INVALID_MUTEX_VALUE;
     }
 
     // Free PCAP dump

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -976,9 +976,10 @@ CleanUp:
 // srtp_protect_rtcp() needs room for auth tag + SRTP trailer past the RTCP payload.
 #define RTCP_SRTP_ENCRYPT_OVERHEAD (SRTP_AUTH_TAG_OVERHEAD + SRTP_MAX_TRAILER_LEN + 4)
 
-// Max builder output: RR (4 header + 4 sender SSRC + 24 report block = 32)
-// is larger than SR (4 header + 24 body = 28).
-#define RTCP_MAX_REPORT_BODY_LEN (RTCP_PACKET_HEADER_LEN + 4 + RTCP_PACKET_RECEIVER_REPORT_BLOCK_LEN)
+// Max builder output across SR (28), RR (32), and XR (header + RRTR + DLRR_header + N*sub-block).
+// Reserve enough for a full XR that carries both RRTR and a DLRR block with MAX_RECEIVED_RRTR sub-blocks.
+#define RTCP_MAX_REPORT_BODY_LEN                                                                                                                     \
+    (RTCP_XR_HEADER_LEN + RTCP_XR_RRTR_BLOCK_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN + MAX_RECEIVED_RRTR * RTCP_XR_DLRR_SUBBLOCK_LEN)
 
 static STATUS sendBuiltRtcpReport(PKvsPeerConnection pKvsPeerConnection, PBYTE pReportBody, UINT32 reportLen)
 {

--- a/src/source/PeerConnection/PeerConnection.h
+++ b/src/source/PeerConnection/PeerConnection.h
@@ -92,6 +92,15 @@ typedef struct {
     UINT64 freePeerConnectionTime;
 } KvsPeerConnectionDiagnostics, *PKvsPeerConnectionDiagnostics;
 
+// RFC 3611 §4.4/§4.5: state needed to answer a received RRTR with a DLRR block.
+#define MAX_RECEIVED_RRTR 4
+typedef struct {
+    UINT32 ssrc;              //!< Reporter SSRC from the XR header; 0 = empty slot.
+    UINT32 ntpMid;            //!< Middle 32 bits of the received NTP timestamp (echoed as LRR).
+    UINT64 arrivalTimeHns;    //!< Local receive time in 100-ns units (for DLRR delay calculation).
+    UINT32 lastRepliedNtpMid; //!< ntpMid we last replied to; used to suppress duplicate DLRRs.
+} ReceivedRrtrEntry, *PReceivedRrtrEntry;
+
 typedef struct {
     RtcPeerConnection peerConnection;
     // UINT32 padding makes transportWideSequenceNumber 64bit aligned
@@ -186,6 +195,10 @@ typedef struct {
     MUTEX twccReceiverLock;
     PTwccReceiverManager pTwccReceiverManager;
     UINT32 twccFeedbackTimerId;
+
+    // RFC 3611 RRTR tracking so rtcpBuildExtendedReport can answer with DLRR.
+    MUTEX rtcpXrLock;
+    ReceivedRrtrEntry receivedRrtrs[MAX_RECEIVED_RRTR];
 
     // Pacing for smooth packet transmission
     PPacer pPacer;

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -136,6 +136,91 @@ CleanUp:
     return retStatus;
 }
 
+// RFC 3611 §4.5: Build XR packet with a single DLRR block echoing each pending RRTR.
+// Sets *pPacketLen = 0 when there is nothing to answer.
+STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer,
+                               PUINT32 pPacketLen)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 pendingCount, pendingIdx, slot, reporterSsrc, packetLen, dlrrBodyWords, delayDlsrUnits;
+    UINT32 pendingSsrc[MAX_RECEIVED_RRTR];
+    UINT32 pendingNtpMid[MAX_RECEIVED_RRTR];
+    UINT64 pendingArrivalHns[MAX_RECEIVED_RRTR];
+    BOOL locked = FALSE;
+    UINT32 offset;
+
+    CHK(pKvsPeerConnection != NULL && pKvsRtpTransceiver != NULL && pOutBuffer != NULL && pPacketLen != NULL, STATUS_NULL_ARG);
+
+    pendingCount = 0;
+    MUTEX_LOCK(pKvsPeerConnection->rtcpXrLock);
+    locked = TRUE;
+    for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
+        PReceivedRrtrEntry entry = &pKvsPeerConnection->receivedRrtrs[slot];
+        if (entry->ssrc != 0 && entry->ntpMid != entry->lastRepliedNtpMid) {
+            pendingSsrc[pendingCount] = entry->ssrc;
+            pendingNtpMid[pendingCount] = entry->ntpMid;
+            pendingArrivalHns[pendingCount] = entry->arrivalTimeHns;
+            pendingCount++;
+        }
+    }
+
+    if (pendingCount == 0) {
+        *pPacketLen = 0;
+        CHK(FALSE, retStatus);
+    }
+
+    packetLen = RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN + pendingCount * RTCP_XR_DLRR_SUBBLOCK_LEN;
+    CHK(*pPacketLen >= packetLen, STATUS_BUFFER_TOO_SMALL);
+
+    reporterSsrc = pKvsRtpTransceiver->sender.ssrc;
+
+    // XR header: V=2, P=0, reserved=0, PT=207, length field = (packetLen/4) - 1
+    pOutBuffer[0] = RTCP_PACKET_VERSION_VAL << 6;
+    pOutBuffer[RTCP_PACKET_TYPE_OFFSET] = RTCP_PACKET_TYPE_EXTENDED_REPORT;
+    putUnalignedInt16BigEndian(pOutBuffer + RTCP_PACKET_LEN_OFFSET, (packetLen / RTCP_PACKET_LEN_WORD_SIZE) - 1);
+    putUnalignedInt32BigEndian(pOutBuffer + 4, reporterSsrc);
+
+    // DLRR block header: BT=5, reserved=0, block length = 3 * pendingCount (three words per sub-block)
+    dlrrBodyWords = pendingCount * (RTCP_XR_DLRR_SUBBLOCK_LEN / RTCP_PACKET_LEN_WORD_SIZE);
+    pOutBuffer[RTCP_XR_HEADER_LEN] = RTCP_XR_BLOCK_TYPE_DLRR;
+    pOutBuffer[RTCP_XR_HEADER_LEN + 1] = 0;
+    putUnalignedInt16BigEndian(pOutBuffer + RTCP_XR_HEADER_LEN + 2, (UINT16) dlrrBodyWords);
+
+    offset = RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN;
+    for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
+        // Compute the hns diff into a local: KVS_CONVERT_TIMESCALE does not parenthesize `pts`,
+        // so passing an expression like `a - b` would be parsed as `a - (b * to / from)`.
+        UINT64 delayHns = currentTime - pendingArrivalHns[pendingIdx];
+        delayDlsrUnits = (UINT32) KVS_CONVERT_TIMESCALE(delayHns, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
+        putUnalignedInt32BigEndian(pOutBuffer + offset, pendingSsrc[pendingIdx]);
+        putUnalignedInt32BigEndian(pOutBuffer + offset + 4, pendingNtpMid[pendingIdx]);
+        putUnalignedInt32BigEndian(pOutBuffer + offset + 8, delayDlsrUnits);
+        offset += RTCP_XR_DLRR_SUBBLOCK_LEN;
+    }
+
+    // Mark each echoed entry as replied-to so a subsequent timer tick doesn't emit a duplicate DLRR.
+    for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
+        for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
+            PReceivedRrtrEntry entry = &pKvsPeerConnection->receivedRrtrs[slot];
+            if (entry->ssrc == pendingSsrc[pendingIdx] && entry->ntpMid == pendingNtpMid[pendingIdx]) {
+                entry->lastRepliedNtpMid = pendingNtpMid[pendingIdx];
+                break;
+            }
+        }
+    }
+
+    *pPacketLen = packetLen;
+    DLOGV("extended report reporterSsrc=%u dlrrSubBlocks=%u bytes=%u", reporterSsrc, pendingCount, packetLen);
+
+CleanUp:
+    if (locked) {
+        MUTEX_UNLOCK(pKvsPeerConnection->rtcpXrLock);
+    }
+    LEAVES();
+    return retStatus;
+}
+
 // TODO handle FIR packet https://tools.ietf.org/html/rfc2032#section-5.2.1
 static STATUS onRtcpFIRPacket(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
 {
@@ -300,6 +385,84 @@ static STATUS onRtcpReceiverReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
 
 CleanUp:
 
+    return retStatus;
+}
+
+// RFC 3611 §2: XR packet = 8-byte header (V/P/rsvd | PT=207 | length | reporter SSRC)
+// followed by one or more blocks. Each block is BT(1) + type-specific(1) + length(2) + body.
+// `length` is in 32-bit words, excluding the block header itself.
+static STATUS onRtcpExtendedReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
+{
+    STATUS retStatus = STATUS_SUCCESS;
+    UINT32 reporterSsrc, blockBodyWords, blockBodyBytes, offset, freeSlot, slot;
+    UINT8 bt;
+    UINT16 blockLen;
+    UINT64 ntp;
+    UINT32 ntpMid;
+    UINT64 arrivalTimeHns;
+
+    CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL && pRtcpPacket->payload != NULL, STATUS_NULL_ARG);
+    CHK(pRtcpPacket->payloadLength >= 4, STATUS_RTCP_INPUT_PARTIAL_PACKET);
+
+    reporterSsrc = getUnalignedInt32BigEndian(pRtcpPacket->payload);
+    DLOGV("RTCP_PACKET_TYPE_EXTENDED_REPORT reporterSsrc: %u payloadLength: %u", reporterSsrc, pRtcpPacket->payloadLength);
+
+    offset = 4;
+    while (offset + 4 <= pRtcpPacket->payloadLength) {
+        bt = pRtcpPacket->payload[offset];
+        blockLen = getUnalignedInt16BigEndian(pRtcpPacket->payload + offset + 2);
+        blockBodyWords = blockLen;
+        blockBodyBytes = blockBodyWords * 4;
+        // Bounds check: the block header plus body must fit inside the remaining payload.
+        if (offset + 4 + blockBodyBytes > pRtcpPacket->payloadLength) {
+            DLOGW("Malformed XR block: bt=%u offset=%u blockLenWords=%u exceeds payloadLength=%u", bt, offset, blockBodyWords,
+                  pRtcpPacket->payloadLength);
+            break;
+        }
+
+        switch (bt) {
+            case RTCP_XR_BLOCK_TYPE_RRTR:
+                // RFC 3611 §4.4: BT=4, block length = 2, body = 8-byte NTP timestamp.
+                if (blockBodyWords != 2) {
+                    DLOGW("XR RRTR block with unexpected length %u words (expected 2)", blockBodyWords);
+                    break;
+                }
+                ntp = getUnalignedInt64BigEndian(pRtcpPacket->payload + offset + 4);
+                ntpMid = MID_NTP(ntp);
+                arrivalTimeHns = GETTIME();
+                MUTEX_LOCK(pKvsPeerConnection->rtcpXrLock);
+                freeSlot = MAX_RECEIVED_RRTR;
+                for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
+                    if (pKvsPeerConnection->receivedRrtrs[slot].ssrc == reporterSsrc) {
+                        break;
+                    }
+                    if (freeSlot == MAX_RECEIVED_RRTR && pKvsPeerConnection->receivedRrtrs[slot].ssrc == 0) {
+                        freeSlot = slot;
+                    }
+                }
+                if (slot == MAX_RECEIVED_RRTR) {
+                    slot = freeSlot;
+                }
+                if (slot < MAX_RECEIVED_RRTR) {
+                    pKvsPeerConnection->receivedRrtrs[slot].ssrc = reporterSsrc;
+                    pKvsPeerConnection->receivedRrtrs[slot].ntpMid = ntpMid;
+                    pKvsPeerConnection->receivedRrtrs[slot].arrivalTimeHns = arrivalTimeHns;
+                    // Leave lastRepliedNtpMid alone so the emitter will generate a DLRR.
+                } else {
+                    DLOGW("Dropping RRTR from ssrc %u: no free slots (cap=%d)", reporterSsrc, MAX_RECEIVED_RRTR);
+                }
+                MUTEX_UNLOCK(pKvsPeerConnection->rtcpXrLock);
+                DLOGV("XR RRTR stored: reporterSsrc=%u ntpMid=0x%08x slot=%u", reporterSsrc, ntpMid, slot);
+                break;
+            default:
+                DLOGV("Skipping XR block type %u (length %u words)", bt, blockBodyWords);
+                break;
+        }
+
+        offset += 4 + blockBodyBytes;
+    }
+
+CleanUp:
     return retStatus;
 }
 
@@ -734,6 +897,9 @@ STATUS onRtcpPacket(PKvsPeerConnection pKvsPeerConnection, PBYTE pBuff, UINT32 b
                 break;
             case RTCP_PACKET_TYPE_RECEIVER_REPORT:
                 CHK_STATUS(onRtcpReceiverReport(&rtcpPacket, pKvsPeerConnection));
+                break;
+            case RTCP_PACKET_TYPE_EXTENDED_REPORT:
+                CHK_STATUS(onRtcpExtendedReport(&rtcpPacket, pKvsPeerConnection));
                 break;
             case RTCP_PACKET_TYPE_SOURCE_DESCRIPTION:
                 DLOGV("unhandled packet type RTCP_PACKET_TYPE_SOURCE_DESCRIPTION");

--- a/src/source/PeerConnection/Rtcp.c
+++ b/src/source/PeerConnection/Rtcp.c
@@ -136,8 +136,14 @@ CleanUp:
     return retStatus;
 }
 
-// RFC 3611 §4.5: Build XR packet with a single DLRR block echoing each pending RRTR.
-// Sets *pPacketLen = 0 when there is nothing to answer.
+// Emit an RRTR at most once per this interval. Chrome uses ~5 s; 2 s gives us
+// more frequent RTT samples without flooding.
+#define RTCP_XR_RRTR_INTERVAL_HNS (2 * HUNDREDS_OF_NANOS_IN_A_SECOND)
+
+// RFC 3611 §4.4/§4.5: Build XR packet with an optional RRTR block (so the peer can
+// reply with a DLRR letting us measure our RTT) followed by an optional DLRR block
+// answering any pending RRTR the peer has already sent us.
+// Sets *pPacketLen = 0 when there is nothing to emit in either direction.
 STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer,
                                PUINT32 pPacketLen)
 {
@@ -147,14 +153,25 @@ STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTra
     UINT32 pendingSsrc[MAX_RECEIVED_RRTR];
     UINT32 pendingNtpMid[MAX_RECEIVED_RRTR];
     UINT64 pendingArrivalHns[MAX_RECEIVED_RRTR];
-    BOOL locked = FALSE;
+    BOOL xrLocked = FALSE, statsLocked = FALSE, sendRrtr = FALSE;
     UINT32 offset;
+    UINT64 ourNtp = 0;
+    UINT32 ourNtpMid = 0;
 
     CHK(pKvsPeerConnection != NULL && pKvsRtpTransceiver != NULL && pOutBuffer != NULL && pPacketLen != NULL, STATUS_NULL_ARG);
 
+    // Decide whether to include an RRTR this tick. Read lastRrtrSentTime under statsLock.
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    statsLocked = TRUE;
+    if (pKvsRtpTransceiver->lastRrtrSentTime == 0 || currentTime - pKvsRtpTransceiver->lastRrtrSentTime >= RTCP_XR_RRTR_INTERVAL_HNS) {
+        sendRrtr = TRUE;
+    }
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+    statsLocked = FALSE;
+
     pendingCount = 0;
     MUTEX_LOCK(pKvsPeerConnection->rtcpXrLock);
-    locked = TRUE;
+    xrLocked = TRUE;
     for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
         PReceivedRrtrEntry entry = &pKvsPeerConnection->receivedRrtrs[slot];
         if (entry->ssrc != 0 && entry->ntpMid != entry->lastRepliedNtpMid) {
@@ -165,12 +182,13 @@ STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTra
         }
     }
 
-    if (pendingCount == 0) {
+    if (!sendRrtr && pendingCount == 0) {
         *pPacketLen = 0;
         CHK(FALSE, retStatus);
     }
 
-    packetLen = RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN + pendingCount * RTCP_XR_DLRR_SUBBLOCK_LEN;
+    packetLen = RTCP_XR_HEADER_LEN + (sendRrtr ? RTCP_XR_RRTR_BLOCK_LEN : 0) +
+        (pendingCount > 0 ? RTCP_XR_DLRR_BLOCK_HDR_LEN + pendingCount * RTCP_XR_DLRR_SUBBLOCK_LEN : 0);
     CHK(*pPacketLen >= packetLen, STATUS_BUFFER_TOO_SMALL);
 
     reporterSsrc = pKvsRtpTransceiver->sender.ssrc;
@@ -181,41 +199,65 @@ STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTra
     putUnalignedInt16BigEndian(pOutBuffer + RTCP_PACKET_LEN_OFFSET, (packetLen / RTCP_PACKET_LEN_WORD_SIZE) - 1);
     putUnalignedInt32BigEndian(pOutBuffer + 4, reporterSsrc);
 
-    // DLRR block header: BT=5, reserved=0, block length = 3 * pendingCount (three words per sub-block)
-    dlrrBodyWords = pendingCount * (RTCP_XR_DLRR_SUBBLOCK_LEN / RTCP_PACKET_LEN_WORD_SIZE);
-    pOutBuffer[RTCP_XR_HEADER_LEN] = RTCP_XR_BLOCK_TYPE_DLRR;
-    pOutBuffer[RTCP_XR_HEADER_LEN + 1] = 0;
-    putUnalignedInt16BigEndian(pOutBuffer + RTCP_XR_HEADER_LEN + 2, (UINT16) dlrrBodyWords);
-
-    offset = RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN;
-    for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
-        // Compute the hns diff into a local: KVS_CONVERT_TIMESCALE does not parenthesize `pts`,
-        // so passing an expression like `a - b` would be parsed as `a - (b * to / from)`.
-        UINT64 delayHns = currentTime - pendingArrivalHns[pendingIdx];
-        delayDlsrUnits = (UINT32) KVS_CONVERT_TIMESCALE(delayHns, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
-        putUnalignedInt32BigEndian(pOutBuffer + offset, pendingSsrc[pendingIdx]);
-        putUnalignedInt32BigEndian(pOutBuffer + offset + 4, pendingNtpMid[pendingIdx]);
-        putUnalignedInt32BigEndian(pOutBuffer + offset + 8, delayDlsrUnits);
-        offset += RTCP_XR_DLRR_SUBBLOCK_LEN;
+    offset = RTCP_XR_HEADER_LEN;
+    if (sendRrtr) {
+        // RRTR block: BT=4, rsvd=0, block length=2 (two 32-bit words of body = 8-byte NTP).
+        ourNtp = convertTimestampToNTP(currentTime);
+        ourNtpMid = MID_NTP(ourNtp);
+        pOutBuffer[offset] = RTCP_XR_BLOCK_TYPE_RRTR;
+        pOutBuffer[offset + 1] = 0;
+        putUnalignedInt16BigEndian(pOutBuffer + offset + 2, 2);
+        putUnalignedInt64BigEndian(pOutBuffer + offset + 4, ourNtp);
+        offset += RTCP_XR_RRTR_BLOCK_LEN;
     }
 
-    // Mark each echoed entry as replied-to so a subsequent timer tick doesn't emit a duplicate DLRR.
-    for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
-        for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
-            PReceivedRrtrEntry entry = &pKvsPeerConnection->receivedRrtrs[slot];
-            if (entry->ssrc == pendingSsrc[pendingIdx] && entry->ntpMid == pendingNtpMid[pendingIdx]) {
-                entry->lastRepliedNtpMid = pendingNtpMid[pendingIdx];
-                break;
+    if (pendingCount > 0) {
+        // DLRR block header: BT=5, reserved=0, block length = 3 * pendingCount (three words per sub-block)
+        dlrrBodyWords = pendingCount * (RTCP_XR_DLRR_SUBBLOCK_LEN / RTCP_PACKET_LEN_WORD_SIZE);
+        pOutBuffer[offset] = RTCP_XR_BLOCK_TYPE_DLRR;
+        pOutBuffer[offset + 1] = 0;
+        putUnalignedInt16BigEndian(pOutBuffer + offset + 2, (UINT16) dlrrBodyWords);
+        offset += RTCP_XR_DLRR_BLOCK_HDR_LEN;
+
+        for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
+            // Compute the hns diff into a local: KVS_CONVERT_TIMESCALE does not parenthesize `pts`,
+            // so passing an expression like `a - b` would be parsed as `a - (b * to / from)`.
+            UINT64 delayHns = currentTime - pendingArrivalHns[pendingIdx];
+            delayDlsrUnits = (UINT32) KVS_CONVERT_TIMESCALE(delayHns, HUNDREDS_OF_NANOS_IN_A_SECOND, DLSR_TIMESCALE);
+            putUnalignedInt32BigEndian(pOutBuffer + offset, pendingSsrc[pendingIdx]);
+            putUnalignedInt32BigEndian(pOutBuffer + offset + 4, pendingNtpMid[pendingIdx]);
+            putUnalignedInt32BigEndian(pOutBuffer + offset + 8, delayDlsrUnits);
+            offset += RTCP_XR_DLRR_SUBBLOCK_LEN;
+        }
+
+        // Mark each echoed entry as replied-to so a subsequent timer tick doesn't emit a duplicate DLRR.
+        for (pendingIdx = 0; pendingIdx < pendingCount; pendingIdx++) {
+            for (slot = 0; slot < MAX_RECEIVED_RRTR; slot++) {
+                PReceivedRrtrEntry entry = &pKvsPeerConnection->receivedRrtrs[slot];
+                if (entry->ssrc == pendingSsrc[pendingIdx] && entry->ntpMid == pendingNtpMid[pendingIdx]) {
+                    entry->lastRepliedNtpMid = pendingNtpMid[pendingIdx];
+                    break;
+                }
             }
         }
     }
 
+    if (sendRrtr) {
+        MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+        pKvsRtpTransceiver->lastRrtrNtpMid = ourNtpMid;
+        pKvsRtpTransceiver->lastRrtrSentTime = currentTime;
+        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+    }
+
     *pPacketLen = packetLen;
-    DLOGV("extended report reporterSsrc=%u dlrrSubBlocks=%u bytes=%u", reporterSsrc, pendingCount, packetLen);
+    DLOGV("extended report reporterSsrc=%u rrtr=%u dlrrSubBlocks=%u bytes=%u", reporterSsrc, sendRrtr ? 1u : 0u, pendingCount, packetLen);
 
 CleanUp:
-    if (locked) {
+    if (xrLocked) {
         MUTEX_UNLOCK(pKvsPeerConnection->rtcpXrLock);
+    }
+    if (statsLocked) {
+        MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
     }
     LEAVES();
     return retStatus;
@@ -394,12 +436,17 @@ CleanUp:
 static STATUS onRtcpExtendedReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerConnection)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    UINT32 reporterSsrc, blockBodyWords, blockBodyBytes, offset, freeSlot, slot;
+    UINT32 reporterSsrc, blockBodyWords, blockBodyBytes, offset, freeSlot, slot, subOffset, subBlockCount, subIdx;
     UINT8 bt;
     UINT16 blockLen;
     UINT64 ntp;
     UINT32 ntpMid;
     UINT64 arrivalTimeHns;
+    UINT32 subSsrc, subLrr, subDlrr;
+    PKvsRtpTransceiver pDlrrTransceiver;
+    UINT64 nowNtp;
+    UINT32 rttDlsrUnits;
+    DOUBLE rttSeconds;
 
     CHK(pKvsPeerConnection != NULL && pRtcpPacket != NULL && pRtcpPacket->payload != NULL, STATUS_NULL_ARG);
     CHK(pRtcpPacket->payloadLength >= 4, STATUS_RTCP_INPUT_PARTIAL_PACKET);
@@ -453,6 +500,44 @@ static STATUS onRtcpExtendedReport(PRtcpPacket pRtcpPacket, PKvsPeerConnection p
                 }
                 MUTEX_UNLOCK(pKvsPeerConnection->rtcpXrLock);
                 DLOGV("XR RRTR stored: reporterSsrc=%u ntpMid=0x%08x slot=%u", reporterSsrc, ntpMid, slot);
+                break;
+            case RTCP_XR_BLOCK_TYPE_DLRR:
+                // RFC 3611 §4.5: body = N * {SSRC_n, LRR, DLRR}, 3 words each.
+                if (blockBodyWords % 3 != 0) {
+                    DLOGW("XR DLRR block with non-multiple-of-3 length %u words", blockBodyWords);
+                    break;
+                }
+                subBlockCount = blockBodyWords / 3;
+                subOffset = offset + 4;
+                nowNtp = convertTimestampToNTP(GETTIME());
+                for (subIdx = 0; subIdx < subBlockCount; subIdx++) {
+                    subSsrc = getUnalignedInt32BigEndian(pRtcpPacket->payload + subOffset);
+                    subLrr = getUnalignedInt32BigEndian(pRtcpPacket->payload + subOffset + 4);
+                    subDlrr = getUnalignedInt32BigEndian(pRtcpPacket->payload + subOffset + 8);
+                    subOffset += RTCP_XR_DLRR_SUBBLOCK_LEN;
+
+                    if (STATUS_FAILED(findTransceiverBySsrc(pKvsPeerConnection, &pDlrrTransceiver, subSsrc))) {
+                        DLOGV("DLRR sub-block for unknown SSRC %u (skipping)", subSsrc);
+                        continue;
+                    }
+                    if (subLrr == 0) {
+                        // Peer hadn't received our RRTR yet — no valid RTT can be derived.
+                        continue;
+                    }
+                    // RTT = NTPmid(now) - LRR - DLRR, in 1/65536 s units per RFC 3611 §4.5.
+                    rttDlsrUnits = MID_NTP(nowNtp) - subLrr - subDlrr;
+                    rttSeconds = (DOUBLE) rttDlsrUnits / (DOUBLE) DLSR_TIMESCALE;
+
+                    MUTEX_LOCK(pDlrrTransceiver->statsLock);
+                    // Only count if the DLRR echoes an RRTR we actually sent (guards against stale/bogus replies).
+                    if (pDlrrTransceiver->lastRrtrNtpMid != 0 && subLrr == pDlrrTransceiver->lastRrtrNtpMid) {
+                        pDlrrTransceiver->remoteOutboundStats.roundTripTime = rttSeconds;
+                        pDlrrTransceiver->remoteOutboundStats.totalRoundTripTime += rttSeconds;
+                        pDlrrTransceiver->remoteOutboundStats.roundTripTimeMeasurements++;
+                    }
+                    MUTEX_UNLOCK(pDlrrTransceiver->statsLock);
+                    DLOGV("XR DLRR processed: ssrc=%u lrr=0x%08x dlrr=%u rtt=%.3fms", subSsrc, subLrr, subDlrr, rttSeconds * 1000.0);
+                }
                 break;
             default:
                 DLOGV("Skipping XR block type %u (length %u words)", bt, blockBodyWords);

--- a/src/source/PeerConnection/Rtcp.h
+++ b/src/source/PeerConnection/Rtcp.h
@@ -25,6 +25,11 @@ STATUS rtcpBuildSenderReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 curre
 // Returns STATUS_SUCCESS if a report was written, STATUS_NOT_READY if nothing has been received yet.
 STATUS rtcpBuildReceiverReport(PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer, PUINT32 pPacketLen);
 
+// Build an RTCP XR packet (RFC 3611) containing a DLRR block with one sub-block per pending RRTR.
+// On success *pPacketLen holds bytes written, or 0 if there is no RRTR to answer yet.
+STATUS rtcpBuildExtendedReport(PKvsPeerConnection pKvsPeerConnection, PKvsRtpTransceiver pKvsRtpTransceiver, UINT64 currentTime, PBYTE pOutBuffer,
+                               PUINT32 pPacketLen);
+
 // TWCC feedback generation (receiver side)
 STATUS createTwccReceiverManager(PTwccReceiverManager* ppManager);
 STATUS freeTwccReceiverManager(PTwccReceiverManager* ppManager);

--- a/src/source/PeerConnection/Rtp.h
+++ b/src/source/PeerConnection/Rtp.h
@@ -113,6 +113,12 @@ typedef struct {
     UINT32 lastSRNtpMid;       // middle 32 bits of last received SR NTP timestamp
     UINT64 lastSRReceivedTime; // wallclock (100ns) when last SR was received
 
+    // For LRR/DLRR in outgoing RRTR (protected by statsLock).
+    // lastRrtrNtpMid is the middle 32 bits of the NTP we most recently sent in an RRTR;
+    // we accept only DLRR sub-blocks whose LRR matches this value.
+    UINT32 lastRrtrNtpMid;
+    UINT64 lastRrtrSentTime; // wallclock (100ns) of last emitted RRTR; 0 = none yet
+
     UINT8 firSequenceNumber;
 
     // RFC 2198 RED receiver-side state. When non-zero, inbound packets whose PT equals

--- a/src/source/PeerConnection/SessionDescription.c
+++ b/src/source/PeerConnection/SessionDescription.c
@@ -794,6 +794,8 @@ STATUS populateSingleMediaSection(PKvsPeerConnection pKvsPeerConnection, PKvsRtp
     APPEND_SDP_ATTR("ssrc", "%u cname:%s", pKvsRtpTransceiver->sender.ssrc, pKvsPeerConnection->localCNAME);
     APPEND_SDP_ATTR("ssrc", "%u msid:%s %s", pKvsRtpTransceiver->sender.ssrc, pRtcMediaStreamTrack->streamId, pRtcMediaStreamTrack->trackId);
     APPEND_SDP_ATTR("rtcp-fb", "%" PRId64 " goog-remb", payloadType);
+    // libwebrtc enables RRTR/DLRR only when the chosen codec carries this feedback param.
+    APPEND_SDP_ATTR("rtcp-fb", "%" PRId64 " rrtr", payloadType);
 
     if (pKvsPeerConnection->twccExtId != 0) {
         APPEND_SDP_ATTR("rtcp-fb", "%" PRId64 " " TWCC_SDP_ATTR, payloadType);

--- a/src/source/Rtcp/RtcpPacket.h
+++ b/src/source/Rtcp/RtcpPacket.h
@@ -43,7 +43,23 @@ typedef enum {
     RTCP_PACKET_TYPE_SOURCE_DESCRIPTION = 202,
     RTCP_PACKET_TYPE_GENERIC_RTP_FEEDBACK = 205,
     RTCP_PACKET_TYPE_PAYLOAD_SPECIFIC_FEEDBACK = 206,
+    RTCP_PACKET_TYPE_EXTENDED_REPORT = 207, // https://tools.ietf.org/html/rfc3611
 } RTCP_PACKET_TYPE;
+
+// RFC 3611 XR block types
+typedef enum {
+    RTCP_XR_BLOCK_TYPE_RRTR = 4, // Receiver Reference Time Report, RFC 3611 §4.4
+    RTCP_XR_BLOCK_TYPE_DLRR = 5, // Delay since Last RR,             RFC 3611 §4.5
+} RTCP_XR_BLOCK_TYPE;
+
+// XR header: V/P/rsvd + PT + length + SSRC of reporter (RFC 3611 §2)
+#define RTCP_XR_HEADER_LEN 8
+// RRTR block: 4-byte block header + 8-byte NTP (block length field = 2)
+#define RTCP_XR_RRTR_BLOCK_LEN 12
+// DLRR block header (RFC 3611 §4.5): BT(1) + rsvd(1) + block length(2)
+#define RTCP_XR_DLRR_BLOCK_HDR_LEN 4
+// Each DLRR sub-block: SSRC_n + LRR + DLRR
+#define RTCP_XR_DLRR_SUBBLOCK_LEN 12
 
 typedef enum {
     RTCP_FEEDBACK_MESSAGE_TYPE_NACK = 1,

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -2800,6 +2800,31 @@ TEST_F(PeerConnectionFunctionalityTest, fullCycleVideoAudioDataChannel)
             << "Remote outbound audio SSRC mismatch";
         EXPECT_GT(audioRemoteOut.remoteTimestamp, nowMs - 60000) << "Remote outbound audio remoteTimestamp too old";
         EXPECT_LE(audioRemoteOut.remoteTimestamp, nowMs + 1000) << "Remote outbound audio remoteTimestamp in the future";
+
+        // Wait for the non-sender RTT loop (RFC 3611 RRTR/DLRR) to complete at least
+        // one round trip on the answer side's remote-outbound-rtp (which represents
+        // the offer's outbound media). answer emits RRTR, offer replies with DLRR,
+        // answer parses it and populates roundTripTime{,Measurements,...}.
+        for (INT32 i = 0; i < 80; i++) {
+            rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+            ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerVideoTransceiver, &rtcMetrics));
+            if (rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats.roundTripTimeMeasurements > 0) {
+                break;
+            }
+            THREAD_SLEEP(100 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND);
+        }
+        auto& videoRemoteOutRtt = rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats;
+        EXPECT_GT(videoRemoteOutRtt.roundTripTimeMeasurements, (UINT64) 0) << "No DLRR-derived RTT measurements on video remote-outbound";
+        EXPECT_GT(videoRemoteOutRtt.roundTripTime, 0.0) << "Video remote-outbound roundTripTime " << videoRemoteOutRtt.roundTripTime << "s";
+        EXPECT_LT(videoRemoteOutRtt.roundTripTime, 1.0) << "Video remote-outbound roundTripTime " << videoRemoteOutRtt.roundTripTime << "s (> 1s on loopback)";
+        EXPECT_GT(videoRemoteOutRtt.totalRoundTripTime, 0.0) << "Video remote-outbound totalRoundTripTime not accumulating";
+
+        rtcMetrics.requestedTypeOfStats = RTC_STATS_TYPE_REMOTE_OUTBOUND_RTP;
+        ASSERT_EQ(STATUS_SUCCESS, rtcPeerConnectionGetMetrics(answerPc, answerAudioTransceiver, &rtcMetrics));
+        auto& audioRemoteOutRtt = rtcMetrics.rtcStatsObject.remoteOutboundRtpStreamStats;
+        EXPECT_GT(audioRemoteOutRtt.roundTripTimeMeasurements, (UINT64) 0) << "No DLRR-derived RTT measurements on audio remote-outbound";
+        EXPECT_GT(audioRemoteOutRtt.roundTripTime, 0.0) << "Audio remote-outbound roundTripTime " << audioRemoteOutRtt.roundTripTime << "s";
+        EXPECT_LT(audioRemoteOutRtt.roundTripTime, 1.0) << "Audio remote-outbound roundTripTime " << audioRemoteOutRtt.roundTripTime << "s (> 1s on loopback)";
     }
 
     closePeerConnection(offerPc);

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1259,6 +1259,110 @@ TEST_F(RtcpFunctionalityTest, jitterFirstPacketDoesNotSpike)
     freePeerConnection(&pRtcPeerConnection);
 }
 
+// XR with a single RRTR block should stash the reporter's SSRC + middle-32 NTP
+// on the peer connection so the DLRR emitter can later echo them back.
+TEST_F(RtcpFunctionalityTest, xrRrtrStoresReporterState)
+{
+    initTransceiver(0x11223344);
+
+    // Wipe slots so the test is order-independent.
+    MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
+
+    const UINT32 reporterSsrc = 0xDEADBEEF;
+    const UINT64 ntp = 0xE1E3204300ABCDEFULL;
+    const UINT32 expectedNtpMid = MID_NTP(ntp);
+
+    // XR header (V=2, P=0, rsvd=0, PT=207, length = 4 words -1 = 4, SSRC=reporter)
+    // then one RRTR block (BT=4, rsvd=0, length=2, 8-byte NTP).
+    BYTE xr[20];
+    MEMSET(xr, 0, SIZEOF(xr));
+    xr[0] = 0x80;                                         // V=2
+    xr[1] = 0xCF;                                         // PT=207
+    putUnalignedInt16BigEndian(xr + 2, 4);                // length: (20/4) - 1
+    putUnalignedInt32BigEndian(xr + 4, reporterSsrc);     // reporter SSRC
+    xr[8] = 0x04;                                         // BT=4 (RRTR)
+    xr[9] = 0x00;
+    putUnalignedInt16BigEndian(xr + 10, 2);               // block length = 2 words
+    putUnalignedInt64BigEndian(xr + 12, ntp);
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+    EXPECT_EQ(reporterSsrc, pKvsPeerConnection->receivedRrtrs[0].ssrc);
+    EXPECT_EQ(expectedNtpMid, pKvsPeerConnection->receivedRrtrs[0].ntpMid);
+    EXPECT_EQ(0u, pKvsPeerConnection->receivedRrtrs[0].lastRepliedNtpMid);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// rtcpBuildExtendedReport should emit a DLRR block that echoes the stored
+// RRTR's middle-32 NTP as LRR and a DLRR value ~= elapsed time.
+TEST_F(RtcpFunctionalityTest, xrDlrrEchoesLrrAndDelay)
+{
+    const UINT32 ourSsrc = 0x12345678;
+    initTransceiver(ourSsrc);
+
+    MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
+    const UINT32 reporterSsrc = 0xDEADBEEF;
+    const UINT32 ntpMid = 0xC0FFEE00;
+    const UINT64 arrival = GETTIME();
+    pKvsPeerConnection->receivedRrtrs[0].ssrc = reporterSsrc;
+    pKvsPeerConnection->receivedRrtrs[0].ntpMid = ntpMid;
+    pKvsPeerConnection->receivedRrtrs[0].arrivalTimeHns = arrival;
+
+    // Emit one millisecond later. Expected DLRR = 1 ms * 65536 / 1 s = 65.
+    const UINT64 currentTime = arrival + 1 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+    BYTE out[64];
+    UINT32 outLen = sizeof(out);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, currentTime, out, &outLen));
+    EXPECT_EQ(RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN + RTCP_XR_DLRR_SUBBLOCK_LEN, outLen);
+
+    // Header: V=2, PT=207, length = 4 (24 bytes / 4 - 1 = 5), reporter SSRC = ours.
+    EXPECT_EQ(0x80, out[0]);
+    EXPECT_EQ(RTCP_PACKET_TYPE_EXTENDED_REPORT, out[1]);
+    EXPECT_EQ(5u, getUnalignedInt16BigEndian(out + 2));
+    EXPECT_EQ(ourSsrc, getUnalignedInt32BigEndian(out + 4));
+
+    // DLRR block header: BT=5, body length = 3 words per sub-block.
+    EXPECT_EQ(RTCP_XR_BLOCK_TYPE_DLRR, out[RTCP_XR_HEADER_LEN]);
+    EXPECT_EQ(3u, getUnalignedInt16BigEndian(out + RTCP_XR_HEADER_LEN + 2));
+
+    // Sub-block: {SSRC_n, LRR=ntpMid, DLRR = 1 ms worth of 1/65536 s ticks = 65}.
+    const UINT32 subOff = RTCP_XR_HEADER_LEN + RTCP_XR_DLRR_BLOCK_HDR_LEN;
+    EXPECT_EQ(reporterSsrc, getUnalignedInt32BigEndian(out + subOff));
+    EXPECT_EQ(ntpMid, getUnalignedInt32BigEndian(out + subOff + 4));
+    EXPECT_EQ(65u, getUnalignedInt32BigEndian(out + subOff + 8));
+
+    // Second call with no new RRTR should be a no-op.
+    outLen = sizeof(out);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, currentTime, out, &outLen));
+    EXPECT_EQ(0u, outLen);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// Unknown block types (e.g. target-bitrate BT=42) must not be treated as errors
+// and must not touch the RRTR storage.
+TEST_F(RtcpFunctionalityTest, xrParserSkipsUnknownBlockTypes)
+{
+    initTransceiver(0xAA);
+    MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
+
+    // XR header + a BT=42 block with length=5 (20 bytes of zero body).
+    BYTE xr[32];
+    MEMSET(xr, 0, SIZEOF(xr));
+    xr[0] = 0x80;
+    xr[1] = 0xCF;                                 // PT=207
+    putUnalignedInt16BigEndian(xr + 2, 7);        // length: (32/4) - 1
+    putUnalignedInt32BigEndian(xr + 4, 0xCAFEF00D);
+    xr[8] = 0x2A;                                 // BT=42
+    xr[9] = 0x00;
+    putUnalignedInt16BigEndian(xr + 10, 5);       // 5 body words = 20 bytes
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+    EXPECT_EQ(0u, pKvsPeerConnection->receivedRrtrs[0].ssrc);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -6,6 +6,70 @@ namespace kinesis {
 namespace video {
 namespace webrtcclient {
 
+// ---- RTCP XR test helpers ----
+// Build XR packets declaratively instead of hand-crafting byte arrays in each test.
+
+namespace {
+
+struct DlrrSub {
+    UINT32 ssrcN;
+    UINT32 lrr;
+    UINT32 dlrr;
+};
+
+// 12-byte RRTR block (RFC 3611 §4.4).
+std::vector<BYTE> rrtrBlock(UINT64 ntp)
+{
+    std::vector<BYTE> blk(RTCP_XR_RRTR_BLOCK_LEN);
+    blk[0] = RTCP_XR_BLOCK_TYPE_RRTR;
+    blk[1] = 0;
+    putUnalignedInt16BigEndian(blk.data() + 2, 2);
+    putUnalignedInt64BigEndian(blk.data() + 4, ntp);
+    return blk;
+}
+
+// DLRR block (RFC 3611 §4.5) with N sub-blocks.
+std::vector<BYTE> dlrrBlock(std::initializer_list<DlrrSub> subs)
+{
+    const UINT32 n = (UINT32) subs.size();
+    std::vector<BYTE> blk(RTCP_XR_DLRR_BLOCK_HDR_LEN + n * RTCP_XR_DLRR_SUBBLOCK_LEN);
+    blk[0] = RTCP_XR_BLOCK_TYPE_DLRR;
+    blk[1] = 0;
+    putUnalignedInt16BigEndian(blk.data() + 2, (UINT16) (n * 3));
+    UINT32 p = RTCP_XR_DLRR_BLOCK_HDR_LEN;
+    for (auto& s : subs) {
+        putUnalignedInt32BigEndian(blk.data() + p, s.ssrcN);
+        putUnalignedInt32BigEndian(blk.data() + p + 4, s.lrr);
+        putUnalignedInt32BigEndian(blk.data() + p + 8, s.dlrr);
+        p += RTCP_XR_DLRR_SUBBLOCK_LEN;
+    }
+    return blk;
+}
+
+// Unknown XR block of type `bt` with `bodyWords` zero-filled 32-bit words.
+std::vector<BYTE> unknownBlock(UINT8 bt, UINT16 bodyWords)
+{
+    std::vector<BYTE> blk(4 + (UINT32) bodyWords * 4);
+    blk[0] = bt;
+    blk[1] = 0;
+    putUnalignedInt16BigEndian(blk.data() + 2, bodyWords);
+    return blk;
+}
+
+// Wrap a body of XR blocks with the 8-byte XR header and return the full packet.
+std::vector<BYTE> buildXrPacket(UINT32 reporterSsrc, std::vector<BYTE> body)
+{
+    std::vector<BYTE> pkt(RTCP_XR_HEADER_LEN + body.size());
+    pkt[0] = 0x80;
+    pkt[1] = RTCP_PACKET_TYPE_EXTENDED_REPORT;
+    putUnalignedInt16BigEndian(pkt.data() + 2, (UINT16) (pkt.size() / RTCP_PACKET_LEN_WORD_SIZE - 1));
+    putUnalignedInt32BigEndian(pkt.data() + 4, reporterSsrc);
+    std::copy(body.begin(), body.end(), pkt.begin() + RTCP_XR_HEADER_LEN);
+    return pkt;
+}
+
+} // namespace
+
 class RtcpFunctionalityTest : public WebRtcClientTestBase {
   public:
     PKvsRtpTransceiver pKvsRtpTransceiver = nullptr;
@@ -1264,30 +1328,15 @@ TEST_F(RtcpFunctionalityTest, jitterFirstPacketDoesNotSpike)
 TEST_F(RtcpFunctionalityTest, xrRrtrStoresReporterState)
 {
     initTransceiver(0x11223344);
-
-    // Wipe slots so the test is order-independent.
     MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
 
     const UINT32 reporterSsrc = 0xDEADBEEF;
     const UINT64 ntp = 0xE1E3204300ABCDEFULL;
-    const UINT32 expectedNtpMid = MID_NTP(ntp);
+    auto xr = buildXrPacket(reporterSsrc, rrtrBlock(ntp));
 
-    // XR header (V=2, P=0, rsvd=0, PT=207, length = 4 words -1 = 4, SSRC=reporter)
-    // then one RRTR block (BT=4, rsvd=0, length=2, 8-byte NTP).
-    BYTE xr[20];
-    MEMSET(xr, 0, SIZEOF(xr));
-    xr[0] = 0x80;                                         // V=2
-    xr[1] = 0xCF;                                         // PT=207
-    putUnalignedInt16BigEndian(xr + 2, 4);                // length: (20/4) - 1
-    putUnalignedInt32BigEndian(xr + 4, reporterSsrc);     // reporter SSRC
-    xr[8] = 0x04;                                         // BT=4 (RRTR)
-    xr[9] = 0x00;
-    putUnalignedInt16BigEndian(xr + 10, 2);               // block length = 2 words
-    putUnalignedInt64BigEndian(xr + 12, ntp);
-
-    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr.data(), (UINT32) xr.size()));
     EXPECT_EQ(reporterSsrc, pKvsPeerConnection->receivedRrtrs[0].ssrc);
-    EXPECT_EQ(expectedNtpMid, pKvsPeerConnection->receivedRrtrs[0].ntpMid);
+    EXPECT_EQ(MID_NTP(ntp), pKvsPeerConnection->receivedRrtrs[0].ntpMid);
     EXPECT_EQ(0u, pKvsPeerConnection->receivedRrtrs[0].lastRepliedNtpMid);
 
     freePeerConnection(&pRtcPeerConnection);
@@ -1297,6 +1346,9 @@ TEST_F(RtcpFunctionalityTest, xrRrtrStoresReporterState)
 // RRTR's middle-32 NTP as LRR and a DLRR value ~= elapsed time.
 TEST_F(RtcpFunctionalityTest, xrDlrrEchoesLrrAndDelay)
 {
+    // This test still inspects the raw bytes of the builder output to pin the
+    // wire layout — that's the *point*. Round-tripping via the parser would
+    // hide simultaneous build/parse offset bugs.
     const UINT32 ourSsrc = 0x12345678;
     initTransceiver(ourSsrc);
 
@@ -1393,46 +1445,27 @@ TEST_F(RtcpFunctionalityTest, xrDlrrPopulatesRemoteOutboundRttStats)
     const UINT32 seededMid = 0x12345678;
     pKvsRtpTransceiver->lastRrtrNtpMid = seededMid;
 
-    // Construct DLRR where LRR = seededMid and DLRR = 0 (peer replied instantly).
-    // Expected RTT = MID_NTP(now) - LRR - 0 in DLSR units, which should match the
-    // measured wall-clock elapsed since we "sent" the RRTR corresponding to seededMid.
-    // To make the test deterministic we instead pick an LRR equal to MID_NTP(GETTIME())
-    // at DLRR construction time; with DLRR=0 RTT should be ~0 ms.
+    // To make the test deterministic, use an LRR equal to MID_NTP(GETTIME()) at
+    // DLRR construction time and DLRR=0 (peer replied instantly). RTT should be
+    // tiny (sub-millisecond, definitely < 1 s).
     const UINT32 lrr = MID_NTP(convertTimestampToNTP(GETTIME()));
     pKvsRtpTransceiver->lastRrtrNtpMid = lrr;
 
-    BYTE xr[24];
-    MEMSET(xr, 0, SIZEOF(xr));
-    xr[0] = 0x80;
-    xr[1] = 0xCF;                                     // PT=207
-    putUnalignedInt16BigEndian(xr + 2, 5);            // length = (24/4) - 1 = 5
-    putUnalignedInt32BigEndian(xr + 4, 0xA1B2C3D4);   // reporter (peer) SSRC (not used)
-    xr[8] = 0x05;                                     // BT=5 (DLRR)
-    xr[9] = 0x00;
-    putUnalignedInt16BigEndian(xr + 10, 3);           // 3 words = 1 sub-block
-    putUnalignedInt32BigEndian(xr + 12, ourSsrc);     // SSRC_n = our sender SSRC
-    putUnalignedInt32BigEndian(xr + 16, lrr);         // LRR echoes our lastRrtrNtpMid
-    putUnalignedInt32BigEndian(xr + 20, 0);           // DLRR = 0 (peer reports no delay)
+    auto goodDlrr = buildXrPacket(0xA1B2C3D4, dlrrBlock({{ourSsrc, lrr, 0}}));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, goodDlrr.data(), (UINT32) goodDlrr.size()));
 
-    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
-
-    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
     EXPECT_EQ(1u, pKvsRtpTransceiver->remoteOutboundStats.roundTripTimeMeasurements);
     EXPECT_GE(pKvsRtpTransceiver->remoteOutboundStats.totalRoundTripTime, 0.0);
     EXPECT_LT(pKvsRtpTransceiver->remoteOutboundStats.roundTripTime, 1.0); // < 1 s on localhost
-    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
 
-    // A DLRR with LRR=0 or not matching our stored ntpMid must NOT bump the counter.
+    // A DLRR with LRR=0 or LRR != our stored ntpMid must NOT bump the counter.
     pKvsRtpTransceiver->lastRrtrNtpMid = 0x99999999;
-    putUnalignedInt32BigEndian(xr + 16, 0); // LRR=0
-    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+    auto zeroLrr = buildXrPacket(0xA1B2C3D4, dlrrBlock({{ourSsrc, 0, 0}}));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, zeroLrr.data(), (UINT32) zeroLrr.size()));
+    auto mismatchLrr = buildXrPacket(0xA1B2C3D4, dlrrBlock({{ourSsrc, 0x00000001, 0}}));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, mismatchLrr.data(), (UINT32) mismatchLrr.size()));
 
-    putUnalignedInt32BigEndian(xr + 16, 0x00000001); // non-matching LRR
-    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
-
-    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
     EXPECT_EQ(1u, pKvsRtpTransceiver->remoteOutboundStats.roundTripTimeMeasurements); // unchanged
-    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
 
     freePeerConnection(&pRtcPeerConnection);
 }
@@ -1444,18 +1477,9 @@ TEST_F(RtcpFunctionalityTest, xrParserSkipsUnknownBlockTypes)
     initTransceiver(0xAA);
     MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
 
-    // XR header + a BT=42 block with length=5 (20 bytes of zero body).
-    BYTE xr[32];
-    MEMSET(xr, 0, SIZEOF(xr));
-    xr[0] = 0x80;
-    xr[1] = 0xCF;                                 // PT=207
-    putUnalignedInt16BigEndian(xr + 2, 7);        // length: (32/4) - 1
-    putUnalignedInt32BigEndian(xr + 4, 0xCAFEF00D);
-    xr[8] = 0x2A;                                 // BT=42
-    xr[9] = 0x00;
-    putUnalignedInt16BigEndian(xr + 10, 5);       // 5 body words = 20 bytes
+    auto xr = buildXrPacket(0xCAFEF00D, unknownBlock(/*bt=*/42, /*bodyWords=*/5));
 
-    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr.data(), (UINT32) xr.size()));
     EXPECT_EQ(0u, pKvsPeerConnection->receivedRrtrs[0].ssrc);
 
     freePeerConnection(&pRtcPeerConnection);

--- a/tst/RtcpFunctionalityTest.cpp
+++ b/tst/RtcpFunctionalityTest.cpp
@@ -1307,6 +1307,8 @@ TEST_F(RtcpFunctionalityTest, xrDlrrEchoesLrrAndDelay)
     pKvsPeerConnection->receivedRrtrs[0].ssrc = reporterSsrc;
     pKvsPeerConnection->receivedRrtrs[0].ntpMid = ntpMid;
     pKvsPeerConnection->receivedRrtrs[0].arrivalTimeHns = arrival;
+    // Suppress RRTR emission so this test only covers the DLRR block layout.
+    pKvsRtpTransceiver->lastRrtrSentTime = arrival;
 
     // Emit one millisecond later. Expected DLRR = 1 ms * 65536 / 1 s = 65.
     const UINT64 currentTime = arrival + 1 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
@@ -1335,6 +1337,102 @@ TEST_F(RtcpFunctionalityTest, xrDlrrEchoesLrrAndDelay)
     outLen = sizeof(out);
     EXPECT_EQ(STATUS_SUCCESS, rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, currentTime, out, &outLen));
     EXPECT_EQ(0u, outLen);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// The builder emits an RRTR block (BT=4) with our NTP when the RRTR interval has elapsed,
+// so the remote peer can reply with a DLRR that lets us measure our RTT.
+TEST_F(RtcpFunctionalityTest, xrBuilderEmitsRrtrBlock)
+{
+    const UINT32 ourSsrc = 0x87654321;
+    initTransceiver(ourSsrc);
+
+    // lastRrtrSentTime = 0 → builder treats this tick as "first RRTR ever", always emits.
+    pKvsRtpTransceiver->lastRrtrSentTime = 0;
+    MEMSET(pKvsPeerConnection->receivedRrtrs, 0, SIZEOF(pKvsPeerConnection->receivedRrtrs));
+
+    const UINT64 now = GETTIME();
+    BYTE out[64];
+    UINT32 outLen = sizeof(out);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, now, out, &outLen));
+    // Just XR header + RRTR block, no DLRR.
+    EXPECT_EQ(RTCP_XR_HEADER_LEN + RTCP_XR_RRTR_BLOCK_LEN, outLen);
+
+    // Header: V=2, PT=207, length = 4 (20 bytes / 4 - 1 = 4), reporter SSRC = ours.
+    EXPECT_EQ(0x80, out[0]);
+    EXPECT_EQ(RTCP_PACKET_TYPE_EXTENDED_REPORT, out[1]);
+    EXPECT_EQ(4u, getUnalignedInt16BigEndian(out + 2));
+    EXPECT_EQ(ourSsrc, getUnalignedInt32BigEndian(out + 4));
+
+    // RRTR block header: BT=4, block length = 2 words.
+    EXPECT_EQ(RTCP_XR_BLOCK_TYPE_RRTR, out[RTCP_XR_HEADER_LEN]);
+    EXPECT_EQ(2u, getUnalignedInt16BigEndian(out + RTCP_XR_HEADER_LEN + 2));
+
+    // NTP at body matches our NTP for `now`, and transceiver state reflects the send.
+    const UINT64 ntpInPacket = getUnalignedInt64BigEndian(out + RTCP_XR_HEADER_LEN + 4);
+    EXPECT_EQ(convertTimestampToNTP(now), ntpInPacket);
+    EXPECT_EQ(MID_NTP(ntpInPacket), pKvsRtpTransceiver->lastRrtrNtpMid);
+    EXPECT_EQ(now, pKvsRtpTransceiver->lastRrtrSentTime);
+
+    // A call well before the interval elapses should emit nothing.
+    outLen = sizeof(out);
+    EXPECT_EQ(STATUS_SUCCESS, rtcpBuildExtendedReport(pKvsPeerConnection, pKvsRtpTransceiver, now + 10, out, &outLen));
+    EXPECT_EQ(0u, outLen);
+
+    freePeerConnection(&pRtcPeerConnection);
+}
+
+// Feeding a DLRR that echoes our stored lastRrtrNtpMid must populate
+// remoteOutboundStats.{roundTripTime,totalRoundTripTime,roundTripTimeMeasurements}.
+TEST_F(RtcpFunctionalityTest, xrDlrrPopulatesRemoteOutboundRttStats)
+{
+    const UINT32 ourSsrc = 0x11223344;
+    initTransceiver(ourSsrc);
+
+    const UINT32 seededMid = 0x12345678;
+    pKvsRtpTransceiver->lastRrtrNtpMid = seededMid;
+
+    // Construct DLRR where LRR = seededMid and DLRR = 0 (peer replied instantly).
+    // Expected RTT = MID_NTP(now) - LRR - 0 in DLSR units, which should match the
+    // measured wall-clock elapsed since we "sent" the RRTR corresponding to seededMid.
+    // To make the test deterministic we instead pick an LRR equal to MID_NTP(GETTIME())
+    // at DLRR construction time; with DLRR=0 RTT should be ~0 ms.
+    const UINT32 lrr = MID_NTP(convertTimestampToNTP(GETTIME()));
+    pKvsRtpTransceiver->lastRrtrNtpMid = lrr;
+
+    BYTE xr[24];
+    MEMSET(xr, 0, SIZEOF(xr));
+    xr[0] = 0x80;
+    xr[1] = 0xCF;                                     // PT=207
+    putUnalignedInt16BigEndian(xr + 2, 5);            // length = (24/4) - 1 = 5
+    putUnalignedInt32BigEndian(xr + 4, 0xA1B2C3D4);   // reporter (peer) SSRC (not used)
+    xr[8] = 0x05;                                     // BT=5 (DLRR)
+    xr[9] = 0x00;
+    putUnalignedInt16BigEndian(xr + 10, 3);           // 3 words = 1 sub-block
+    putUnalignedInt32BigEndian(xr + 12, ourSsrc);     // SSRC_n = our sender SSRC
+    putUnalignedInt32BigEndian(xr + 16, lrr);         // LRR echoes our lastRrtrNtpMid
+    putUnalignedInt32BigEndian(xr + 20, 0);           // DLRR = 0 (peer reports no delay)
+
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    EXPECT_EQ(1u, pKvsRtpTransceiver->remoteOutboundStats.roundTripTimeMeasurements);
+    EXPECT_GE(pKvsRtpTransceiver->remoteOutboundStats.totalRoundTripTime, 0.0);
+    EXPECT_LT(pKvsRtpTransceiver->remoteOutboundStats.roundTripTime, 1.0); // < 1 s on localhost
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
+
+    // A DLRR with LRR=0 or not matching our stored ntpMid must NOT bump the counter.
+    pKvsRtpTransceiver->lastRrtrNtpMid = 0x99999999;
+    putUnalignedInt32BigEndian(xr + 16, 0); // LRR=0
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+
+    putUnalignedInt32BigEndian(xr + 16, 0x00000001); // non-matching LRR
+    EXPECT_EQ(STATUS_SUCCESS, onRtcpPacket(pKvsPeerConnection, xr, SIZEOF(xr)));
+
+    MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
+    EXPECT_EQ(1u, pKvsRtpTransceiver->remoteOutboundStats.roundTripTimeMeasurements); // unchanged
+    MUTEX_UNLOCK(pKvsRtpTransceiver->statsLock);
 
     freePeerConnection(&pRtcPeerConnection);
 }


### PR DESCRIPTION
Stacked on top of #70 (fix-remote-inbound-rtt-stats).

*What was changed?*

Added a minimal RFC 3611 RTCP Extended Reports (XR) implementation: parse incoming XR packets (RRTR block type 4, plus graceful skipping of every other block type including libwebrtc's proprietary target-bitrate BT=42), emit XR packets with a DLRR block (BT=5) echoing each pending RRTR back to its reporter, and advertise the `a=rtcp-fb:<pt> rrtr` per-codec feedback parameter in the answer SDP that libwebrtc requires to enable non-sender RTT measurement on its side.

New wire-level pieces live in `src/source/PeerConnection/Rtcp.c` (`onRtcpExtendedReport`, `rtcpBuildExtendedReport`), new constants and block-size definitions in `src/source/Rtcp/RtcpPacket.h`, a small per-peer-connection RRTR state table on `KvsPeerConnection` (new `rtcpXrLock` + 4-slot array in `src/source/PeerConnection/PeerConnection.h`), the DLRR emission hook in `rtcpReportsCallback` (`src/source/PeerConnection/PeerConnection.c`), the SDP attribute in `src/source/PeerConnection/SessionDescription.c`, and three new unit tests in `tst/RtcpFunctionalityTest.cpp` covering RRTR storage, DLRR byte layout, and unknown-block-type tolerance.

*Why was it changed?*

The library neither parsed nor emitted RTCP XR. A receive-only Chrome peer in a WHEP-style session will advertise non-sender RTT capability via `a=rtcp-fb:<pt> rrtr` and emit XR+RRTR packets expecting XR+DLRR in response — this is the only spec-defined mechanism by which a non-RTP-sender can measure its RTT to the sender in WebRTC. Without this implementation, XR packets fell through the RTCP dispatch switch as an unhandled type, there was no state to answer them with, and libwebrtc had no hook to turn RRTR emission on in the first place. This made it impossible for a receive-only peer to feed its congestion control and candidate-pair RTT estimates with real RTT measurements (only STUN RTT was available), and it closed the door on future work around RFC 3611-based latency reporting.

Chrome's `getStats()` `remote-outbound-rtp.roundTripTime` field is a separate open item — current libwebrtc does not populate it from DLRR even though the W3C spec implies it should (see [w3c/webrtc-stats#602](https://github.com/w3c/webrtc-stats/issues/602) and [w3c/webrtc-extensions#165](https://github.com/w3c/webrtc-extensions/issues/165)). This PR does not attempt to work around that browser-side gap.

*How was it changed?*

The parser walks the standard RFC 3611 §3 `{BT, type-specific, length}` block framing, using the 16-bit length field to advance past every block regardless of whether we understand the type, so an XR compound that contains a libwebrtc-proprietary BT=42 target-bitrate block plus an RRTR block parses cleanly. On RRTR (BT=4) the parser stores the reporter SSRC, the middle-32 of the received NTP timestamp, and the local arrival time into a fixed 4-slot table on the peer connection; the slot index is keyed by reporter SSRC so repeat RRTRs from the same reporter update in place.

The builder assembles a complete XR packet: 8-byte header (V=2, P=0, rsvd=0, PT=207, length, our sender SSRC) followed by one DLRR block header (BT=5, rsvd=0, block length = 3 * number of sub-blocks) and one 12-byte sub-block per pending RRTR `{SSRC_n=reporter, LRR=stored NTP-mid, DLRR=delay-since-arrival in 1/65536s}`. Entries are marked replied-to after each emission to avoid duplicate DLRRs across successive RTCP timer ticks when no new RRTR has arrived. The emit site is `rtcpReportsCallback`, right after the existing SR/RR pair, reusing `sendBuiltRtcpReport` so XR goes through the same SRTP-encrypt/ICE-send path and does not confuse SRTCP replay counters.

Direction-agnostic: both paths work regardless of whether the transceiver is sendonly, recvonly, or sendrecv on the library side, so the future case of a receive-only KVS library talking to an XR-enabled sender is also covered.

The SDP side is minimal: the answer emits `a=rtcp-fb:<pt> rrtr` next to the existing `goog-remb` line on every negotiated codec. This is the libwebrtc-specific gate on Chrome's non-sender RTT measurement — libwebrtc ignores the session-level `a=rtcp-xr` attribute entirely and only flips non-sender RTT on when it sees the per-codec feedback param.

*What testing was done for the changes?*

- Three new gtest cases in `tst/RtcpFunctionalityTest.cpp`: `xrRrtrStoresReporterState` (parser stashes reporter SSRC and NTP-mid into the table), `xrDlrrEchoesLrrAndDelay` (builder emits a byte-for-byte correct DLRR with LRR echoing the stored NTP-mid and DLRR close to the supplied delay, and a second call with no new RRTR is a no-op), and `xrParserSkipsUnknownBlockTypes` (parser accepts a BT=42 block without error and without touching RRTR storage). All 34 tests in `RtcpFunctionalityTest` pass.
- End-to-end with Chrome via the WHEP sample: the answer SDP now carries `a=rtcp-fb:109 rrtr` (H.264) and `a=rtcp-fb:111 rrtr` (Opus). Chrome starts emitting XR+RRTR at its usual cadence; verbose logs confirm `onRtcpExtendedReport` parses them and `rtcpBuildExtendedReport` emits 24-byte XR+DLRR replies whose raw bytes were inspected and match RFC 3611 §4.5 exactly. Chrome's candidate-pair stats stay populated, confirming the transport-level RTCP pipe keeps working; the expected browser-side gap in `remote-outbound-rtp.roundTripTime` is documented above.
- `./scripts/clang-format.sh -f` run on every changed C/C++ file outside `tst/`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.