### PR TITLE
Quiet Android CI logs on gtest assertion failure

### DIFF
--- a/android-test-app/jni_bridge.cpp
+++ b/android-test-app/jni_bridge.cpp
@@ -194,7 +194,7 @@ extern "C" JNIEXPORT jint JNICALL Java_com_kvs_webrtctest_NativeTestLib_runTests
     // Build gtest argv
     std::string filterArg = std::string("--gtest_filter=") + filterStr;
     char arg0[] = "webrtc_test_jni";
-    char* argv[] = {arg0, const_cast<char*>(filterArg.c_str()), "--gtest_break_on_failure", nullptr};
+    char* argv[] = {arg0, const_cast<char*>(filterArg.c_str()), "--gtest_fail_fast", nullptr};
     int argc = 3;
 
     ::testing::InitGoogleTest(&argc, argv);

--- a/scripts/run-android-app-test.sh
+++ b/scripts/run-android-app-test.sh
@@ -34,11 +34,27 @@ STATUS_CODE=$(grep '^INSTRUMENTATION_STATUS_CODE:' "$OUTPUT_LOG" | tail -1 | awk
 
 if [[ "$STATUS_CODE" != "0" ]]; then
   echo "::error::Tests failed (INSTRUMENTATION_STATUS_CODE: ${STATUS_CODE})"
+
+  TEST_LOG_FILE=$(mktemp)
+  "${ADB}" -s "${SERIAL}" shell run-as com.kvs.webrtctest cat files/test.log 2>/dev/null > "$TEST_LOG_FILE" || true
   echo "=== test.log ==="
-  "${ADB}" -s "${SERIAL}" shell run-as com.kvs.webrtctest cat files/test.log 2>/dev/null || echo "(test.log not available)"
+  if [[ -s "$TEST_LOG_FILE" ]]; then
+    cat "$TEST_LOG_FILE"
+  else
+    echo "(test.log not available)"
+  fi
+
   echo "=== logcat ==="
   "${ADB}" -s "${SERIAL}" logcat -d -s "webrtc_test_jni:*" "WebRtcNativeTest:*" "TestRunner:*"
-  echo "=== crash log ==="
-  "${ADB}" -s "${SERIAL}" logcat -d -b crash
+
+  # Skip the native crash-buffer dump when it's just a gtest assertion
+  # failure — the "[  FAILED  ]" line above already tells the whole story.
+  if ! grep -qE '^\[  FAILED  \]' "$TEST_LOG_FILE" \
+     || grep -qE 'AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:' "$TEST_LOG_FILE"; then
+    echo "=== crash log ==="
+    "${ADB}" -s "${SERIAL}" logcat -d -b crash
+  fi
+
+  rm -f "$TEST_LOG_FILE"
   exit 1
 fi

--- a/scripts/run-tests-on-device.sh
+++ b/scripts/run-tests-on-device.sh
@@ -20,7 +20,7 @@ echo ""
 
 timeout -s ABRT 300 ./webrtc_client_test \
     --gtest_filter="${GTEST_FILTER}" \
-    --gtest_break_on_failure 2>&1
+    --gtest_fail_fast 2>&1
 
 EXIT_CODE=$?
 echo ""

--- a/scripts/test-ci-android.sh
+++ b/scripts/test-ci-android.sh
@@ -91,15 +91,28 @@ TEST_LOG="${BUILD_DIR}/test-output.log"
 TEST_EXIT=$(sed -n 's/.*exit code: \([0-9]*\).*/\1/p' "${TEST_LOG}" | tail -1)
 TEST_EXIT=${TEST_EXIT:-0}
 
-# Dump crash logcat on failure
-if [[ ${TEST_EXIT} -ne 0 ]]; then
+# A gtest assertion failure already produced a "[  FAILED  ]" line with the
+# root cause; the SIGABRT tombstone and ASan symbolization that follow are
+# redundant noise. Skip them unless the failure looks like a real native crash
+# or a sanitizer report.
+GTEST_FAILED=false
+if grep -qE '^\[  FAILED  \]' "${TEST_LOG}"; then
+    GTEST_FAILED=true
+fi
+SANITIZER_REPORT=false
+if grep -qE 'AddressSanitizer|UndefinedBehaviorSanitizer|runtime error:' "${TEST_LOG}"; then
+    SANITIZER_REPORT=true
+fi
+
+# Dump crash logcat only on real native crashes (not plain assertion failures).
+if [[ ${TEST_EXIT} -ne 0 ]] && { [[ "${GTEST_FAILED}" == "false" ]] || [[ "${SANITIZER_REPORT}" == "true" ]]; }; then
     echo ""
     echo "=== crash log ==="
     "${ADB}" -s "${SERIAL}" logcat -d -b crash
 fi
 
-# Symbolize ASan/UBSan stack traces on failure
-if [[ "${ASAN}" == "true" && ${TEST_EXIT} -ne 0 ]]; then
+# Symbolize ASan/UBSan stack traces only when an actual sanitizer report was emitted.
+if [[ "${ASAN}" == "true" && ${TEST_EXIT} -ne 0 && "${SANITIZER_REPORT}" == "true" ]]; then
     HOST_BINARY="${BUILD_DIR}/sdk/tst/webrtc_client_test"
     LLVM_SYMBOLIZER=$(find "${ANDROID_NDK}/toolchains/llvm/prebuilt" -name "llvm-symbolizer" -type f | head -1)
     if [[ -x "${LLVM_SYMBOLIZER}" && -f "${HOST_BINARY}" ]]; then


### PR DESCRIPTION
*What was changed?*

- `scripts/run-tests-on-device.sh`: replaced `--gtest_break_on_failure` with `--gtest_fail_fast`.
- `scripts/test-ci-android.sh`: gated the `adb logcat -b crash` dump and the llvm-symbolizer pass on whether the test log contains a gtest `[  FAILED  ]` marker and/or a sanitizer report.
- `tst/DataChannelApiTest.cpp`: **TEMP** — a deliberate `EXPECT_EQ(1, 2)` was added to `createDataChannel_Disconnected` to force the Android CI path through the new quieter-failure branch. **This commit must be reverted before merge.**

*Why was it changed?*

On Android, `--gtest_break_on_failure` converted every `EXPECT_*`/`ASSERT_*` failure into an `abort()`, which Android `debuggerd` turned into a full tombstone (registers, backtrace, memory map) dumped through the crash logcat buffer. For plain assertion failures the gtest `[  FAILED  ]` line already tells the full story, so the tombstone and the ASan symbolizer output that followed were pure noise — and, for ASan builds, ran llvm-symbolizer over frames that had nothing to do with a sanitizer error. CI logs for a single wrong-value assertion were hundreds of lines of useless crash data.

*How was it changed?*

`--gtest_fail_fast` exits the process cleanly with status 1 on the first failure, so there is no SIGABRT, no tombstone, and no crash-buffer entry for ordinary assertion failures. The CI driver now scans the captured test output: if a `[  FAILED  ]` line is present and no sanitizer report (`AddressSanitizer`/`UndefinedBehaviorSanitizer`/`runtime error:`) appears, both the crash-buffer dump and the symbolizer pass are skipped. Genuine native crashes (SIGSEGV with no preceding gtest failure marker) and real ASan/UBSan reports still fall through to the full crash log and symbolized output.

*What testing was done for the changes?*

The deliberate `EXPECT_EQ(1, 2)` in `DataChannelApiTest.createDataChannel_Disconnected` forces the Android CI jobs to take the assertion-failure path. The expected result in the Android job logs:
- Normal gtest `[  FAILED  ]` output with the assertion site.
- No `=== crash log ===` section.
- No `=== Symbolized stack traces ===` section (even for the ASan job, since no sanitizer report is emitted).
- Overall job exit status is non-zero.

Once verified, the temp-failure commit (`TEMP: deliberate EXPECT_EQ failure…`) will be dropped and the PR re-pushed before merge.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.