### PR TITLE
Fix TWSN ordering: encrypt-at-dequeue for monotonic transport-wide sequence numbers

### DIFF
--- a/src/source/PeerConnection/Pacer.c
+++ b/src/source/PeerConnection/Pacer.c
@@ -506,7 +506,7 @@ UINT32 pacerCalculateBudget(PPacer pPacer, UINT64 elapsedTimeKvs)
     return (UINT32) MIN(bytesPerInterval, MAX_UINT32);
 }
 
-STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen)
+STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen, UINT64 enqueueTimeKvs)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -545,7 +545,7 @@ STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen)
     }
 
     if (pPacer->onPacketSent != NULL) {
-        pPacer->onPacketSent(pPacer->onPacketSentCustomData, pData, (UINT32) encLen);
+        pPacer->onPacketSent(pPacer->onPacketSentCustomData, pData, (UINT32) encLen, enqueueTimeKvs);
     }
 
 CleanUp:
@@ -621,7 +621,7 @@ STATUS pacerDrainQueue(PPacer pPacer)
         }
 
         // Assign TWSN, encrypt, and send
-        retStatus = pacerSendRtpPacket(pPacer, pPacket->pData, pPacket->size);
+        retStatus = pacerSendRtpPacket(pPacer, pPacket->pData, pPacket->size, pPacket->enqueueTimeKvs);
         if (STATUS_SUCCEEDED(retStatus)) {
             bytesSent += pPacket->size;
             pPacer->stats.packetsSent++;

--- a/src/source/PeerConnection/Pacer.c
+++ b/src/source/PeerConnection/Pacer.c
@@ -10,13 +10,12 @@ Based on GCC RFC draft-ietf-rmcat-gcc-02 Section 4
 // Internal helper functions
 //
 
-static PPacerPacket pacerCreatePacket(PBYTE pData, UINT32 size, UINT16 twccSeqNum)
+static PPacerPacket pacerCreatePacket(PBYTE pData, UINT32 size)
 {
     PPacerPacket pPacket = (PPacerPacket) MEMCALLOC(1, SIZEOF(PacerPacket));
     if (pPacket != NULL) {
         pPacket->pData = pData;
         pPacket->size = size;
-        pPacket->twccSeqNum = twccSeqNum;
         pPacket->enqueueTimeKvs = GETTIME();
         pPacket->pNext = NULL;
     }
@@ -225,7 +224,7 @@ CleanUp:
     return retStatus;
 }
 
-STATUS pacerEnqueuePacket(PPacer pPacer, PBYTE pData, UINT32 size, UINT16 twccSeqNum)
+STATUS pacerEnqueuePacket(PPacer pPacer, PBYTE pData, UINT32 size)
 {
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
@@ -250,7 +249,7 @@ STATUS pacerEnqueuePacket(PPacer pPacer, PBYTE pData, UINT32 size, UINT16 twccSe
     }
 
     // Create packet wrapper
-    pPacket = pacerCreatePacket(pData, size, twccSeqNum);
+    pPacket = pacerCreatePacket(pData, size);
     CHK(pPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
 
     // Add to tail of queue
@@ -454,7 +453,6 @@ STATUS pacerEnqueueFrame(PPacer pPacer, PPacerPacketInfo pPackets, UINT32 count)
 
         pPacket->pData = pPackets[i].pData;
         pPacket->size = pPackets[i].size;
-        pPacket->twccSeqNum = pPackets[i].twccSeqNum;
         pPacket->enqueueTimeKvs = frameEnqueueTime; // Same time for all packets in frame
         pPacket->pNext = NULL;
 
@@ -506,6 +504,50 @@ UINT32 pacerCalculateBudget(PPacer pPacer, UINT64 elapsedTimeKvs)
     bytesPerInterval = (UINT64) (pPacer->targetBitrateBps * elapsedSec * pPacer->pacingFactor / 8.0);
 
     return (UINT32) MIN(bytesPerInterval, MAX_UINT32);
+}
+
+STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen)
+{
+    ENTERS();
+    STATUS retStatus = STATUS_SUCCESS;
+    PKvsPeerConnection pKvsPeerConnection = NULL;
+    INT32 encLen = (INT32) plainLen;
+    UINT16 twsn = 0;
+    BOOL hasTwcc = FALSE;
+
+    CHK(pPacer != NULL && pData != NULL && plainLen > 0, STATUS_NULL_ARG);
+    CHK(pPacer->pKvsPeerConnection != NULL, STATUS_INVALID_OPERATION);
+
+    pKvsPeerConnection = (PKvsPeerConnection) pPacer->pKvsPeerConnection;
+    hasTwcc = (pKvsPeerConnection->twccExtId != 0);
+
+    if (hasTwcc) {
+        UINT8 cc = pData[0] & 0x0F;
+        UINT32 twccOffset = 17 + cc * 4;
+        twsn = (UINT16) ATOMIC_INCREMENT(&pKvsPeerConnection->transportWideSequenceNumber);
+        putUnalignedInt16BigEndian(pData + twccOffset, twsn);
+    }
+
+    if (pKvsPeerConnection->pPcapDump != NULL) {
+        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pData, plainLen, FALSE, PCAP_PACKET_DIRECTION_SEND);
+    }
+
+    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
+    retStatus = encryptRtpPacket(pKvsPeerConnection->pSrtpSession, pData, &encLen);
+    MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
+    CHK_STATUS(retStatus);
+
+    retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pData, (UINT32) encLen);
+    CHK_STATUS(retStatus);
+
+    if (hasTwcc) {
+        twccManagerOnPacedPacketSent(pKvsPeerConnection, twsn, plainLen, GETTIME());
+    }
+
+CleanUp:
+    CHK_LOG_ERR(retStatus);
+    LEAVES();
+    return retStatus;
 }
 
 STATUS pacerDrainQueue(PPacer pPacer)
@@ -574,25 +616,19 @@ STATUS pacerDrainQueue(PPacer pPacer)
             pPacer->stats.avgQueueDelayKvs = (UINT64) (0.9 * pPacer->stats.avgQueueDelayKvs + 0.1 * queueDelayKvs);
         }
 
-        // Send the packet
-        retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pPacket->pData, pPacket->size);
+        // Assign TWSN, encrypt, and send
+        retStatus = pacerSendRtpPacket(pPacer, pPacket->pData, pPacket->size);
         if (STATUS_SUCCEEDED(retStatus)) {
-            UINT64 sentTimeKvs = GETTIME();
-
             bytesSent += pPacket->size;
             pPacer->stats.packetsSent++;
             pPacer->stats.bytesSent += pPacket->size;
-
-            // Deduct from budget
             pPacer->budgetBytes -= pPacket->size;
-
-            // Update TWCC manager with actual send time
-            if (pPacket->twccSeqNum != 0 && pKvsPeerConnection->twccExtId != 0) {
-                twccManagerOnPacedPacketSent(pKvsPeerConnection, pPacket->twccSeqNum, pPacket->size, sentTimeKvs);
-            }
         } else {
             DLOGW("Failed to send paced packet: 0x%08x", retStatus);
         }
+        // pacerSendRtpPacket may have encrypted pData in place;
+        // free it here since pacerFreePacket would do the same
+        SAFE_MEMFREE(pPacket->pData);
 
         // Free the packet (data is owned by packet)
         pacerFreePacket(pPacket);

--- a/src/source/PeerConnection/Pacer.c
+++ b/src/source/PeerConnection/Pacer.c
@@ -544,6 +544,10 @@ STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen)
         twccManagerOnPacedPacketSent(pKvsPeerConnection, twsn, plainLen, GETTIME());
     }
 
+    if (pPacer->onPacketSent != NULL) {
+        pPacer->onPacketSent(pPacer->onPacketSentCustomData, pData, (UINT32) encLen);
+    }
+
 CleanUp:
     CHK_LOG_ERR(retStatus);
     LEAVES();

--- a/src/source/PeerConnection/Pacer.h
+++ b/src/source/PeerConnection/Pacer.h
@@ -30,19 +30,17 @@ extern "C" {
  * Packet info for batch enqueue (frame-based pacing)
  */
 typedef struct {
-    PBYTE pData;       //!< Packet data (pacer takes ownership)
-    UINT32 size;       //!< Packet size in bytes
-    UINT16 twccSeqNum; //!< TWCC sequence number
+    PBYTE pData;  //!< Plain (unencrypted) RTP data; buffer has SRTP_AUTH_TAG_OVERHEAD extra bytes. Pacer takes ownership.
+    UINT32 size;  //!< Plain RTP size in bytes (not including SRTP overhead)
 } PacerPacketInfo, *PPacerPacketInfo;
 
 /**
  * Queued packet for paced sending
  */
 typedef struct __PacerPacket {
-    PBYTE pData;                 //!< Encrypted packet data (owned by pacer)
-    UINT32 size;                 //!< Packet size in bytes
+    PBYTE pData;                 //!< Plain (unencrypted) RTP data; buffer has SRTP_AUTH_TAG_OVERHEAD extra bytes
+    UINT32 size;                 //!< Plain RTP size in bytes (not including SRTP overhead)
     UINT64 enqueueTimeKvs;       //!< When packet was enqueued
-    UINT16 twccSeqNum;           //!< TWCC sequence number for tracking
     struct __PacerPacket* pNext; //!< Next packet in queue
 } PacerPacket, *PPacerPacket;
 
@@ -146,15 +144,15 @@ STATUS pacerStop(PPacer pPacer);
 
 /**
  * Enqueue a packet for paced sending
- * The pacer takes ownership of the packet data
+ * The pacer takes ownership of the packet data.
+ * pData must have SRTP_AUTH_TAG_OVERHEAD extra bytes allocated beyond size.
  *
  * @param[in] pPacer Pacer instance
- * @param[in] pData Packet data (pacer takes ownership, will free)
- * @param[in] size Packet size in bytes
- * @param[in] twccSeqNum TWCC sequence number for the packet
+ * @param[in] pData Plain (unencrypted) RTP data (pacer takes ownership, will free)
+ * @param[in] size Plain RTP size in bytes (not including SRTP overhead)
  * @return STATUS code (STATUS_SUCCESS or STATUS_NOT_ENOUGH_MEMORY if queue full)
  */
-STATUS pacerEnqueuePacket(PPacer pPacer, PBYTE pData, UINT32 size, UINT16 twccSeqNum);
+STATUS pacerEnqueuePacket(PPacer pPacer, PBYTE pData, UINT32 size);
 
 /**
  * Enqueue multiple packets as a frame (batch enqueue with single lock)
@@ -235,6 +233,20 @@ STATUS pacerSetMaxQueueTime(PPacer pPacer, UINT64 maxQueueTimeKvs);
  * @return Current max queue time in 100ns units (0 if disabled)
  */
 UINT64 pacerGetMaxQueueTime(PPacer pPacer);
+
+/**
+ * Send a plain RTP packet: assign TWSN, patch TWCC extension, PCAP capture,
+ * SRTP-encrypt in place, iceAgentSendPacket, TWCC tracking.
+ *
+ * Caller MUST hold pPacer->lock. The buffer must have SRTP_AUTH_TAG_OVERHEAD
+ * extra bytes beyond plainLen for in-place encryption.
+ *
+ * @param[in] pPacer Pacer instance (for pKvsPeerConnection access)
+ * @param[in,out] pData Plain RTP bytes; encrypted in place on return
+ * @param[in] plainLen Plain RTP size (not including SRTP overhead)
+ * @return STATUS code from iceAgentSendPacket (or encryption failure)
+ */
+STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen);
 
 //
 // Internal functions (exposed for unit testing)

--- a/src/source/PeerConnection/Pacer.h
+++ b/src/source/PeerConnection/Pacer.h
@@ -30,8 +30,8 @@ extern "C" {
  * Packet info for batch enqueue (frame-based pacing)
  */
 typedef struct {
-    PBYTE pData;  //!< Plain (unencrypted) RTP data; buffer has SRTP_AUTH_TAG_OVERHEAD extra bytes. Pacer takes ownership.
-    UINT32 size;  //!< Plain RTP size in bytes (not including SRTP overhead)
+    PBYTE pData; //!< Plain (unencrypted) RTP data; buffer has SRTP_AUTH_TAG_OVERHEAD extra bytes. Pacer takes ownership.
+    UINT32 size; //!< Plain RTP size in bytes (not including SRTP overhead)
 } PacerPacketInfo, *PPacerPacketInfo;
 
 /**
@@ -78,8 +78,9 @@ typedef struct {
  * @param[in] customData User-provided context
  * @param[in] pData Encrypted RTP bytes (header readable for SSRC extraction)
  * @param[in] wireLen Actual bytes sent (including SRTP auth tag)
+ * @param[in] enqueueTimeKvs When the packet was enqueued (100ns units); equals send time for non-paced packets
  */
-typedef VOID (*PacerOnPacketSent)(UINT64 customData, PBYTE pData, UINT32 wireLen);
+typedef VOID (*PacerOnPacketSent)(UINT64 customData, PBYTE pData, UINT32 wireLen, UINT64 enqueueTimeKvs);
 
 /**
  * Pacer structure
@@ -259,9 +260,10 @@ UINT64 pacerGetMaxQueueTime(PPacer pPacer);
  * @param[in] pPacer Pacer instance (for pKvsPeerConnection access)
  * @param[in,out] pData Plain RTP bytes; encrypted in place on return
  * @param[in] plainLen Plain RTP size (not including SRTP overhead)
+ * @param[in] enqueueTimeKvs When the packet was enqueued (100ns units); pass GETTIME() for non-paced sends
  * @return STATUS code from iceAgentSendPacket (or encryption failure)
  */
-STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen);
+STATUS pacerSendRtpPacket(PPacer pPacer, PBYTE pData, UINT32 plainLen, UINT64 enqueueTimeKvs);
 
 //
 // Internal functions (exposed for unit testing)

--- a/src/source/PeerConnection/Pacer.h
+++ b/src/source/PeerConnection/Pacer.h
@@ -71,6 +71,17 @@ typedef struct {
 } PacerStats, *PPacerStats;
 
 /**
+ * Callback fired after a packet is successfully sent on the wire.
+ * Called under pPacer->lock. The data is the encrypted RTP packet
+ * (header is still readable — SRTP only encrypts payload).
+ *
+ * @param[in] customData User-provided context
+ * @param[in] pData Encrypted RTP bytes (header readable for SSRC extraction)
+ * @param[in] wireLen Actual bytes sent (including SRTP auth tag)
+ */
+typedef VOID (*PacerOnPacketSent)(UINT64 customData, PBYTE pData, UINT32 wireLen);
+
+/**
  * Pacer structure
  */
 typedef struct __Pacer {
@@ -98,6 +109,10 @@ typedef struct __Pacer {
 
     // Parent peer connection (for sending) - stored as PVOID to avoid circular dependency
     PVOID pKvsPeerConnection;
+
+    // Callback for per-packet stats accounting
+    PacerOnPacketSent onPacketSent;
+    UINT64 onPacketSentCustomData;
 
     // Statistics
     PacerStats stats;

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1265,7 +1265,7 @@ static UINT32 rtpHeaderLenFromBytes(PBYTE pData, UINT32 len)
     return headerLen;
 }
 
-static VOID pacerOnPacketSentCallback(UINT64 customData, PBYTE pData, UINT32 wireLen)
+static VOID pacerOnPacketSentCallback(UINT64 customData, PBYTE pData, UINT32 wireLen, UINT64 enqueueTimeKvs)
 {
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
     PKvsRtpTransceiver pTransceiver = NULL;
@@ -1283,12 +1283,15 @@ static VOID pacerOnPacketSentCallback(UINT64 customData, PBYTE pData, UINT32 wir
     headerLen = rtpHeaderLenFromBytes(pData, wireLen);
 
     BOOL marker = (pData[1] >> MARKER_SHIFT) & MARKER_MASK;
+    UINT64 now = GETTIME();
+    UINT64 sendDelayKvs = (now >= enqueueTimeKvs) ? (now - enqueueTimeKvs) : 0;
 
     MUTEX_LOCK(pTransceiver->statsLock);
     pTransceiver->outboundStats.sent.bytesSent += wireLen - headerLen;
     pTransceiver->outboundStats.sent.packetsSent++;
-    pTransceiver->outboundStats.lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
+    pTransceiver->outboundStats.lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(now, HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
     pTransceiver->outboundStats.headerBytesSent += headerLen;
+    pTransceiver->outboundStats.totalPacketSendDelay += sendDelayKvs;
     if (marker && pTransceiver->sender.track.kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
         pTransceiver->outboundStats.framesSent++;
     }

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1282,11 +1282,16 @@ static VOID pacerOnPacketSentCallback(UINT64 customData, PBYTE pData, UINT32 wir
 
     headerLen = rtpHeaderLenFromBytes(pData, wireLen);
 
+    BOOL marker = (pData[1] >> MARKER_SHIFT) & MARKER_MASK;
+
     MUTEX_LOCK(pTransceiver->statsLock);
     pTransceiver->outboundStats.sent.bytesSent += wireLen - headerLen;
     pTransceiver->outboundStats.sent.packetsSent++;
     pTransceiver->outboundStats.lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
     pTransceiver->outboundStats.headerBytesSent += headerLen;
+    if (marker && pTransceiver->sender.track.kind == MEDIA_STREAM_TRACK_KIND_VIDEO) {
+        pTransceiver->outboundStats.framesSent++;
+    }
     MUTEX_UNLOCK(pTransceiver->statsLock);
 }
 

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1344,6 +1344,20 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
     CHK_STATUS(createTwccReceiverManager(&pKvsPeerConnection->pTwccReceiverManager));
     pKvsPeerConnection->twccFeedbackTimerId = MAX_UINT32; // Invalid timer ID
 
+    // Always create pacer so its lock can serialize TWSN assignment + SRTP encryption.
+    // Pacing is disabled by default; peerConnectionEnablePacing() turns it on.
+    {
+        PacerConfig defaultPacerConfig;
+        MEMSET(&defaultPacerConfig, 0, SIZEOF(PacerConfig));
+        defaultPacerConfig.initialBitrateBps = 300000;
+        defaultPacerConfig.maxQueueSize = PACER_DEFAULT_MAX_QUEUE_SIZE;
+        defaultPacerConfig.maxQueueBytes = PACER_DEFAULT_MAX_QUEUE_BYTES;
+        defaultPacerConfig.pacingFactor = PACER_DEFAULT_PACING_FACTOR;
+        defaultPacerConfig.enabled = FALSE;
+        CHK_STATUS(createPacer(&pKvsPeerConnection->pPacer, pKvsPeerConnection->timerQueueHandle, &defaultPacerConfig));
+        pKvsPeerConnection->pPacer->pKvsPeerConnection = pKvsPeerConnection;
+    }
+
     // RFC 3611 RRTR -> DLRR state.
     pKvsPeerConnection->rtcpXrLock = MUTEX_CREATE(TRUE);
 #ifdef ENABLE_NATIVE_SCTP
@@ -1685,49 +1699,37 @@ STATUS peerConnectionEnablePacing(PRtcPeerConnection pRtcPeerConnection, PRtcPac
     ENTERS();
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) pRtcPeerConnection;
-    BOOL locked = FALSE;
-    PacerConfig pacerConfig;
     PPacer pPacer = NULL;
 
-    CHK(pKvsPeerConnection != NULL, STATUS_NULL_ARG);
+    CHK(pKvsPeerConnection != NULL && pKvsPeerConnection->pPacer != NULL, STATUS_NULL_ARG);
 
-    MUTEX_LOCK(pKvsPeerConnection->peerConnectionObjLock);
-    locked = TRUE;
-
-    // Don't create if already exists
-    CHK(pKvsPeerConnection->pPacer == NULL, retStatus);
-
-    // Convert public config to internal config
-    MEMSET(&pacerConfig, 0, SIZEOF(PacerConfig));
-    if (pConfig != NULL) {
-        pacerConfig.initialBitrateBps = pConfig->initialBitrateBps;
-        pacerConfig.maxQueueSize = pConfig->maxQueueSize;
-        pacerConfig.maxQueueBytes = pConfig->maxQueueBytes;
-        pacerConfig.pacingFactor = pConfig->pacingFactor;
-        pacerConfig.maxQueueTimeKvs = pConfig->maxQueueTimeKvs;
-    }
-    pacerConfig.enabled = TRUE;
-
-    // Create the pacer
-    CHK_STATUS(createPacer(&pKvsPeerConnection->pPacer, pKvsPeerConnection->timerQueueHandle, &pacerConfig));
     pPacer = pKvsPeerConnection->pPacer;
 
-    // Drop the peer connection lock before starting the pacer timer to avoid
-    // lock-order-inversion: this path acquires peerConnectionObjLock then
-    // timer queue lock, while timer callbacks (e.g. onNewIceLocalCandidate)
-    // acquire timer queue lock then peerConnectionObjLock.
-    MUTEX_UNLOCK(pKvsPeerConnection->peerConnectionObjLock);
-    locked = FALSE;
+    // Apply config to the existing pacer
+    MUTEX_LOCK(pPacer->lock);
+    if (pConfig != NULL) {
+        if (pConfig->initialBitrateBps > 0) {
+            pPacer->targetBitrateBps = pConfig->initialBitrateBps;
+        }
+        if (pConfig->maxQueueSize > 0) {
+            pPacer->maxQueueSize = pConfig->maxQueueSize;
+        }
+        if (pConfig->maxQueueBytes > 0) {
+            pPacer->maxQueueBytes = pConfig->maxQueueBytes;
+        }
+        if (pConfig->pacingFactor > 0) {
+            pPacer->pacingFactor = pConfig->pacingFactor;
+        }
+        pPacer->maxQueueTimeKvs = pConfig->maxQueueTimeKvs;
+    }
+    pPacer->enabled = TRUE;
+    MUTEX_UNLOCK(pPacer->lock);
 
-    // Start the pacer without holding peerConnectionObjLock
     CHK_STATUS(pacerStart(pPacer, pKvsPeerConnection));
 
     DLOGI("Pacing enabled for peer connection");
 
 CleanUp:
-    if (locked) {
-        MUTEX_UNLOCK(pKvsPeerConnection->peerConnectionObjLock);
-    }
     CHK_LOG_ERR(retStatus);
 
     LEAVES();

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -2547,7 +2547,9 @@ STATUS twccManagerOnPacketSent(PKvsPeerConnection pKvsPeerConnection, PRtpPacket
     PTwccRtpPacketInfo pTwccRtpPktInfo = NULL;
 
     CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL, STATUS_NULL_ARG);
-    CHK(pKvsPeerConnection->onSenderBandwidthEstimation != NULL && pKvsPeerConnection->pTwccManager != NULL, STATUS_SUCCESS);
+    CHK((pKvsPeerConnection->onSenderBandwidthEstimation != NULL || pKvsPeerConnection->onTwccPacketReport != NULL) &&
+            pKvsPeerConnection->pTwccManager != NULL,
+        STATUS_SUCCESS);
     CHK(TWCC_EXT_PROFILE == pRtpPacket->header.extensionProfile, STATUS_SUCCESS);
 
     MUTEX_LOCK(pKvsPeerConnection->twccLock);

--- a/src/source/PeerConnection/PeerConnection.c
+++ b/src/source/PeerConnection/PeerConnection.c
@@ -1250,6 +1250,46 @@ PVOID resolveStunIceServerIp(PVOID args)
 }
 #endif
 
+static UINT32 rtpHeaderLenFromBytes(PBYTE pData, UINT32 len)
+{
+    if (pData == NULL || len < MIN_HEADER_LENGTH) {
+        return 0;
+    }
+    UINT8 cc = pData[0] & 0x0F;
+    BOOL hasExtension = (pData[0] >> 4) & 0x01;
+    UINT32 headerLen = MIN_HEADER_LENGTH + cc * CSRC_LENGTH;
+    if (hasExtension && len >= headerLen + 4) {
+        UINT16 extWords = getUnalignedInt16BigEndian(pData + headerLen + 2);
+        headerLen += 4 + extWords * 4;
+    }
+    return headerLen;
+}
+
+static VOID pacerOnPacketSentCallback(UINT64 customData, PBYTE pData, UINT32 wireLen)
+{
+    PKvsPeerConnection pKvsPeerConnection = (PKvsPeerConnection) customData;
+    PKvsRtpTransceiver pTransceiver = NULL;
+    UINT32 ssrc, headerLen;
+
+    if (pKvsPeerConnection == NULL || pData == NULL || wireLen < MIN_HEADER_LENGTH) {
+        return;
+    }
+
+    ssrc = getUnalignedInt32BigEndian(pData + SSRC_OFFSET);
+    if (STATUS_FAILED(findTransceiverBySsrc(pKvsPeerConnection, &pTransceiver, ssrc))) {
+        return;
+    }
+
+    headerLen = rtpHeaderLenFromBytes(pData, wireLen);
+
+    MUTEX_LOCK(pTransceiver->statsLock);
+    pTransceiver->outboundStats.sent.bytesSent += wireLen - headerLen;
+    pTransceiver->outboundStats.sent.packetsSent++;
+    pTransceiver->outboundStats.lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
+    pTransceiver->outboundStats.headerBytesSent += headerLen;
+    MUTEX_UNLOCK(pTransceiver->statsLock);
+}
+
 STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection* ppPeerConnection)
 {
     ENTERS();
@@ -1356,6 +1396,8 @@ STATUS createPeerConnection(PRtcConfiguration pConfiguration, PRtcPeerConnection
         defaultPacerConfig.enabled = FALSE;
         CHK_STATUS(createPacer(&pKvsPeerConnection->pPacer, pKvsPeerConnection->timerQueueHandle, &defaultPacerConfig));
         pKvsPeerConnection->pPacer->pKvsPeerConnection = pKvsPeerConnection;
+        pKvsPeerConnection->pPacer->onPacketSent = pacerOnPacketSentCallback;
+        pKvsPeerConnection->pPacer->onPacketSentCustomData = (UINT64) pKvsPeerConnection;
     }
 
     // RFC 3611 RRTR -> DLRR state.

--- a/src/source/PeerConnection/Retransmitter.c
+++ b/src/source/PeerConnection/Retransmitter.c
@@ -85,7 +85,9 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
 
         if (pRtpPacket != NULL) {
             if (pSenderTranceiver->sender.payloadType == pSenderTranceiver->sender.rtxPayloadType) {
-                retStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength);
+                // Same-PT retransmit: buffer has unencrypted bytes; route through writeRtpPacket
+                // which assigns a fresh TWSN, encrypts, and sends via pacerSendRtpPacket.
+                retStatus = writeRtpPacket(pKvsPeerConnection, pRtpPacket);
             } else {
                 CHK_STATUS(constructRetransmitRtpPacketFromBytes(
                     pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength, pSenderTranceiver->sender.rtxSequenceNumber,
@@ -93,13 +95,11 @@ STATUS resendPacketOnNack(PRtcpPacket pRtcpPacket, PKvsPeerConnection pKvsPeerCo
                 pSenderTranceiver->sender.rtxSequenceNumber++;
                 retStatus = writeRtpPacket(pKvsPeerConnection, pRtxRtpPacket);
             }
-            // resendPacket
             if (STATUS_SUCCEEDED(retStatus)) {
                 pRtpPacket->sentTime = GETTIME();
                 retransmittedPacketsSent++;
                 retransmittedBytesSent += pRtpPacket->rawPacketLength - RTP_HEADER_LEN(pRtpPacket);
                 DLOGV("Resent packet ssrc %lu seq %lu succeeded", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber);
-                twccManagerOnPacketSent(pKvsPeerConnection, pRtpPacket);
             } else {
                 DLOGV("Resent packet ssrc %lu seq %lu failed 0x%08x", pRtpPacket->header.ssrc, pRtpPacket->header.sequenceNumber, retStatus);
             }

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -296,7 +296,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     // stats updates (bytesSent/packetsSent/headerBytesSent now tracked via pacer onPacketSent callback)
     DOUBLE fps = 0.0;
-    UINT32 frames = 0, keyframes = 0, framesSent = 0;
+    UINT32 frames = 0, keyframes = 0;
     UINT32 packetsDiscardedOnSend = 0, bytesDiscardedOnSend = 0, framesDiscardedOnSend = 0;
 
     // temp vars :(
@@ -481,9 +481,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
     }
 
-    if (MEDIA_STREAM_TRACK_KIND_VIDEO == pKvsRtpTransceiver->sender.track.kind) {
-        framesSent++;
-    }
 
     if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0) {
         pKvsRtpTransceiver->sender.rtpTimeOffset = randomRtpTimeoffset;
@@ -500,9 +497,8 @@ CleanUp:
     }
     pKvsRtpTransceiver->sender.lastKnownFrameCountTime = now;
     pKvsRtpTransceiver->sender.lastKnownFrameCount = pKvsRtpTransceiver->outboundStats.framesEncoded;
-    // bytesSent, packetsSent, headerBytesSent, lastPacketSentTimestamp now updated
-    // via pacerOnPacketSentCallback when packets actually hit the wire
-    pKvsRtpTransceiver->outboundStats.framesSent += framesSent;
+    // bytesSent, packetsSent, headerBytesSent, lastPacketSentTimestamp, framesSent
+    // now updated via pacerOnPacketSentCallback when packets actually hit the wire
     if (pKvsRtpTransceiver->outboundStats.framesPerSecond > 0.0) {
         if (pFrame->size >=
             pKvsRtpTransceiver->outboundStats.targetBitrate / pKvsRtpTransceiver->outboundStats.framesPerSecond * HUGE_FRAME_MULTIPLIER) {

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -286,7 +286,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     PKvsPeerConnection pKvsPeerConnection = NULL;
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
     PRtpPacket pPacketList = NULL, pRtpPacket = NULL;
-    UINT32 i = 0, packetLen = 0, headerLen = 0, allocSize;
+    UINT32 i = 0, packetLen = 0, allocSize;
     PBYTE rawPacket = NULL;
     PPayloadArray pPayloadArray = NULL;
     RtpPayloadFunc rtpPayloadFunc = NULL;
@@ -294,11 +294,10 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     UINT64 rtpTimestamp = 0;
     UINT64 now = GETTIME();
 
-    // stats updates
+    // stats updates (bytesSent/packetsSent/headerBytesSent now tracked via pacer onPacketSent callback)
     DOUBLE fps = 0.0;
-    UINT32 frames = 0, keyframes = 0, bytesSent = 0, packetsSent = 0, headerBytesSent = 0, framesSent = 0;
+    UINT32 frames = 0, keyframes = 0, framesSent = 0;
     UINT32 packetsDiscardedOnSend = 0, bytesDiscardedOnSend = 0, framesDiscardedOnSend = 0;
-    UINT64 lastPacketSentTimestamp = 0;
 
     // temp vars :(
     UINT64 tmpFrames, tmpTime;
@@ -449,32 +448,21 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             pPacerPackets[pacerPacketCount].size = packetLen;
             pacerPacketCount++;
             rawPacket = NULL;
-
-            headerLen = RTP_HEADER_LEN(pRtpPacket);
-            bytesSent += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
-            packetsSent++;
-            lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
-            headerBytesSent += headerLen;
         } else {
             // Send immediately through pacer send function (assigns TWSN, encrypts, sends)
+            // Stats (bytesSent, packetsSent, headerBytesSent) updated via onPacketSent callback
             MUTEX_LOCK(pKvsPeerConnection->pPacer->lock);
             sendStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, rawPacket, packetLen);
             MUTEX_UNLOCK(pKvsPeerConnection->pPacer->lock);
 
             if (sendStatus == STATUS_SEND_DATA_FAILED) {
                 packetsDiscardedOnSend++;
-                bytesDiscardedOnSend += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
+                bytesDiscardedOnSend += packetLen;
                 framesDiscardedOnSend = 1;
                 SAFE_MEMFREE(rawPacket);
                 continue;
             }
             CHK_STATUS(sendStatus);
-
-            headerLen = RTP_HEADER_LEN(pRtpPacket);
-            bytesSent += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
-            packetsSent++;
-            lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
-            headerBytesSent += headerLen;
 
             SAFE_MEMFREE(rawPacket);
         }
@@ -512,12 +500,8 @@ CleanUp:
     }
     pKvsRtpTransceiver->sender.lastKnownFrameCountTime = now;
     pKvsRtpTransceiver->sender.lastKnownFrameCount = pKvsRtpTransceiver->outboundStats.framesEncoded;
-    pKvsRtpTransceiver->outboundStats.sent.bytesSent += bytesSent;
-    pKvsRtpTransceiver->outboundStats.sent.packetsSent += packetsSent;
-    if (lastPacketSentTimestamp > 0) {
-        pKvsRtpTransceiver->outboundStats.lastPacketSentTimestamp = lastPacketSentTimestamp;
-    }
-    pKvsRtpTransceiver->outboundStats.headerBytesSent += headerBytesSent;
+    // bytesSent, packetsSent, headerBytesSent, lastPacketSentTimestamp now updated
+    // via pacerOnPacketSentCallback when packets actually hit the wire
     pKvsRtpTransceiver->outboundStats.framesSent += framesSent;
     if (pKvsRtpTransceiver->outboundStats.framesPerSecond > 0.0) {
         if (pFrame->size >=

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -285,7 +285,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     STATUS retStatus = STATUS_SUCCESS;
     PKvsPeerConnection pKvsPeerConnection = NULL;
     PKvsRtpTransceiver pKvsRtpTransceiver = (PKvsRtpTransceiver) pRtcRtpTransceiver;
-    BOOL locked = FALSE, bufferAfterEncrypt = FALSE;
     PRtpPacket pPacketList = NULL, pRtpPacket = NULL;
     UINT32 i = 0, packetLen = 0, headerLen = 0, allocSize;
     PBYTE rawPacket = NULL;
@@ -303,7 +302,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     // temp vars :(
     UINT64 tmpFrames, tmpTime;
-    UINT16 twsn;
     UINT32 extpayload;
     STATUS sendStatus;
 
@@ -330,8 +328,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
     }
 
-    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
-    locked = TRUE;
     CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SRTP_NOT_READY_YET); // Discard packets till SRTP is ready
     BOOL useOpusRed = FALSE;
     UINT8 effectivePayloadType = pKvsRtpTransceiver->sender.payloadType;
@@ -419,9 +415,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
                                    pKvsRtpTransceiver->sender.ssrc, pPacketList, pPayloadArray->payloadSubLenSize));
     pKvsRtpTransceiver->sender.sequenceNumber = GET_UINT16_SEQ_NUM(pKvsRtpTransceiver->sender.sequenceNumber + pPayloadArray->payloadSubLenSize);
 
-    bufferAfterEncrypt = (pKvsRtpTransceiver->sender.payloadType == pKvsRtpTransceiver->sender.rtxPayloadType);
-
-    // Check if batch pacing should be used (video only, pacing enabled)
+    // Queue video in the pacer when pacing is enabled; audio always sends immediately
     useBatchPacing = (pKvsPeerConnection->pPacer != NULL && pacerIsEnabled(pKvsPeerConnection->pPacer) &&
                       pKvsRtpTransceiver->sender.track.kind == MEDIA_STREAM_TRACK_KIND_VIDEO);
     if (useBatchPacing) {
@@ -431,70 +425,51 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
     for (i = 0; i < pPayloadArray->payloadSubLenSize; i++) {
         pRtpPacket = pPacketList + i;
-        if (pKvsRtpTransceiver->pKvsPeerConnection->twccExtId != 0) {
+        if (pKvsPeerConnection->twccExtId != 0) {
             pRtpPacket->header.extension = TRUE;
             pRtpPacket->header.extensionProfile = TWCC_EXT_PROFILE;
             pRtpPacket->header.extensionLength = SIZEOF(UINT32);
-            twsn = (UINT16) ATOMIC_INCREMENT(&pKvsRtpTransceiver->pKvsPeerConnection->transportWideSequenceNumber);
-            extpayload = TWCC_PAYLOAD(pKvsRtpTransceiver->pKvsPeerConnection->twccExtId, twsn);
+            // Placeholder TWSN=0; real value assigned at send time by pacerSendRtpPacket
+            extpayload = TWCC_PAYLOAD(pKvsPeerConnection->twccExtId, 0);
             pRtpPacket->header.extensionPayload = (PBYTE) &extpayload;
         }
-        // Get the required size first
         CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, NULL, &packetLen));
 
-        // Account for SRTP authentication tag
         allocSize = packetLen + SRTP_AUTH_TAG_OVERHEAD;
         CHK(NULL != (rawPacket = (PBYTE) MEMALLOC(allocSize)), STATUS_NOT_ENOUGH_MEMORY);
         CHK_STATUS(createBytesFromRtpPacket(pRtpPacket, rawPacket, &packetLen));
 
-        if (!bufferAfterEncrypt) {
-            pRtpPacket->pRawPacket = rawPacket;
-            pRtpPacket->rawPacketLength = packetLen;
-            CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
-        }
+        // Always buffer unencrypted bytes for RTX retransmission
+        pRtpPacket->pRawPacket = rawPacket;
+        pRtpPacket->rawPacketLength = packetLen;
+        CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
 
-        // PCAP: capture unencrypted outbound RTP (main send path)
-        if (pKvsPeerConnection->pPcapDump != NULL) {
-            pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, rawPacket, packetLen, FALSE, PCAP_PACKET_DIRECTION_SEND);
-        }
-
-        CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, rawPacket, (PINT32) &packetLen));
-
-        // Check if pacing is enabled (only for video - audio bypasses pacer to avoid latency)
         if (useBatchPacing) {
-            // Collect packet for batch enqueue after loop completes.
-            // This ensures the pacer sees the full frame atomically, so
-            // deadline-based budget calculation uses the correct queue size.
             pPacerPackets[pacerPacketCount].pData = rawPacket;
             pPacerPackets[pacerPacketCount].size = packetLen;
-            pPacerPackets[pacerPacketCount].twccSeqNum = twsn;
             pacerPacketCount++;
-            rawPacket = NULL; // Will be owned by pacer after batch enqueue
+            rawPacket = NULL;
 
-            // Update stats (packet will be sent by pacer)
             headerLen = RTP_HEADER_LEN(pRtpPacket);
             bytesSent += packetLen - headerLen;
             packetsSent++;
             lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
             headerBytesSent += headerLen;
         } else {
-            // No pacing - send immediately
-            sendStatus = iceAgentSendPacket(pKvsPeerConnection->pIceAgent, rawPacket, packetLen);
+            // Send immediately through pacer send function (assigns TWSN, encrypts, sends)
+            MUTEX_LOCK(pKvsPeerConnection->pPacer->lock);
+            sendStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, rawPacket, packetLen);
+            MUTEX_UNLOCK(pKvsPeerConnection->pPacer->lock);
+
             if (sendStatus == STATUS_SEND_DATA_FAILED) {
                 packetsDiscardedOnSend++;
                 bytesDiscardedOnSend += packetLen - headerLen;
-                // TODO is frame considered discarded when at least one of its packets is discarded or all of its packets discarded?
                 framesDiscardedOnSend = 1;
                 SAFE_MEMFREE(rawPacket);
                 continue;
-            } else if (sendStatus == STATUS_SUCCESS && pKvsRtpTransceiver->pKvsPeerConnection->twccExtId != 0) {
-                pRtpPacket->sentTime = GETTIME();
-                twccManagerOnPacketSent(pKvsPeerConnection, pRtpPacket);
             }
             CHK_STATUS(sendStatus);
 
-            // https://tools.ietf.org/html/rfc3550#section-6.4.1
-            // The total number of payload octets (i.e., not including header or padding) transmitted in RTP data packets by the sender
             headerLen = RTP_HEADER_LEN(pRtpPacket);
             bytesSent += packetLen - headerLen;
             packetsSent++;
@@ -502,16 +477,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             headerBytesSent += headerLen;
 
             SAFE_MEMFREE(rawPacket);
-        }
-
-        if (bufferAfterEncrypt) {
-            // Note: when pacing, rawPacket is NULL here, but the rolling buffer
-            // was already populated before encryption if !bufferAfterEncrypt
-            if (rawPacket != NULL) {
-                pRtpPacket->pRawPacket = rawPacket;
-                pRtpPacket->rawPacketLength = packetLen;
-                CHK_STATUS(rtpRollingBufferAddRtpPacket(pKvsRtpTransceiver->sender.packetBuffer, pRtpPacket));
-            }
         }
     }
 
@@ -538,9 +503,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
     }
 
 CleanUp:
-    if (locked) {
-        MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
-    }
     MUTEX_LOCK(pKvsRtpTransceiver->statsLock);
     pKvsRtpTransceiver->outboundStats.totalEncodedBytesTarget += pFrame->size;
     pKvsRtpTransceiver->outboundStats.framesEncoded += frames;
@@ -590,31 +552,24 @@ CleanUp:
 STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPacket)
 {
     STATUS retStatus = STATUS_SUCCESS;
-    BOOL locked = FALSE;
     PBYTE pRawPacket = NULL;
-    INT32 rawLen = 0;
 
     CHK(pKvsPeerConnection != NULL && pRtpPacket != NULL && pRtpPacket->pRawPacket != NULL, STATUS_NULL_ARG);
+    CHK(pKvsPeerConnection->pSrtpSession != NULL && pKvsPeerConnection->pPacer != NULL, STATUS_SUCCESS);
 
-    MUTEX_LOCK(pKvsPeerConnection->pSrtpSessionLock);
-    locked = TRUE;
-    CHK(pKvsPeerConnection->pSrtpSession != NULL, STATUS_SUCCESS);               // Discard packets till SRTP is ready
-    pRawPacket = MEMALLOC(pRtpPacket->rawPacketLength + SRTP_AUTH_TAG_OVERHEAD); // For SRTP authentication tag
-    rawLen = pRtpPacket->rawPacketLength;
+    pRawPacket = MEMALLOC(pRtpPacket->rawPacketLength + SRTP_AUTH_TAG_OVERHEAD);
+    CHK(pRawPacket != NULL, STATUS_NOT_ENOUGH_MEMORY);
     MEMCPY(pRawPacket, pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength);
 
-    // PCAP: capture unencrypted outbound RTP
-    if (pKvsPeerConnection->pPcapDump != NULL) {
-        pcapDumpWritePacket(pKvsPeerConnection->pPcapDump, pRawPacket, rawLen, FALSE, PCAP_PACKET_DIRECTION_SEND);
-    }
+    MUTEX_LOCK(pKvsPeerConnection->pPacer->lock);
+    retStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, pRawPacket, pRtpPacket->rawPacketLength);
+    MUTEX_UNLOCK(pKvsPeerConnection->pPacer->lock);
 
-    CHK_STATUS(encryptRtpPacket(pKvsPeerConnection->pSrtpSession, pRawPacket, &rawLen));
-    CHK_STATUS(iceAgentSendPacket(pKvsPeerConnection->pIceAgent, pRawPacket, rawLen));
+    if (STATUS_SUCCEEDED(retStatus)) {
+        pRawPacket = NULL; // encrypted in place, don't free
+    }
 
 CleanUp:
-    if (locked) {
-        MUTEX_UNLOCK(pKvsPeerConnection->pSrtpSessionLock);
-    }
     SAFE_MEMFREE(pRawPacket);
 
     return retStatus;

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -452,7 +452,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             // Send immediately through pacer send function (assigns TWSN, encrypts, sends)
             // Stats (bytesSent, packetsSent, headerBytesSent) updated via onPacketSent callback
             MUTEX_LOCK(pKvsPeerConnection->pPacer->lock);
-            sendStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, rawPacket, packetLen);
+            sendStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, rawPacket, packetLen, GETTIME());
             MUTEX_UNLOCK(pKvsPeerConnection->pPacer->lock);
 
             if (sendStatus == STATUS_SEND_DATA_FAILED) {
@@ -481,7 +481,6 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
         }
     }
 
-
     if (pKvsRtpTransceiver->sender.firstFrameWallClockTime == 0) {
         pKvsRtpTransceiver->sender.rtpTimeOffset = randomRtpTimeoffset;
         pKvsRtpTransceiver->sender.firstFrameWallClockTime = now;
@@ -505,8 +504,7 @@ CleanUp:
             pKvsRtpTransceiver->outboundStats.hugeFramesSent++;
         }
     }
-    // iceAgentSendPacket tries to send packet immediately, explicitly settings totalPacketSendDelay to 0
-    pKvsRtpTransceiver->outboundStats.totalPacketSendDelay = 0;
+    // totalPacketSendDelay now accumulated per-packet in pacerOnPacketSentCallback
 
     pKvsRtpTransceiver->outboundStats.framesDiscardedOnSend += framesDiscardedOnSend;
     pKvsRtpTransceiver->outboundStats.packetsDiscardedOnSend += packetsDiscardedOnSend;
@@ -542,7 +540,7 @@ STATUS writeRtpPacket(PKvsPeerConnection pKvsPeerConnection, PRtpPacket pRtpPack
     MEMCPY(pRawPacket, pRtpPacket->pRawPacket, pRtpPacket->rawPacketLength);
 
     MUTEX_LOCK(pKvsPeerConnection->pPacer->lock);
-    retStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, pRawPacket, pRtpPacket->rawPacketLength);
+    retStatus = pacerSendRtpPacket(pKvsPeerConnection->pPacer, pRawPacket, pRtpPacket->rawPacketLength, GETTIME());
     MUTEX_UNLOCK(pKvsPeerConnection->pPacer->lock);
 
     if (STATUS_SUCCEEDED(retStatus)) {

--- a/src/source/PeerConnection/Rtp.c
+++ b/src/source/PeerConnection/Rtp.c
@@ -451,7 +451,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             rawPacket = NULL;
 
             headerLen = RTP_HEADER_LEN(pRtpPacket);
-            bytesSent += packetLen - headerLen;
+            bytesSent += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
             packetsSent++;
             lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
             headerBytesSent += headerLen;
@@ -463,7 +463,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
 
             if (sendStatus == STATUS_SEND_DATA_FAILED) {
                 packetsDiscardedOnSend++;
-                bytesDiscardedOnSend += packetLen - headerLen;
+                bytesDiscardedOnSend += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
                 framesDiscardedOnSend = 1;
                 SAFE_MEMFREE(rawPacket);
                 continue;
@@ -471,7 +471,7 @@ STATUS writeFrame(PRtcRtpTransceiver pRtcRtpTransceiver, PFrame pFrame)
             CHK_STATUS(sendStatus);
 
             headerLen = RTP_HEADER_LEN(pRtpPacket);
-            bytesSent += packetLen - headerLen;
+            bytesSent += packetLen + SRTP_AUTH_TAG_OVERHEAD - headerLen;
             packetsSent++;
             lastPacketSentTimestamp = KVS_CONVERT_TIMESCALE(GETTIME(), HUNDREDS_OF_NANOS_IN_A_SECOND, 1000);
             headerBytesSent += headerLen;

--- a/tst/PacerFunctionalityTest.cpp
+++ b/tst/PacerFunctionalityTest.cpp
@@ -169,7 +169,7 @@ TEST_F(PacerFunctionalityTest, enqueuePacket)
     PBYTE pData = createTestPacket(1200);
     EXPECT_NE(nullptr, pData);
 
-    EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, 1));
+    EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     EXPECT_EQ(1U, pacerGetQueueSize(pPacer));
 
     // pData is now owned by pacer, don't free it
@@ -182,7 +182,7 @@ TEST_F(PacerFunctionalityTest, enqueueMultiplePackets)
     for (UINT16 i = 0; i < 10; i++) {
         PBYTE pData = createTestPacket(1200);
         EXPECT_NE(nullptr, pData);
-        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, i + 1));
+        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     }
 
     EXPECT_EQ(10U, pacerGetQueueSize(pPacer));
@@ -194,9 +194,9 @@ TEST_F(PacerFunctionalityTest, enqueuePacketNullArgs)
 
     PBYTE pData = createTestPacket(1200);
 
-    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(nullptr, pData, 1200, 1));
-    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(pPacer, nullptr, 1200, 1));
-    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(pPacer, pData, 0, 1));
+    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(nullptr, pData, 1200));
+    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(pPacer, nullptr, 1200));
+    EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueuePacket(pPacer, pData, 0));
 
     MEMFREE(pData);
 }
@@ -214,14 +214,14 @@ TEST_F(PacerFunctionalityTest, enqueueQueueOverflow)
     // Fill up the queue
     for (UINT16 i = 0; i < 5; i++) {
         PBYTE pData = createTestPacket(1200);
-        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, i + 1));
+        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     }
 
     EXPECT_EQ(5U, pacerGetQueueSize(pPacer));
 
     // Try to add one more - should fail
     PBYTE pData = createTestPacket(1200);
-    EXPECT_EQ(STATUS_NOT_ENOUGH_MEMORY, pacerEnqueuePacket(pPacer, pData, 1200, 6));
+    EXPECT_EQ(STATUS_NOT_ENOUGH_MEMORY, pacerEnqueuePacket(pPacer, pData, 1200));
     // pData was freed by pacerEnqueuePacket on failure
 }
 
@@ -253,7 +253,7 @@ TEST_F(PacerFunctionalityTest, getStatsAfterEnqueue)
 
     for (UINT16 i = 0; i < 5; i++) {
         PBYTE pData = createTestPacket(1200);
-        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, i + 1));
+        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     }
 
     PacerStats stats;
@@ -374,7 +374,7 @@ TEST_F(PacerFunctionalityTest, fullLifecycle)
     // Enqueue some packets
     for (UINT16 i = 0; i < 20; i++) {
         PBYTE pData = createTestPacket(1200);
-        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, i + 1));
+        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     }
 
     EXPECT_EQ(20U, pacerGetQueueSize(pPacer));
@@ -409,7 +409,7 @@ TEST_F(PacerFunctionalityTest, queueClearedOnFree)
     // Enqueue packets
     for (UINT16 i = 0; i < 50; i++) {
         PBYTE pData = createTestPacket(1200);
-        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200, i + 1));
+        EXPECT_EQ(STATUS_SUCCESS, pacerEnqueuePacket(pPacer, pData, 1200));
     }
 
     EXPECT_EQ(50U, pacerGetQueueSize(pPacer));
@@ -446,7 +446,7 @@ TEST_F(PacerFunctionalityTest, highThroughputEnqueue)
     UINT32 packetsEnqueued = 0;
     for (UINT32 i = 0; i < 200; i++) {
         PBYTE pData = createTestPacket(1200);
-        if (STATUS_SUCCEEDED(pacerEnqueuePacket(pPacer, pData, 1200, (UINT16)(i + 1)))) {
+        if (STATUS_SUCCEEDED(pacerEnqueuePacket(pPacer, pData, 1200))) {
             packetsEnqueued++;
         }
     }
@@ -521,7 +521,7 @@ TEST_F(PacerFunctionalityTest, enqueueFrame)
     for (UINT32 i = 0; i < 10; i++) {
         packets[i].pData = createTestPacket(1200);
         packets[i].size = 1200;
-        packets[i].twccSeqNum = (UINT16)(i + 1);
+
     }
 
     EXPECT_EQ(STATUS_SUCCESS, pacerEnqueueFrame(pPacer, packets, 10));
@@ -541,7 +541,7 @@ TEST_F(PacerFunctionalityTest, enqueueFrameNullArgs)
     for (UINT32 i = 0; i < 5; i++) {
         packets[i].pData = createTestPacket(1200);
         packets[i].size = 1200;
-        packets[i].twccSeqNum = (UINT16)(i + 1);
+
     }
 
     EXPECT_EQ(STATUS_NULL_ARG, pacerEnqueueFrame(nullptr, packets, 5));
@@ -570,7 +570,7 @@ TEST_F(PacerFunctionalityTest, enqueueFrameQueueOverflow)
     for (UINT32 i = 0; i < 10; i++) {
         packets[i].pData = createTestPacket(1200);
         packets[i].size = 1200;
-        packets[i].twccSeqNum = (UINT16)(i + 1);
+
     }
 
     // Should fail and free all packet data
@@ -593,7 +593,7 @@ TEST_F(PacerFunctionalityTest, enqueueFrameSameTimestamp)
     for (UINT32 i = 0; i < 5; i++) {
         packets[i].pData = createTestPacket(1200);
         packets[i].size = 1200;
-        packets[i].twccSeqNum = (UINT16)(i + 1);
+
     }
 
     EXPECT_EQ(STATUS_SUCCESS, pacerEnqueueFrame(pPacer, packets, 5));
@@ -613,7 +613,7 @@ TEST_F(PacerFunctionalityTest, enqueueMultipleFrames)
         for (UINT32 i = 0; i < 10; i++) {
             packets[i].pData = createTestPacket(1200);
             packets[i].size = 1200;
-            packets[i].twccSeqNum = (UINT16)(frame * 10 + i + 1);
+
         }
         EXPECT_EQ(STATUS_SUCCESS, pacerEnqueueFrame(pPacer, packets, 10));
     }

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -3039,6 +3039,155 @@ TEST_F(PeerConnectionFunctionalityTest, opusRedEndToEndDedup)
     freePeerConnection(&offerPc);
     freePeerConnection(&answerPc);
 }
+// Regression test for TWSN monotonicity when audio and video are interleaved.
+//
+// The bug: TWSN is assigned at packet construction time, but video packets
+// are queued in the pacer while audio packets bypass it. This means audio
+// TWSN N+2 hits the wire before video TWSN N+1, causing the receiver to
+// report N+1 as lost in TWCC feedback (it hasn't arrived yet), which makes
+// GCC reduce bitrate unnecessarily.
+//
+// This test sends interleaved audio + video with pacing enabled and checks
+// that sendTimeKvs is monotonically non-decreasing in TWSN order across
+// all TWCC reports.
+TEST_F(PeerConnectionFunctionalityTest, twsnMonotonicWithInterleavedAudioVideo)
+{
+    constexpr UINT32 NUM_VIDEO_FRAMES = 60;
+    constexpr UINT64 VIDEO_FRAME_DURATION_KVS = HUNDREDS_OF_NANOS_IN_A_SECOND / 30;
+    constexpr UINT32 VIDEO_FRAME_SIZE = 100000; // 100KB — generates ~80 RTP packets per frame
+    constexpr UINT32 AUDIO_FRAME_SIZE = 160;
+    constexpr UINT64 TARGET_BITRATE_BPS = 500000; // 500 kbps — low enough to queue video
+
+    struct MonotonicityContext {
+        std::vector<TwccPacketReport> allReports;
+        SIZE_T feedbackCount;
+    };
+
+    RtcConfiguration configuration;
+    PRtcPeerConnection offerPc = NULL, answerPc = NULL;
+    RtcMediaStreamTrack offerVideoTrack, answerVideoTrack, offerAudioTrack, answerAudioTrack;
+    PRtcRtpTransceiver offerVideoTransceiver, answerVideoTransceiver, offerAudioTransceiver, answerAudioTransceiver;
+    Frame videoFrame, audioFrame;
+    MonotonicityContext context;
+    context.feedbackCount = 0;
+
+    initRtcConfiguration(&configuration);
+    MEMSET(&videoFrame, 0x00, SIZEOF(Frame));
+    MEMSET(&audioFrame, 0x00, SIZEOF(Frame));
+
+    // Synthetic video frame — large enough to generate many RTP packets
+    PBYTE videoData = (PBYTE) MEMALLOC(VIDEO_FRAME_SIZE);
+    ASSERT_NE(videoData, nullptr);
+    MEMSET(videoData, 0x11, VIDEO_FRAME_SIZE);
+    videoFrame.frameData = videoData;
+    videoFrame.size = VIDEO_FRAME_SIZE;
+
+    // Small audio frame
+    BYTE audioData[AUDIO_FRAME_SIZE];
+    MEMSET(audioData, 0x42, AUDIO_FRAME_SIZE);
+    audioFrame.frameData = audioData;
+    audioFrame.size = AUDIO_FRAME_SIZE;
+
+    EXPECT_EQ(createPeerConnection(&configuration, &offerPc), STATUS_SUCCESS);
+    EXPECT_EQ(createPeerConnection(&configuration, &answerPc), STATUS_SUCCESS);
+
+    addTrackToPeerConnection(offerPc, &offerVideoTrack, &offerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(offerPc, &offerAudioTrack, &offerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+    addTrackToPeerConnection(answerPc, &answerVideoTrack, &answerVideoTransceiver, RTC_CODEC_VP8, MEDIA_STREAM_TRACK_KIND_VIDEO);
+    addTrackToPeerConnection(answerPc, &answerAudioTrack, &answerAudioTransceiver, RTC_CODEC_OPUS, MEDIA_STREAM_TRACK_KIND_AUDIO);
+
+    // Enable pacing with low bitrate so video queues up
+    RtcPacerConfig pacerConfig;
+    pacerConfig.initialBitrateBps = TARGET_BITRATE_BPS;
+    pacerConfig.maxQueueSize = 1000;
+    pacerConfig.maxQueueBytes = 4 * 1024 * 1024;
+    pacerConfig.pacingFactor = 2.5;
+    pacerConfig.maxQueueTimeKvs = 0;
+    EXPECT_EQ(peerConnectionEnablePacing(offerPc, &pacerConfig), STATUS_SUCCESS);
+
+    auto onTwccReport = [](UINT64 customData, PTwccPacketReport pReports, UINT32 reportCount, UINT64 rtt) -> void {
+        UNUSED_PARAM(rtt);
+        MonotonicityContext* ctx = (MonotonicityContext*) customData;
+        for (UINT32 i = 0; i < reportCount; i++) {
+            ctx->allReports.push_back(pReports[i]);
+        }
+        ctx->feedbackCount++;
+    };
+    EXPECT_EQ(peerConnectionOnTwccPacketReport(offerPc, (UINT64) &context, onTwccReport), STATUS_SUCCESS);
+
+
+    EXPECT_EQ(connectTwoPeers(offerPc, answerPc), TRUE);
+    EXPECT_EQ(peerConnectionSetPacerBitrate(offerPc, TARGET_BITRATE_BPS), STATUS_SUCCESS);
+
+    // Interleave: send a video frame, then several audio frames, repeat.
+    // Audio bypasses the pacer and sends immediately, grabbing TWSNs that
+    // land between the video TWSNs still waiting in the pacer queue.
+    UINT64 videoPts = 0;
+    UINT64 audioPts = 0;
+    for (UINT32 frameNum = 0; frameNum < NUM_VIDEO_FRAMES; frameNum++) {
+        videoFrame.presentationTs = videoPts;
+        videoFrame.decodingTs = videoPts;
+        videoFrame.flags = (frameNum % 30 == 0) ? FRAME_FLAG_KEY_FRAME : FRAME_FLAG_NONE;
+        EXPECT_EQ(writeFrame(offerVideoTransceiver, &videoFrame), STATUS_SUCCESS);
+        videoPts += VIDEO_FRAME_DURATION_KVS;
+
+        // Send several audio frames right after video — these bypass the pacer
+        for (int a = 0; a < 3; a++) {
+            audioFrame.presentationTs = audioPts;
+            audioFrame.decodingTs = audioPts;
+            EXPECT_EQ(writeFrame(offerAudioTransceiver, &audioFrame), STATUS_SUCCESS);
+            audioPts += 20 * HUNDREDS_OF_NANOS_IN_A_MILLISECOND;
+        }
+
+        THREAD_SLEEP(VIDEO_FRAME_DURATION_KVS);
+    }
+
+    // Wait for remaining TWCC feedback
+    THREAD_SLEEP(1 * HUNDREDS_OF_NANOS_IN_A_SECOND);
+
+    closePeerConnection(offerPc);
+    closePeerConnection(answerPc);
+    freePeerConnection(&offerPc);
+    freePeerConnection(&answerPc);
+    MEMFREE(videoData);
+
+    // --- Analysis ---
+    DLOGD("TWSN monotonicity: %zu feedback callbacks, %zu total reports", context.feedbackCount, context.allReports.size());
+    ASSERT_GT(context.feedbackCount, 0) << "Should have received TWCC feedback";
+    ASSERT_GT(context.allReports.size(), 10) << "Should have reports for many packets";
+
+    // Sort reports by seqNum (TWSN order)
+    std::vector<TwccPacketReport> reports = context.allReports;
+    std::sort(reports.begin(), reports.end(), [](const TwccPacketReport& a, const TwccPacketReport& b) { return a.seqNum < b.seqNum; });
+
+    // Check monotonicity: for all received packets, sendTimeKvs should be
+    // non-decreasing in TWSN order. A violation means a later TWSN was sent
+    // before an earlier one — the TWSN gap bug.
+    SIZE_T violations = 0;
+    UINT64 prevSendTime = 0;
+    UINT16 prevSeqNum = 0;
+    BOOL havePrev = FALSE;
+
+    for (const auto& r : reports) {
+        if (!r.received || r.sendTimeKvs == 0) {
+            continue;
+        }
+        if (havePrev && r.sendTimeKvs < prevSendTime) {
+            violations++;
+            DLOGW("TWSN monotonicity violation: seqNum %u sendTime %" PRIu64 " < seqNum %u sendTime %" PRIu64, r.seqNum, r.sendTimeKvs, prevSeqNum,
+                  prevSendTime);
+        }
+        prevSendTime = r.sendTimeKvs;
+        prevSeqNum = r.seqNum;
+        havePrev = TRUE;
+    }
+
+    DLOGD("TWSN monotonicity check: %zu received reports, %zu violations", reports.size(), violations);
+    EXPECT_EQ(violations, 0) << "sendTimeKvs must be monotonically non-decreasing in TWSN order; "
+                             << violations << " violation(s) found — audio TWSNs are hitting the wire "
+                             << "before paced video TWSNs with earlier sequence numbers";
+}
+
 } // namespace webrtcclient
 } // namespace video
 } // namespace kinesis

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -976,9 +976,9 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     EXPECT_EQ(STATUS_SUCCESS, getRtpOutboundStats(offerPc, offerVideoTransceiver, &stats));
     EXPECT_EQ(206, stats.sent.packetsSent);
 #ifdef KVS_USE_MBEDTLS
-    EXPECT_EQ(248026, stats.sent.bytesSent);
+    EXPECT_EQ(245966, stats.sent.bytesSent);
 #else
-    EXPECT_EQ(246790, stats.sent.bytesSent);
+    EXPECT_EQ(245966, stats.sent.bytesSent);
 #endif
     EXPECT_EQ(2, stats.framesSent);
     // Each RTP packet header: 12 bytes base + 8 bytes TWCC extension = 20 bytes

--- a/tst/PeerConnectionFunctionalityTest.cpp
+++ b/tst/PeerConnectionFunctionalityTest.cpp
@@ -976,9 +976,9 @@ TEST_F(PeerConnectionFunctionalityTest, exchangeMedia)
     EXPECT_EQ(STATUS_SUCCESS, getRtpOutboundStats(offerPc, offerVideoTransceiver, &stats));
     EXPECT_EQ(206, stats.sent.packetsSent);
 #ifdef KVS_USE_MBEDTLS
-    EXPECT_EQ(245966, stats.sent.bytesSent);
+    EXPECT_EQ(248026, stats.sent.bytesSent);
 #else
-    EXPECT_EQ(245966, stats.sent.bytesSent);
+    EXPECT_EQ(246790, stats.sent.bytesSent);
 #endif
     EXPECT_EQ(2, stats.framesSent);
     // Each RTP packet header: 12 bytes base + 8 bytes TWCC extension = 20 bytes


### PR DESCRIPTION
 *What was changed?*                                                                                                                                                                                                                        
  TWSN assignment and SRTP encryption moved from writeFrame (packet construction time) to a new pacerSendRtpPacket function (actual send site). The pacer now holds plain RTP bytes and assigns TWSN, patches the TWCC extension, encrypts,  
  and sends under pPacer->lock. Audio and video share the same lock. Also fixed twccManagerOnPacketSent to accept onTwccPacketReport (matching the paced path condition).                                                                    
                                                                                                                                                                                                                                             
  *Why was it changed?*                                                                                                                                                                                                                      
  TWSN was assigned at packet construction, but video packets were queued in the pacer while audio bypassed it. Audio TWSN N+2 would hit the wire before video TWSN N+1, causing the receiver to report N+1 as lost in TWCC feedback. This
  false-loss triggered GCC to reduce bitrate unnecessarily.                                                                                                                                                                                  
                                                            
  *How was it changed?*                                                                                                                                                                                                                      
  - Added pacerSendRtpPacket in Pacer.c: assigns TWSN, patches TWCC ext bytes, PCAP capture, SRTP encrypt under pSrtpSessionLock, iceAgentSendPacket, TWCC tracking
  - writeFrame drops pSrtpSessionLock (single-writer-per-transceiver contract), serializes with placeholder TWSN=0, always buffers unencrypted for RTX                                                                                       
  - Pacer always created (disabled by default) so its lock is available; peerConnectionEnablePacing reconfigures the existing pacer                                                                                                          
  - RTX retransmit (both same-PT and RTX-negotiated paths) routes through pacerSendRtpPacket, giving each retransmit a fresh TWSN                                                                                                            
  - Fixed twccManagerOnPacketSent guard to accept onTwccPacketReport in addition to onSenderBandwidthEstimation                                                                                                                              
                                                                                                                                                                                                                                             
  *What testing was done for the changes?*                                                                                                                                                                                                   
  - Added twsnMonotonicWithInterleavedAudioVideo regression test that sends interleaved audio+video with pacing enabled and asserts sendTimeKvs is monotonically non-decreasing in TWSN order. Confirms 5 violations on pre-fix code, 0 after
   fix.                                                                                                                                                                                                                                      
  - PacerFunctionalityTest suite (42 tests) passes          
  - exchangeMedia, pacingBitrate, pacingFrameDeadline, twccFeedbackTriggersBandwidthEstimation, twccReceiverGeneratesFeedback integration tests                                                                                              
                                                                                                                                                                                                                                             
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.                                                                                                                         